### PR TITLE
Pedantic as a compiler option

### DIFF
--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -255,15 +255,16 @@ public class Compiler implements Opcodes {
   static final public Keyword disableLocalsClearingKey = Keyword.intern("disable-locals-clearing");
   static final public Keyword directLinkingKey = Keyword.intern("direct-linking");
   static final public Keyword elideMetaKey = Keyword.intern("elide-meta");
+  static final public Keyword pedanticKey = Keyword.intern("pedantic");
 
   static final public Var COMPILER_OPTIONS;
 
   static public Object getCompilerOption(Keyword k) {
-    return RT.get(COMPILER_OPTIONS.deref(),k);
+    return RT.get(COMPILER_OPTIONS.deref(), k);
   }
 
   static {
-    Object compilerOptions = null;
+    Object compilerOptions = RT.assoc(null, pedanticKey, RT.T);
 
     for (Map.Entry e : System.getProperties().entrySet()) {
       String name = (String) e.getKey();

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -83,6 +83,10 @@ public class Compiler implements Opcodes {
   static final Keyword inlineAritiesKey = Keyword.intern(null, "inline-arities");
   static final Keyword staticKey = Keyword.intern(null, "static");
   static final Keyword arglistsKey = Keyword.intern(null, "arglists");
+  static final Keyword methodMapKey = Keyword.intern(null, "method-map");
+  static final Keyword deprecatedKey = Keyword.intern(null, "deprecated");
+  static final Keyword privateKey = Keyword.intern(null, "private");
+
   static final Symbol INVOKE_STATIC = Symbol.intern("invokeStatic");
 
   static final Keyword volatileKey = Keyword.intern(null, "volatile");
@@ -91,7 +95,7 @@ public class Compiler implements Opcodes {
 
   static final Keyword protocolKey = Keyword.intern(null, "protocol");
   static final Keyword onKey = Keyword.intern(null, "on");
-  static Keyword dynamicKey = Keyword.intern("dynamic");
+  static final Keyword dynamicKey = Keyword.intern(null, "dynamic");
   static final Keyword redefKey = Keyword.intern(null, "redef");
 
   static final Symbol NS = Symbol.intern("ns");
@@ -255,6 +259,7 @@ public class Compiler implements Opcodes {
   static final public Keyword disableLocalsClearingKey = Keyword.intern("disable-locals-clearing");
   static final public Keyword directLinkingKey = Keyword.intern("direct-linking");
   static final public Keyword elideMetaKey = Keyword.intern("elide-meta");
+  static final public Keyword warnOnBoxedKeyword = Keyword.intern("warn-on-boxed");
   static final public Keyword pedanticKey = Keyword.intern("pedantic");
 
   static final public Var COMPILER_OPTIONS;
@@ -1560,7 +1565,6 @@ public class Compiler implements Opcodes {
     final static Method forNameMethod = Method.getMethod("Class classForName(String)");
     final static Method invokeStaticMethodMethod =
       Method.getMethod("Object invokeStaticMethod(Class,String,Object[])");
-    final static Keyword warnOnBoxedKeyword = Keyword.intern("warn-on-boxed");
 
     public StaticMethodExpr(String source, int line, int column, Symbol tag, Class c, String methodName, IPersistentVector args) {
       this.c = c;
@@ -3462,8 +3466,6 @@ public class Compiler implements Opcodes {
     public int siteIndex = -1;
     public Class protocolOn;
     public java.lang.reflect.Method onMethod;
-    static Keyword onKey = Keyword.intern("on");
-    static Keyword methodMapKey = Keyword.intern("method-map");
 
     static Object sigTag(int argcount, Var v) {
       Object arglists = RT.get(RT.meta(v), arglistsKey);
@@ -3484,25 +3486,31 @@ public class Compiler implements Opcodes {
       this.args = args;
       this.line = line;
       this.column = column;
+
       if (fexpr instanceof VarExpr) {
         Var fvar = ((VarExpr)fexpr).var;
         Var pvar =  (Var)RT.get(fvar.meta(), protocolKey);
+
         if (pvar != null && PROTOCOL_CALLSITES.isBound()) {
           this.isProtocol = true;
           this.siteIndex = registerProtocolCallsite(((VarExpr)fexpr).var);
           Object pon = RT.get(pvar.get(), onKey);
           this.protocolOn = HostExpr.maybeClass(pon,false);
+
           if (this.protocolOn != null) {
             IPersistentMap mmap = (IPersistentMap) RT.get(pvar.get(), methodMapKey);
             Keyword mmapVal = (Keyword) mmap.valAt(Keyword.intern(fvar.sym));
+            
             if (mmapVal == null) {
               throw new IllegalArgumentException(
                 "No method of interface: " + protocolOn.getName() +
                 " found for function: " + fvar.sym + " of protocol: " + pvar.sym +
                 " (The protocol method may have been defined before and removed.)");
             }
+
             String mname = munge(mmapVal.sym.toString());
             List methods = Reflector.getMethods(protocolOn, args.count() - 1, mname, false);
+
             if (methods.size() != 1)
               throw new IllegalArgumentException(
                 "No single method: " + mname + " of interface: " + protocolOn.getName() +
@@ -3553,6 +3561,7 @@ public class Compiler implements Opcodes {
         gen.checkCast(IFN_TYPE);
         emitArgsAndCall(0, context,objx,gen);
       }
+      
       if (context == C.STATEMENT) {
         gen.pop();
       }
@@ -3661,19 +3670,24 @@ public class Compiler implements Opcodes {
           Expr ret = StaticInvokeExpr
                      .parse(v, RT.next(form), formtag != null ? formtag : sigtag != null ? sigtag : vtag);
           if (ret != null) {
-//            System.out.println("invoke direct: " + v);
+            // System.out.println("invoke direct: " + v);
             return ret;
+          } else {
+            // System.out.println("NOT direct: " + v);
           }
-//                System.out.println("NOT direct: " + v);
         }
       }
 
-      if (fexpr instanceof VarExpr && context != C.EVAL) {
+      if (fexpr instanceof VarExpr
+          && context != C.EVAL) {
         Var v = ((VarExpr)fexpr).var;
-        Object arglists = RT.get(RT.meta(v), arglistsKey);
+        Object meta = RT.meta(v);
+        Object arglists = RT.get(meta, arglistsKey);
         int arity = RT.count(form.next());
+        
         for (ISeq s = RT.seq(arglists); s != null; s = s.next()) {
           IPersistentVector args = (IPersistentVector) s.first();
+          
           if (args.count() == arity) {
             String primc = FnMethod.primInterface(args);
             if (primc != null)
@@ -6750,18 +6764,33 @@ public class Compiler implements Opcodes {
       }
     }
     //Var v = lookupVar(sym, false);
-//  Var v = lookupVar(sym, false);
-//  if(v != null)
-//    return new VarExpr(v, tag);
+    //  Var v = lookupVar(sym, false);
+    //  if(v != null)
+    //    return new VarExpr(v, tag);
     Object o = resolve(sym);
     if (o instanceof Var) {
       Var v = (Var) o;
       if (isMacro(v) != null) {
         throw Util.runtimeException("Can't take value of a macro: " + v);
       }
-      if (RT.booleanCast(RT.get(v.meta(),RT.CONST_KEY))) {
+      if (RT.booleanCast(RT.get(v.meta(), RT.CONST_KEY))) {
         return analyze(C.EXPRESSION, RT.list(QUOTE, v.get()));
       }
+
+      String loc = String.format(" (%s:%d:%d)", SOURCE.get(), lineDeref(), columnDeref());
+      Object meta = RT.meta(v);
+      
+      if (RT.booleanCast(RT.get(meta, deprecatedKey, false))
+          && isPedantic()) {
+        RT.errPrintWriter().println("Warning: using deprecated var: " + v.toString() + loc);
+      }
+      
+      if (RT.booleanCast(RT.get(meta, privateKey, false))
+          && !Util.equals(RT.CURRENT_NS.get(), v.ns)
+          && isPedantic()) {
+        RT.errPrintWriter().println("Warning: using private var in other ns: " + v.toString() + loc);
+      }
+
       registerVar(v);
       return new VarExpr(v, tag);
     } else if (o instanceof Class) {
@@ -8109,11 +8138,11 @@ public class Compiler implements Opcodes {
     final static Method hashMethod = Method.getMethod("int hash(Object)");
     final static Method hashCodeMethod = Method.getMethod("int hashCode()");
     final static Method equivMethod = Method.getMethod("boolean equiv(Object, Object)");
-    final static Keyword compactKey = Keyword.intern(null, "compact");
-    final static Keyword sparseKey = Keyword.intern(null, "sparse");
-    final static Keyword hashIdentityKey = Keyword.intern(null, "hash-identity");
-    final static Keyword hashEquivKey = Keyword.intern(null, "hash-equiv");
-    final static Keyword intKey = Keyword.intern(null, "int");
+    final static Keyword compactKey = Keyword.intern("compact");
+    final static Keyword sparseKey = Keyword.intern("sparse");
+    final static Keyword hashIdentityKey = Keyword.intern("hash-identity");
+    final static Keyword hashEquivKey = Keyword.intern("hash-equiv");
+    final static Keyword intKey = Keyword.intern("int");
     //(case* expr shift mask default map<minhash, [test then]> table-type test-type skip-check?)
     public CaseExpr(int line, int column, LocalBindingExpr expr, int shift, int mask, int low, int high, Expr defaultExpr,
                     SortedMap<Integer,Expr> tests,HashMap<Integer,Expr> thens, Keyword switchType, Keyword testType, Set<Integer> skipCheck) {

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -369,6 +369,10 @@ public class Compiler implements Opcodes {
     return specials.containsKey(sym);
   }
 
+  static boolean isPedantic() {
+    return RT.booleanCast(getCompilerOption(pedanticKey));
+  }
+
   static Symbol resolveSymbol(Symbol sym) {
     //already qualified or classname?
     if (sym.name.indexOf('.') > 0) {

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -6780,7 +6780,9 @@ public class Compiler implements Opcodes {
       String loc = String.format(" (%s:%d:%d)", SOURCE.get(), lineDeref(), columnDeref());
       Object meta = RT.meta(v);
       
-      if (RT.booleanCast(RT.get(meta, deprecatedKey, false))
+      if ((RT.booleanCast(RT.get(meta, deprecatedKey, false))
+           || (RT.booleanCast(RT.get(v.ns, deprecatedKey, false))
+               && !Util.equiv(v.ns, RT.CURRENT_NS.get())))
           && isPedantic()) {
         RT.errPrintWriter().println("Warning: using deprecated var: " + v.toString() + loc);
       }

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -550,7 +550,10 @@ public class Compiler implements Opcodes {
         if (isDynamic) {
           v.setDynamic();
         }
-        if (!isDynamic && sym.name.startsWith("*") && sym.name.endsWith("*") && sym.name.length() > 2) {
+        if (!isDynamic && sym.name.startsWith("*")
+            && sym.name.endsWith("*")
+            && sym.name.length() > 2
+            && isPedantic()) {
           RT.errPrintWriter().format("Warning: %1$s not declared dynamic and thus is not dynamically rebindable, "
                                      +"but its name suggests otherwise. Please either indicate ^:dynamic %1$s or change the name. (%2$s:%3$d)\n",
                                      sym, SOURCE_PATH.get(), LINE.get());


### PR DESCRIPTION
This changeset adds a compiler option which enables what are arguably linters, in the honorable tradition of `$ cc -Wpedantic` except here it's `-Dclojure.compiler.pedantic=true` and it's `true` by default.

Warnings include:
- [x] Using a `^:private` Var from another NS Eg. by the `#'` notation
- [x] Using a `^:deprecated` Var anywhere
- [x] Using `^:dynamic` on a var that doesn't have earmuffs
- [x] Loading a `^:deprecated` namespace
- [x] Using a Var from a `^:deprecated` namespace
