### PR TITLE
Pedantic as a compiler option

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -179,6 +179,13 @@
  vector? (fn ^:static vector? [x] (instance? clojure.lang.IPersistentVector x)))
 
 (def
+ ^{:arglists '([x])
+   :doc "Return true if x is a Var"
+   :added "1.0"
+   :static true}
+  var? (fn ^:static var? [x] (instance? clojure.lang.Var x)))
+
+(def
  ^{:arglists '([map key val] [map key val & kvs])
    :doc "assoc[iate]. When applied to a map, returns a new map of the
     same (hashed/sorted) type, that contains the mapping of key(s) to
@@ -224,7 +231,10 @@
     :added "1.9"}
   deprecated?
   (fn [o]
-    (clojure.lang.RT/booleanCast (:deprecated (meta o)))))
+    (let [d' (clojure.lang.RT/booleanCast (:deprecated (meta o)))]
+      (if d' d'
+          (if (var? o)
+            (deprecated? (.ns ^clojure.lang.Var o)))))))
 
 (def
   ^{:doc   "Checks to see if the supplied object is marked private."

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4128,7 +4128,7 @@
     (when (and to-do (not (instance? clojure.lang.Sequential to-do)))
       (throw (new Exception ":only/:refer value must be a sequential collection of symbols")))
     (when (deprecated? ns)
-      (.write *err* (str "Warning: referring vars from deprecated ns: " (ns-name ns))))
+      (.write *err* (str "Warning: referring vars from deprecated ns: " (name ns))))
     (doseq [sym to-do]
       (when-not (exclude sym)
         (let [v (nspublics sym)]
@@ -5760,7 +5760,7 @@
         (throw-if (and need-ns (not (find-ns lib)))
                   "namespace '%s' not found" lib))
       (when (and need-ns *loading-verbosely*)
-        (printf "(clojure.core/in-ns '%s)\n" (ns-name *ns*)))
+        (printf "(clojure.core/in-ns '%s)\n" (name *ns*)))
       (when as
         (when *loading-verbosely*
           (printf "(clojure.core/alias '%s '%s)\n" as lib))
@@ -5901,7 +5901,7 @@
   (doseq [^String path paths]
     (let [^String path (if (.startsWith path "/")
                           path
-                          (str (root-directory (ns-name *ns*)) \/ path))]
+                          (str (root-directory (name *ns*)) \/ path))]
       (when *loading-verbosely*
         (printf "(clojure.core/load \"%s\")\n" path)
         (flush))

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6269,9 +6269,14 @@
 (add-doc-and-meta *compiler-options*
   "A map of keys to options.
   Note, when binding dynamically make sure to merge with previous value.
+
   Supported options:
   :elide-meta - a collection of metadata keys to elide during compilation.
   :disable-locals-clearing - set to true to disable clearing, useful for using a debugger
+  :warn-on-deprecated - on by default. Switches warnings for using ^:deprecated vars.
+  :warn-on-access-violation - on by default. Switches warnings for using ^:private vars from other namespaces.
+  :warn-on-earmuffs - on by default. Switches warnings for non-dynamic earmuffed vars.
+
   Alpha, subject to change."
   {:added "1.4"})
 

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -200,22 +200,24 @@
 
 ;;;;;;;;;;;;;;;;; metadata ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (def
- ^{:arglists '([obj])
-   :doc "Returns the metadata of obj, returns nil if there is no metadata."
-   :added "1.0"
-   :static true}
- meta (fn ^:static meta [x]
-        (if (instance? clojure.lang.IMeta x)
-          (. ^clojure.lang.IMeta x (meta)))))
+  ^{:arglists '([obj])
+    :doc      "Returns the metadata of obj, returns nil if there is no metadata."
+    :added    "1.0"
+    :static   true}
+  meta
+  (fn meta [x]
+    (if (instance? clojure.lang.IMeta x)
+      (. ^clojure.lang.IMeta x (meta)))))
 
 (def
- ^{:arglists '([^clojure.lang.IObj obj m])
-   :doc "Returns an object of the same type and value as obj, with
+  ^{:arglists '([^clojure.lang.IObj obj m])
+    :doc      "Returns an object of the same type and value as obj, with
     map m as its metadata."
-   :added "1.0"
-   :static true}
- with-meta (fn ^:static with-meta [^clojure.lang.IObj x m]
-             (. x (withMeta m))))
+    :added    "1.0"
+    :static   true}
+  with-meta
+  (fn with-meta [^clojure.lang.IObj x m]
+    (. x (withMeta m))))
 
 (def ^{:private true :dynamic true}
   assert-valid-fdecl (fn [fdecl]))

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4157,7 +4157,10 @@
   {:added "1.0"
    :static true}
   [alias namespace-sym]
-  (.addAlias *ns* alias (the-ns namespace-sym)))
+  (let [other (the-ns namespace-sym)]
+    (when (deprecated? other)
+      (.write *err* (str "Warning: aliasing deprecated ns: " (name namespace-sym) "\n")))
+    (.addAlias *ns* alias other)))
 
 (defn ns-aliases
   "Returns a map of the aliases for the namespace."

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4148,7 +4148,8 @@
       (throw (Exception. ":only/:refer value must be a sequential collection of symbols")))
     (when (and (= op :all)
                (deprecated? ns))
-      (.write *err* (str "Warning: referring vars from deprecated ns: " (name ns) "\n")))
+      (.write *err* (str "Warning: referring vars from deprecated ns: " (name ns)
+                         " (" *file* ":" *line* ":" *column* ")\n")))
     (doseq [sym to-do]
       (when-not (exclude sym)
         (let [v (nspublics sym)]
@@ -4159,7 +4160,8 @@
                           (str sym " does not exist")))))
           (when (and (deprecated? v)
                      (not= op :all))
-            (.write *err* (str "Warning: referring deprecated var: " v "\n")))
+            (.write *err* (str "Warning: referring deprecated var: " v
+                               " (" *file* ":" *line* ":" *column* ")\n")))
           (. *ns* (refer (or (rename sym) sym) v)))))))
 
 (defn ns-refers
@@ -4182,7 +4184,8 @@
   [alias namespace-sym]
   (let [other (the-ns namespace-sym)]
     (when (deprecated? other)
-      (.write *err* (str "Warning: aliasing deprecated ns: " (name namespace-sym) "\n")))
+      (.write *err* (str "Warning: aliasing deprecated ns: " (name namespace-sym)
+                         " (" *file* ":" *line* ":" *column* ")\n")))
     (.addAlias *ns* alias other)))
 
 (defn ns-aliases

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4142,11 +4142,13 @@
         to-do     (cond (= op :all)   all
                         (= op :refer) refer
                         (= op :only)  only
-                        :else         all)]
+                        :else         all)
+        d-ctx     (deprecated? *ns*)]
     (when (and to-do
                (not (instance? clojure.lang.Sequential to-do)))
       (throw (Exception. ":only/:refer value must be a sequential collection of symbols")))
     (when (and (= op :all)
+               (not d-ctx)
                (deprecated? ns))
       (.write *err* (str "Warning: referring vars from deprecated ns: " (name ns)
                          " (" *file* ":" *line* ":" *column* ")\n")))
@@ -4159,6 +4161,7 @@
                           (str sym " is not public")
                           (str sym " does not exist")))))
           (when (and (deprecated? v)
+                     (not d-ctx)
                      (not= op :all))
             (.write *err* (str "Warning: referring deprecated var: " v
                                " (" *file* ":" *line* ":" *column* ")\n")))
@@ -4183,7 +4186,8 @@
    :static true}
   [alias namespace-sym]
   (let [other (the-ns namespace-sym)]
-    (when (deprecated? other)
+    (when (and (not (deprecated? *ns*))
+               (deprecated? other))
       (.write *err* (str "Warning: aliasing deprecated ns: " (name namespace-sym)
                          " (" *file* ":" *line* ":" *column* ")\n")))
     (.addAlias *ns* alias other)))

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6276,6 +6276,7 @@
   :warn-on-deprecated - on by default. Switches warnings for using ^:deprecated vars.
   :warn-on-access-violation - on by default. Switches warnings for using ^:private vars from other namespaces.
   :warn-on-earmuffs - on by default. Switches warnings for non-dynamic earmuffed vars.
+  :pedantic - off by default. Enables all warning switches.
 
   Alpha, subject to change."
   {:added "1.4"})

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5000,7 +5000,6 @@
   {:added "1.0"
    :deprecated "1.1"}
   [url]
-  (println "WARNING: add-classpath is deprecated")
   (clojure.lang.RT/addURL url))
 
 (defn hash

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -219,6 +219,20 @@
   (fn with-meta [^clojure.lang.IObj x m]
     (. x (withMeta m))))
 
+(def
+  ^{:doc   "Checks to see if the supplied object is marked deprecated."
+    :added "1.9"}
+  deprecated?
+  (fn [o]
+    (clojure.lang.RT/booleanCast (:deprecated (meta o)))))
+
+(def
+  ^{:doc   "Checks to see if the supplied object is marked private."
+    :added "1.9"}
+  private?
+  (fn [o]
+    (clojure.lang.RT/booleanCast (:deprecated (meta o)))))
+
 (def ^{:private true :dynamic true}
   assert-valid-fdecl (fn [fdecl]))
 

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4110,6 +4110,12 @@
                                  (= ns (.ns v))))
                 (ns-map ns))))
 
+;; FIXME: not really how I want to do this in the long run but correct for now.
+;; See arrdem/clojarr#21
+(defn ^:private warn-deprecated? []
+  (or (:pedantic *compiler-options*)
+      (:warn-on-deprecated *compiler-options*)))
+
 (defn refer
   "refers to all public vars of ns, subject to filters.
   filters can include at most one each of:
@@ -4149,6 +4155,7 @@
       (throw (Exception. ":only/:refer value must be a sequential collection of symbols")))
     (when (and (= op :all)
                (not d-ctx)
+               (warn-deprecated?)
                (deprecated? ns))
       (.write *err* (str "Warning: referring vars from deprecated ns: " (name ns)
                          " (" *file* ":" *line* ":" *column* ")\n")))
@@ -4162,6 +4169,7 @@
                           (str sym " does not exist")))))
           (when (and (deprecated? v)
                      (not d-ctx)
+                     (warn-deprecated?)
                      (not= op :all))
             (.write *err* (str "Warning: referring deprecated var: " v
                                " (" *file* ":" *line* ":" *column* ")\n")))
@@ -4187,6 +4195,7 @@
   [alias namespace-sym]
   (let [other (the-ns namespace-sym)]
     (when (and (not (deprecated? *ns*))
+               (warn-deprecated?)
                (deprecated? other))
       (.write *err* (str "Warning: aliasing deprecated ns: " (name namespace-sym)
                          " (" *file* ":" *line* ":" *column* ")\n")))

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5003,8 +5003,6 @@
   (println "WARNING: add-classpath is deprecated")
   (clojure.lang.RT/addURL url))
 
-
-
 (defn hash
   "Returns the hash code of its argument. Note this is the hash code
   consistent with =, and thus is different than .hashCode for Integer,

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -243,7 +243,7 @@
                        `(entrySet [this#] (set this#)))])
       ]
      (let [[i m] (-> [interfaces methods] irecord eqhash iobj ilookup imap ijavamap)]
-       `(deftype* ~(symbol (name (ns-name *ns*)) (name tagname)) ~classname ~(conj hinted-fields '__meta '__extmap)
+       `(deftype* ~(symbol (name *ns*) (name tagname)) ~classname ~(conj hinted-fields '__meta '__extmap)
           :implements ~(vec i) 
           ~@(mapcat identity opts)
           ~@m))))))
@@ -399,7 +399,7 @@
   [tagname cname fields interfaces methods opts]
   (let [classname (with-meta (symbol (str (namespace-munge *ns*) "." cname)) (meta cname))
         interfaces (conj interfaces 'clojure.lang.IType)]
-    `(deftype* ~(symbol (name (ns-name *ns*)) (name tagname)) ~classname ~fields
+    `(deftype* ~(symbol (name *ns*) (name tagname)) ~classname ~fields
        :implements ~interfaces 
        ~@(mapcat identity opts)
        ~@methods)))

--- a/src/clj/clojure/core_proxy.clj
+++ b/src/clj/clojure/core_proxy.clj
@@ -109,7 +109,7 @@
                                         ;call fn
                   (. gen (invokeInterface ifn-type (new Method "invoke" obj-type 
                                                         (into-array (cons obj-type 
-                                                                          (replicate (count ptypes) obj-type))))))
+                                                                          (repeat (count ptypes) obj-type))))))
                                         ;unbox return
                   (. gen (unbox rtype))
                   (when (= (. rtype (getSort)) (. Type VOID))

--- a/src/clj/clojure/genclass.clj
+++ b/src/clj/clojure/genclass.clj
@@ -123,7 +123,7 @@
 
 (defn- generate-class [options-map]
   (validate-generate-class-options options-map)
-  (let [default-options {:prefix "-" :load-impl-ns true :impl-ns (ns-name *ns*)}
+  (let [default-options {:prefix "-" :load-impl-ns true :impl-ns (name *ns*)}
         {:keys [name extends implements constructors methods main factory state init exposes 
                 exposes-methods prefix load-impl-ns impl-ns post-init]} 
           (merge default-options options-map)

--- a/src/clj/clojure/genclass.clj
+++ b/src/clj/clojure/genclass.clj
@@ -146,7 +146,7 @@
                             (make-array Type 0)))
         obj-type ^Type (totype Object)
         arg-types (fn [n] (if (pos? n)
-                            (into-array (replicate n obj-type))
+                            (into-array (repeat n obj-type))
                             (make-array Type 0)))
         super-type ^Type (totype super)
         init-name (str init)
@@ -232,11 +232,11 @@
                   (. clojure.lang.Compiler$HostExpr (emitBoxReturn nil gen (nth pclasses i))))
                                         ;call fn
                 (. gen (invokeInterface ifn-type (new Method "invoke" obj-type 
-                                                      (to-types (replicate (+ (count ptypes)
+                                                      (to-types (repeat (+ (count ptypes)
                                                                               (if as-static 0 1)) 
                                                                            Object)))))
                                         ;(into-array (cons obj-type 
-                                        ;                 (replicate (count ptypes) obj-type))))))
+                                        ;                 (repeat (count ptypes) obj-type))))))
                                         ;unbox return
                 (. gen (unbox rtype))
                 (when (= (. rtype (getSort)) (. Type VOID))

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -6799,7 +6799,7 @@ public class Compiler implements Opcodes {
         return analyze(C.EXPRESSION, RT.list(QUOTE, v.get()));
       }
 
-      String loc = String.format(" (%s:%d:%d)", SOURCE.get(), lineDeref(), columnDeref());
+      String loc = String.format(" (%s:%d:%d)", SOURCE_PATH.get(), lineDeref(), columnDeref());
       Object meta = RT.meta(v);
       Namespace nsc = (Namespace) RT.CURRENT_NS.get();
 

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -255,15 +255,16 @@ public class Compiler implements Opcodes {
   static final public Keyword disableLocalsClearingKey = Keyword.intern("disable-locals-clearing");
   static final public Keyword directLinkingKey = Keyword.intern("direct-linking");
   static final public Keyword elideMetaKey = Keyword.intern("elide-meta");
+  static final public Keyword pedanticKey = Keyword.intern("pedantic");
 
   static final public Var COMPILER_OPTIONS;
 
   static public Object getCompilerOption(Keyword k) {
-    return RT.get(COMPILER_OPTIONS.deref(),k);
+    return RT.get(COMPILER_OPTIONS.deref(), k);
   }
 
   static {
-    Object compilerOptions = null;
+    Object compilerOptions = RT.assoc(null, pedanticKey, RT.T);
 
     for (Map.Entry e : System.getProperties().entrySet()) {
       String name = (String) e.getKey();

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -6785,7 +6785,9 @@ public class Compiler implements Opcodes {
       String loc = String.format(" (%s:%d:%d)", SOURCE.get(), lineDeref(), columnDeref());
       Object meta = RT.meta(v);
       
-      if (RT.booleanCast(RT.get(meta, deprecatedKey, false))
+      if ((RT.booleanCast(RT.get(meta, deprecatedKey, false))
+           || (RT.booleanCast(RT.get(v.ns, deprecatedKey, false))
+               && !Util.equiv(v.ns, RT.CURRENT_NS.get())))
           && isPedantic()) {
         RT.errPrintWriter().println("Warning: using deprecated var: " + v.toString() + loc);
       }

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -555,7 +555,10 @@ public class Compiler implements Opcodes {
         if (isDynamic) {
           v.setDynamic();
         }
-        if (!isDynamic && sym.name.startsWith("*") && sym.name.endsWith("*") && sym.name.length() > 2) {
+        if (!isDynamic && sym.name.startsWith("*")
+            && sym.name.endsWith("*")
+            && sym.name.length() > 2
+            && isPedantic()) {
           RT.errPrintWriter().format("Warning: %1$s not declared dynamic and thus is not dynamically rebindable, "
                                      +"but its name suggests otherwise. Please either indicate ^:dynamic %1$s or change the name. (%2$s:%3$d)\n",
                                      sym, SOURCE_PATH.get(), LINE.get());

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -275,7 +275,10 @@ public class Compiler implements Opcodes {
   }
 
   static {
-    Object compilerOptions = RT.assoc(null, pedanticKey, RT.T);
+    Object compilerOptions =
+      RT.assoc(null, warnOnEarmuffsKey, RT.T)
+      .assoc(warnOnDeprecatedKey, RT.T)
+      .assoc(warnOnAccessKey, RT.T);
 
     for (Map.Entry e : System.getProperties().entrySet()) {
       String name = (String) e.getKey();
@@ -399,7 +402,7 @@ public class Compiler implements Opcodes {
   static boolean warnOnAccessViolation() {
     return warnOnPedantic() || RT.booleanCast(getCompilerOption(warnOnAccessKey));
   }
-  
+
   static boolean isDeprecated(Var v) {
     return (RT.booleanCast(RT.get(v.meta(), deprecatedKey, false))
             || isDeprecated(v.ns));

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -373,6 +373,10 @@ public class Compiler implements Opcodes {
     return specials.containsKey(sym);
   }
 
+  static boolean isPedantic() {
+    return RT.booleanCast(getCompilerOption(pedanticKey));
+  }
+
   static Symbol resolveSymbol(Symbol sym) {
     //already qualified or classname?
     if (sym.name.indexOf('.') > 0) {

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -83,6 +83,10 @@ public class Compiler implements Opcodes {
   static final Keyword inlineAritiesKey = Keyword.intern(null, "inline-arities");
   static final Keyword staticKey = Keyword.intern(null, "static");
   static final Keyword arglistsKey = Keyword.intern(null, "arglists");
+  static final Keyword methodMapKey = Keyword.intern(null, "method-map");
+  static final Keyword deprecatedKey = Keyword.intern(null, "deprecated");
+  static final Keyword privateKey = Keyword.intern(null, "private");
+
   static final Symbol INVOKE_STATIC = Symbol.intern("invokeStatic");
 
   static final Keyword volatileKey = Keyword.intern(null, "volatile");
@@ -91,7 +95,7 @@ public class Compiler implements Opcodes {
 
   static final Keyword protocolKey = Keyword.intern(null, "protocol");
   static final Keyword onKey = Keyword.intern(null, "on");
-  static Keyword dynamicKey = Keyword.intern("dynamic");
+  static final Keyword dynamicKey = Keyword.intern(null, "dynamic");
   static final Keyword redefKey = Keyword.intern(null, "redef");
 
   static final Symbol NS = Symbol.intern("ns");
@@ -255,6 +259,7 @@ public class Compiler implements Opcodes {
   static final public Keyword disableLocalsClearingKey = Keyword.intern("disable-locals-clearing");
   static final public Keyword directLinkingKey = Keyword.intern("direct-linking");
   static final public Keyword elideMetaKey = Keyword.intern("elide-meta");
+  static final public Keyword warnOnBoxedKeyword = Keyword.intern("warn-on-boxed");
   static final public Keyword pedanticKey = Keyword.intern("pedantic");
 
   static final public Var COMPILER_OPTIONS;
@@ -1565,7 +1570,6 @@ public class Compiler implements Opcodes {
     final static Method forNameMethod = Method.getMethod("Class classForName(String)");
     final static Method invokeStaticMethodMethod =
       Method.getMethod("Object invokeStaticMethod(Class,String,Object[])");
-    final static Keyword warnOnBoxedKeyword = Keyword.intern("warn-on-boxed");
 
     public StaticMethodExpr(String source, int line, int column, Symbol tag, Class c, String methodName, IPersistentVector args) {
       this.c = c;
@@ -3467,8 +3471,6 @@ public class Compiler implements Opcodes {
     public int siteIndex = -1;
     public Class protocolOn;
     public java.lang.reflect.Method onMethod;
-    static Keyword onKey = Keyword.intern("on");
-    static Keyword methodMapKey = Keyword.intern("method-map");
 
     static Object sigTag(int argcount, Var v) {
       Object arglists = RT.get(RT.meta(v), arglistsKey);
@@ -3489,25 +3491,31 @@ public class Compiler implements Opcodes {
       this.args = args;
       this.line = line;
       this.column = column;
+
       if (fexpr instanceof VarExpr) {
         Var fvar = ((VarExpr)fexpr).var;
         Var pvar =  (Var)RT.get(fvar.meta(), protocolKey);
+
         if (pvar != null && PROTOCOL_CALLSITES.isBound()) {
           this.isProtocol = true;
           this.siteIndex = registerProtocolCallsite(((VarExpr)fexpr).var);
           Object pon = RT.get(pvar.get(), onKey);
           this.protocolOn = HostExpr.maybeClass(pon,false);
+
           if (this.protocolOn != null) {
             IPersistentMap mmap = (IPersistentMap) RT.get(pvar.get(), methodMapKey);
             Keyword mmapVal = (Keyword) mmap.valAt(Keyword.intern(fvar.sym));
+            
             if (mmapVal == null) {
               throw new IllegalArgumentException(
                 "No method of interface: " + protocolOn.getName() +
                 " found for function: " + fvar.sym + " of protocol: " + pvar.sym +
                 " (The protocol method may have been defined before and removed.)");
             }
+
             String mname = munge(mmapVal.sym.toString());
             List methods = Reflector.getMethods(protocolOn, args.count() - 1, mname, false);
+
             if (methods.size() != 1)
               throw new IllegalArgumentException(
                 "No single method: " + mname + " of interface: " + protocolOn.getName() +
@@ -3558,6 +3566,7 @@ public class Compiler implements Opcodes {
         gen.checkCast(IFN_TYPE);
         emitArgsAndCall(0, context,objx,gen);
       }
+      
       if (context == C.STATEMENT) {
         gen.pop();
       }
@@ -3666,19 +3675,24 @@ public class Compiler implements Opcodes {
           Expr ret = StaticInvokeExpr
                      .parse(v, RT.next(form), formtag != null ? formtag : sigtag != null ? sigtag : vtag);
           if (ret != null) {
-//            System.out.println("invoke direct: " + v);
+            // System.out.println("invoke direct: " + v);
             return ret;
+          } else {
+            // System.out.println("NOT direct: " + v);
           }
-//                System.out.println("NOT direct: " + v);
         }
       }
 
-      if (fexpr instanceof VarExpr && context != C.EVAL) {
+      if (fexpr instanceof VarExpr
+          && context != C.EVAL) {
         Var v = ((VarExpr)fexpr).var;
-        Object arglists = RT.get(RT.meta(v), arglistsKey);
+        Object meta = RT.meta(v);
+        Object arglists = RT.get(meta, arglistsKey);
         int arity = RT.count(form.next());
+        
         for (ISeq s = RT.seq(arglists); s != null; s = s.next()) {
           IPersistentVector args = (IPersistentVector) s.first();
+          
           if (args.count() == arity) {
             String primc = FnMethod.primInterface(args);
             if (primc != null)
@@ -6755,18 +6769,33 @@ public class Compiler implements Opcodes {
       }
     }
     //Var v = lookupVar(sym, false);
-//  Var v = lookupVar(sym, false);
-//  if(v != null)
-//    return new VarExpr(v, tag);
+    //  Var v = lookupVar(sym, false);
+    //  if(v != null)
+    //    return new VarExpr(v, tag);
     Object o = resolve(sym);
     if (o instanceof Var) {
       Var v = (Var) o;
       if (isMacro(v) != null) {
         throw Util.runtimeException("Can't take value of a macro: " + v);
       }
-      if (RT.booleanCast(RT.get(v.meta(),RT.CONST_KEY))) {
+      if (RT.booleanCast(RT.get(v.meta(), RT.CONST_KEY))) {
         return analyze(C.EXPRESSION, RT.list(QUOTE, v.get()));
       }
+
+      String loc = String.format(" (%s:%d:%d)", SOURCE.get(), lineDeref(), columnDeref());
+      Object meta = RT.meta(v);
+      
+      if (RT.booleanCast(RT.get(meta, deprecatedKey, false))
+          && isPedantic()) {
+        RT.errPrintWriter().println("Warning: using deprecated var: " + v.toString() + loc);
+      }
+      
+      if (RT.booleanCast(RT.get(meta, privateKey, false))
+          && !Util.equals(RT.CURRENT_NS.get(), v.ns)
+          && isPedantic()) {
+        RT.errPrintWriter().println("Warning: using private var in other ns: " + v.toString() + loc);
+      }
+
       registerVar(v);
       return new VarExpr(v, tag);
     } else if (o instanceof Class) {
@@ -8115,11 +8144,11 @@ public class Compiler implements Opcodes {
     final static Method hashMethod = Method.getMethod("int hash(Object)");
     final static Method hashCodeMethod = Method.getMethod("int hashCode()");
     final static Method equivMethod = Method.getMethod("boolean equiv(Object, Object)");
-    final static Keyword compactKey = Keyword.intern(null, "compact");
-    final static Keyword sparseKey = Keyword.intern(null, "sparse");
-    final static Keyword hashIdentityKey = Keyword.intern(null, "hash-identity");
-    final static Keyword hashEquivKey = Keyword.intern(null, "hash-equiv");
-    final static Keyword intKey = Keyword.intern(null, "int");
+    final static Keyword compactKey = Keyword.intern("compact");
+    final static Keyword sparseKey = Keyword.intern("sparse");
+    final static Keyword hashIdentityKey = Keyword.intern("hash-identity");
+    final static Keyword hashEquivKey = Keyword.intern("hash-equiv");
+    final static Keyword intKey = Keyword.intern("int");
     //(case* expr shift mask default map<minhash, [test then]> table-type test-type skip-check?)
     public CaseExpr(int line, int column, LocalBindingExpr expr, int shift, int mask, int low, int high, Expr defaultExpr,
                     SortedMap<Integer,Expr> tests,HashMap<Integer,Expr> thens, Keyword switchType, Keyword testType, Set<Integer> skipCheck) {

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3505,7 +3505,7 @@ public class Compiler implements Opcodes {
           if (this.protocolOn != null) {
             IPersistentMap mmap = (IPersistentMap) RT.get(pvar.get(), methodMapKey);
             Keyword mmapVal = (Keyword) mmap.valAt(Keyword.intern(fvar.sym));
-            
+
             if (mmapVal == null) {
               throw new IllegalArgumentException(
                 "No method of interface: " + protocolOn.getName() +
@@ -3566,7 +3566,7 @@ public class Compiler implements Opcodes {
         gen.checkCast(IFN_TYPE);
         emitArgsAndCall(0, context,objx,gen);
       }
-      
+
       if (context == C.STATEMENT) {
         gen.pop();
       }
@@ -3689,10 +3689,10 @@ public class Compiler implements Opcodes {
         Object meta = RT.meta(v);
         Object arglists = RT.get(meta, arglistsKey);
         int arity = RT.count(form.next());
-        
+
         for (ISeq s = RT.seq(arglists); s != null; s = s.next()) {
           IPersistentVector args = (IPersistentVector) s.first();
-          
+
           if (args.count() == arity) {
             String primc = FnMethod.primInterface(args);
             if (primc != null)
@@ -6784,14 +6784,14 @@ public class Compiler implements Opcodes {
 
       String loc = String.format(" (%s:%d:%d)", SOURCE.get(), lineDeref(), columnDeref());
       Object meta = RT.meta(v);
-      
+
       if ((RT.booleanCast(RT.get(meta, deprecatedKey, false))
            || (RT.booleanCast(RT.get(v.ns, deprecatedKey, false))
                && !Util.equiv(v.ns, RT.CURRENT_NS.get())))
           && isPedantic()) {
         RT.errPrintWriter().println("Warning: using deprecated var: " + v.toString() + loc);
       }
-      
+
       if (RT.booleanCast(RT.get(meta, privateKey, false))
           && !Util.equals(RT.CURRENT_NS.get(), v.ns)
           && isPedantic()) {

--- a/test/clojure/test_clojure/agents.clj
+++ b/test/clojure/test_clojure/agents.clj
@@ -25,11 +25,10 @@
      ;; Let the action finish; eat the "agent has errors" error that bubbles up
      (await-for fragile-wait agt)
      (catch RuntimeException _))
-    (is (instance? Throwable (first (agent-errors agt))))
-    (is (= 1 (count (agent-errors agt))))
+    (is (instance? Throwable (agent-error agt)))
 
     ;; And now send an action that should work
-    (clear-agent-errors agt)
+    (restart-agent agt @agt)
     (is (= nil @agt))
     (send agt nil?)
     (is (true? (await-for fragile-wait agt)))

--- a/test/clojure/test_clojure/ns_libs.clj
+++ b/test/clojure/test_clojure/ns_libs.clj
@@ -41,10 +41,18 @@
   (is (let [err (with-out-str
                   (binding [*err* *out*
                             *ns*  *ns*]
-                    (eval '(do (ns exporter-r {:deprecated true})
+                    (eval '(do (ns exporter-r1 {:deprecated true})
                                (def otherd 3)
-                               (ns importer-r)
-                               (refer 'exporter-r :only '(otherd))))))]
+                               (ns importer-r1)
+                               (refer 'exporter-r1 :only '(otherd))))))]
+        (re-find #"referring deprecated var:" err)))
+  (is (let [err (with-out-str
+                  (binding [*err* *out*
+                            *ns*  *ns*]
+                    (eval '(do (ns exporter-r2)
+                               (def ^:deprecated otherd 3)
+                               (ns importer-r2)
+                               (refer 'exporter-r2 :only '(otherd))))))]
         (re-find #"referring deprecated var:" err))))
 
 (deftest test-require

--- a/test/clojure/test_clojure/ns_libs.clj
+++ b/test/clojure/test_clojure/ns_libs.clj
@@ -35,6 +35,16 @@
                                (ns importer-d)
                                (alias 'e 'exporter-d)))))]
         (re-find #"aliasing deprecated ns:" err))))
+
+(deftest test-refer
+  (is (let [err (with-out-str
+                  (binding [*err* *out*]
+                    (eval '(do (ns exporter-r {:deprecated true})
+                               (def otherd 3)
+                               (ns importer-r)
+                               (refer 'exporter-r :only '(otherd))))))]
+        (re-find #"referring deprecated var:" err))))
+
 (deftest test-require
          (is (thrown? Exception (require :foo)))
          (is (thrown? Exception (require))))

--- a/test/clojure/test_clojure/ns_libs.clj
+++ b/test/clojure/test_clojure/ns_libs.clj
@@ -29,7 +29,8 @@
 (deftest test-alias
   (is (thrown-with-msg? Exception #"No namespace: epicfail found" (alias 'bogus 'epicfail)))
   (is (let [err (with-out-str
-                  (binding [*err* *out*]
+                  (binding [*err* *out*
+                            *ns*  *ns*]
                     (eval '(do (ns exporter-d {:deprecated true})
                                (def otherd 3)
                                (ns importer-d)
@@ -38,7 +39,8 @@
 
 (deftest test-refer
   (is (let [err (with-out-str
-                  (binding [*err* *out*]
+                  (binding [*err* *out*
+                            *ns*  *ns*]
                     (eval '(do (ns exporter-r {:deprecated true})
                                (def otherd 3)
                                (ns importer-r)

--- a/test/clojure/test_clojure/ns_libs.clj
+++ b/test/clojure/test_clojure/ns_libs.clj
@@ -27,8 +27,14 @@
 ; loaded-libs
 
 (deftest test-alias
-	(is (thrown-with-msg? Exception #"No namespace: epicfail found" (alias 'bogus 'epicfail))))
-	
+  (is (thrown-with-msg? Exception #"No namespace: epicfail found" (alias 'bogus 'epicfail)))
+  (is (let [err (with-out-str
+                  (binding [*err* *out*]
+                    (eval '(do (ns exporter-d {:deprecated true})
+                               (def otherd 3)
+                               (ns importer-d)
+                               (alias 'e 'exporter-d)))))]
+        (re-find #"aliasing deprecated ns:" err))))
 (deftest test-require
          (is (thrown? Exception (require :foo)))
          (is (thrown? Exception (require))))

--- a/test/clojure/test_clojure/numbers.clj
+++ b/test/clojure/test_clojure/numbers.clj
@@ -515,7 +515,7 @@
 (defn- expt
   "clojure.contrib.math/expt is a better and much faster impl, but this works.
 Math/pow overflows to Infinity."
-  [x n] (apply *' (replicate n x)))
+  [x n] (apply *' (repeat n x)))
 
 (deftest test-bit-shift-left
   (are [x y] (= x y)


### PR DESCRIPTION
This changeset adds a compiler option which enables what are arguably linters, in the honorable tradition of `$ cc -Wpedantic` except here it's `-Dclojure.compiler.pedantic=true` and it's `true` by default.

Warnings include:
- [x] Using a `^:private` Var from another NS Eg. by the `#'` notation
- [x] Using `^:dynamic` on a var that doesn't have earmuffs
- [x] Using a Var from a `^:deprecated` namespace in a non-deprecated ns
- [x] Requiring or referring a `^:deprecated` namespace, not just evaluating a `^:deprecated` ns form
- [x] Fix uses of `^:deprecated` Vars `agent-errors` and `clear-agent-errors` in test suite
- [x] Fix uses of `^:deprecated` Var `replicate` in `core_proxy.clj`
- [x] Fix uses of `^:deprecated` Vars in `clojure.test.junit`
