### PR TITLE
Add CircleCi config

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -112,7 +112,10 @@
           description="Run clojure tests without recompiling clojure."
           depends="compile-tests"
           unless="maven.test.skip">
-    <java classname="clojure.main" failonerror="true" fork="true">
+    <java classname="clojure.main"
+          failonerror="true"
+          fork="true"
+          maxmemory="3g">
       <sysproperty key="clojure.test-clojure.exclude-namespaces"
                    value="#{clojure.test-clojure.compilation.load-ns}"/>
       <sysproperty key="clojure.compiler.direct-linking" value="${directlinking}"/>
@@ -131,7 +134,10 @@
           description="Run test generative tests without recompiling clojure."
           depends="compile-tests"
           unless="maven.test.skip">
-    <java classname="clojure.main" failonerror="true" fork="true">
+    <java classname="clojure.main"
+          failonerror="true"
+          fork="true"
+          maxmemory="3g">
       <sysproperty key="clojure.compiler.direct-linking" value="${directlinking}"/>
       <classpath>
         <pathelement path="${maven.test.classpath}"/>

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  java:
+    version: openjdk8

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   java:
-    version: openjdk8
+    version: oraclejdk8


### PR DESCRIPTION
This patch tells CircleCi to use OpenJDK Java 8 to run the tests, and limits the memory usage of the Clojarr test suite to 3gb total so that it fits in a single CircleCi container.
