### PR TITLE
Download dependencies in Circle ahead of build time

### DIFF
--- a/circle-deps.sh
+++ b/circle-deps.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-DIR="~/.m2/tags"
-FILE="$DIR/$(cat pom.xml build.xml circle-deps.sh | grep -v "<version>.*</version>" | shasum -a 512 | awk '{print $1}')"
-mkdir -p "$DIR"
+M2="$HOME/.m2"
+FLAGS="$M2/tags"
+mkdir -p "$FLAGS"
+FILE="$FLAGS/$(cat pom.xml build.xml circle-deps.sh | grep -v "<version>.*</version>" | shasum -a 512 | awk '{print $1}')"
 if [ ! -e "$FILE" ]
 then
   # Do a deploy
@@ -18,7 +19,7 @@ then
 
   # purge clojarr from m2
   # no reason to leave those lying about
-  rm -r ~/.m2/repository/me/arrdem/clojarr/
+   rm -r "$M2/repository/me/arrdem/clojarr/"
   
   # leave the flag file behind
   touch "$FILE"

--- a/circle-deps.sh
+++ b/circle-deps.sh
@@ -3,7 +3,7 @@
 DIR="~/.m2/tags"
 FILE="$DIR/$(cat pom.xml build.xml circle-deps.sh | grep -v "<version>.*</version>" | shasum -a 512 | awk '{print $1}')"
 mkdir -p "$DIR"
-if [ ! -f "$FILE" ]
+if [ ! -e "$FILE" ]
 then
   # Do a deploy
   # - Forces a build

--- a/circle-deps.sh
+++ b/circle-deps.sh
@@ -12,13 +12,14 @@ then
   # - Without a profile, the deploy fails
   mvn deploy -Dmaven.test.skip=true
 
-  # cleans up the mess
-  mvn clean
+  # use the versions plugin
+  mvn versions:set -DgenerateBackupPoms=false -DnewVersion=whatever
+  git checkout pom.xml
 
   # purge clojarr from m2
   # no reason to leave those lying about
   rm -r ~/.m2/repository/me/arrdem/clojarr/
-
+  
   # leave the flag file behind
   touch "$FILE"
 fi

--- a/circle-deps.sh
+++ b/circle-deps.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+DIR="~/.m2/tags"
+FILE="$DIR/$(cat pom.xml build.xml circle-deps.sh | grep -v "<version>.*</version>" | shasum -a 512 | awk '{print $1}')"
+mkdir -p "$DIR"
+if [ ! -f "$FILE" ]
+then
+  # Do a deploy
+  # - Forces a build
+  # - Forces but does not run tests
+  # - Uses all plugins
+  # - Without a profile, the deploy fails
+  mvn deploy -Dmaven.test.skip=true
+
+  # cleans up the mess
+  mvn clean
+
+  # purge clojarr from m2
+  # no reason to leave those lying about
+  rm -r ~/.m2/repository/me/arrdem/clojarr/
+
+  # leave the flag file behind
+  touch "$FILE"
+fi

--- a/circle.yml
+++ b/circle.yml
@@ -17,9 +17,9 @@ test:
 
 deployment:
   staging:
-    branch: /.*/
+    branch: /develop/
     commands:
-      - mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$(cat VERSION)-$(git rev-parse HEAD | head -c 8)-SNAPSHOT
+      - mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$(cat VERSION)-SNAPSHOT
       - mvn -s settings.xml deploy
   release:
     tag: /v[0-9]+(\.[0-9]+)*/

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ dependencies:
     - ~/bin
   pre:
     - bash make-astyle.sh
+    - bash circle-deps.sh
   post:
     - mvn dependency:resolve-plugins
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,10 +3,12 @@ machine:
     version: oraclejdk8
 
 dependencies:
-  pre:
-    - bash make-astyle.sh
   cache_directories:
     - ~/bin
+  pre:
+    - bash make-astyle.sh
+  post:
+    - mvn dependency:resolve-plugins
 
 test:
   pre:

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
 
   <properties>
     <directlinking>true</directlinking>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -215,4 +215,16 @@
       </properties>
     </profile>
   </profiles>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Repository Switchboard</name>
+      <layout>default</layout>
+      <url>http://repo1.maven.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
I'm not 100% sure why, but mvn dependency:go-offline does not download
all of the necessary dependencies to run the build. This means that
Circle's caching isn't very effective, as more deps are downloaded after
the cache is saved.
- [ ] Downloads the necessary plugins ahead of time, should dramatically speed up build time.
- [x] I also needed to update the location for central. See
  http://stackoverflow.com/questions/35022961/how-do-i-use-mvn-dependencyget-to-use-https-repo1-maven-org/35023015#35023015
  for more details.
