### PR TITLE
Promote ns-name from ^:deprecated

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4036,7 +4036,7 @@
   {:added  "1.0"
    :static true}
   [ns]
-  (symbol (.getName (the-ns ns))))
+  (.name ^clojure.lang.Namespace (the-ns ns)))
 
 (defn ns-map
   "Returns a map of all the mappings for the namespace."

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4033,9 +4033,8 @@
 
 (defn ns-name
   "Returns the name of the namespace, a symbol."
-  {:added      "1.0"
-   :static     true
-   :deprecated "1.9"}
+  {:added  "1.0"
+   :static true}
   [ns]
   (symbol (.getName (the-ns ns))))
 

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4035,7 +4035,7 @@
   "Returns the name of the namespace, a symbol."
   {:added  "1.0"
    :static true}
-  [ns]
+  ^clojure.lang.Symbol [ns]
   (.name ^clojure.lang.Namespace (the-ns ns)))
 
 (defn ns-map


### PR DESCRIPTION
Fixes #47, see that issue for discussion of the reasons for rolling this
back. Rather than implementing the suggested `Namespace.getNamingSymbol():Symbol`, this patch opts to use the existing `final public Symbol name` field.
