### PR TITLE
Add *line* and *column*

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6166,6 +6166,18 @@
   When there is no file, e.g. in the REPL, the value is not defined."
   {:added "1.0"})
 
+(add-doc-and-meta *line*
+  "The line number into *file* of the top level form being evaluated.
+
+  Integer valued, 0 by default."
+  {:added "1.9"})
+
+(add-doc-and-meta *column*
+  "The column number into *file*:*line* of the top level form being evaluated.
+
+  Integer valued, 0 by default."
+  {:added "1.9"})
+
 (add-doc-and-meta *command-line-args*
   "A sequence of the supplied command line arguments, or nil if
   none were supplied"

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -291,9 +291,15 @@ public class Compiler implements Opcodes {
     return m;
   }
 
-//Integer
-  static final public Var LINE = Var.create(0).setDynamic();
-  static final public Var COLUMN = Var.create(0).setDynamic();
+  //Integer
+  static final public Var LINE =
+    Var.intern(RT.CLOJURE_NS, Symbol.intern("*line*"), 0)
+      .setDynamic();
+  
+  //Integer
+  static final public Var COLUMN =
+    Var.intern(RT.CLOJURE_NS, Symbol.intern("*column*"), 0)
+      .setDynamic();
 
   static int lineDeref() {
     return ((Number)LINE.deref()).intValue();

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -293,13 +293,11 @@ public class Compiler implements Opcodes {
 
   //Integer
   static final public Var LINE =
-    Var.intern(RT.CLOJURE_NS, Symbol.intern("*line*"), 0)
-      .setDynamic();
-  
+    Var.intern(RT.CLOJURE_NS, Symbol.intern("*line*"), 0).setDynamic();
+
   //Integer
   static final public Var COLUMN =
-    Var.intern(RT.CLOJURE_NS, Symbol.intern("*column*"), 0)
-      .setDynamic();
+    Var.intern(RT.CLOJURE_NS, Symbol.intern("*column*"), 0).setDynamic();
 
   static int lineDeref() {
     return ((Number)LINE.deref()).intValue();

--- a/test/clojure/test_clojure/vars.clj
+++ b/test/clojure/test_clojure/vars.clj
@@ -98,3 +98,16 @@
     (with-redefs [dynamic-var 3]
       (is (= 2 dynamic-var))))
   (is (= 1 dynamic-var)))
+
+(defmacro capturing-line-column [& forms]
+  (let [info (meta &form)]
+    `(let [~'mline   ~(:line info)
+           ~'mcolumn ~(:column info)]
+       ~@forms)))
+
+(capturing-line-column
+ (let [vline   *line*
+       vcolumn *column*]
+   (deftest line-column-test
+     (is (= vline mline))
+     (is (= vcolumn mcolumn)))))


### PR DESCRIPTION
Fixes #51

This changeset adds the dynamic variables `clojure.core/*line*` and
`clojure.core/*column*`. These variables are bound to be the line/column
of the top level form currently being compiled and evaluated. That is
the scope of a binding of these vars is the macroexpansion and
evaluation of that top level form.

So, for instance:

```
;; fn decl, does nothing
(defn foo []
  (printf "Debugging... %s:%d:%d\n" *file* *line* *column*))

;; top level form
(foo)
;; compiles to
;; (.invoke (fn* [] (foo)))
;; evaluates with *line* 5, *column* 0
;; prints "Debugging... NO_FILE:5:0\n"
```

These Vars are handy for generating warning messages eg. in the `ns`
macro which refer to the line, column and file of the top level form as
well as in writing debugging macros which otherwise have to use form
metadata introspection to extract this information which could be easily
exposed.
