### PR TITLE
Implement lazy building

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,6 +37,7 @@
   <property name="compile-clojure-flag" value="${target}/compile-clojure.flag"/>
   <property name="compile-tests-flag" value="${target}/compile-tests.flag"/>
   <property name="test-example-flag" value="${target}/test-example.flag"/>
+  <property name="test-generative-flag" value="${target}/test-generative.flag"/>
 
   <target name="init" depends="">
     <tstamp/>
@@ -206,10 +207,31 @@
     <touch file="${test-example-flag}"/>
   </target>
 
+  <target name="test-generative.check"
+          depends="compile-clojure.check,compile-tests.check">
+    <condition property="test-generative.files.uptodate">
+      <uptodate targetfile="${test-generative-flag}">
+        <srcfiles dir="${test}" includes="**/*.clj"/>
+        <srcfiles dir="${test}" includes="**/*.cljc"/>
+        <srcfiles dir="${test}" includes="**/*.edn"/>
+      </uptodate>
+    </condition>
+    <condition property="test-generative.uptodate">
+      <or>
+        <istrue value="${maven.test.skip}"/>
+        <and>
+          <istrue value="${compile-tests.uptodate}"/>
+          <istrue value="${compile-clojure.uptodate}"/>
+          <istrue value="${test-generative.files.uptodate}"/>
+        </and>
+      </or>
+    </condition>
+  </target>
+
   <target name="test-generative"
           description="Run test generative tests without recompiling clojure."
-          depends="compile-tests"
-          unless="maven.test.skip">
+          depends="compile-tests,test-generative.check"
+          unless="test-generative.uptodate">
     <java classname="clojure.main"
           failonerror="true"
           fork="true"
@@ -224,6 +246,7 @@
       </classpath>
       <arg value="${test-generative-script}"/>
     </java>
+    <touch file="${test-generative-flag}"/>
   </target>
 
   <target name="test"

--- a/build.xml
+++ b/build.xml
@@ -60,8 +60,26 @@
            debug="true" source="1.6" target="1.6"/>
     <touch file="${compile-java-flag}"/>
   </target>
+  
+  <target name="compile-clojure.check"
+          depends="compile-java.check">
+    <uptodate property="compile-clojure.files.uptodate">
+      <srcfiles dir="${cljsrc}" includes="**/*.clj"/>
+      <srcfiles dir="${cljsrc}" includes="**/*.cljc"/>
+      <srcfiles dir="${cljsrc}" includes="**/*.edn"/>
+      <mapper type="merge" to="${compile-clojure-flag}"/>
+    </uptodate>
+    <condition property="compile-clojure.uptodate">
+      <and>
+        <istrue value="${compile-java.uptodate}"/>
+        <istrue value="${compile-clojure.files.uptodate}"/>
+      </and>
+    </condition>
+  </target>
 
   <target name="compile-clojure"
+          depends="compile-java,compile-clojure.check"
+          unless="compile-clojure.uptodate"
           description="Compile Clojure sources.">
     <java classname="clojure.lang.Compile"
           classpath="${maven.compile.classpath}:${build}:${cljsrc}"
@@ -99,6 +117,7 @@
       <arg value="clojure.data"/>
       <arg value="clojure.reflect"/>
     </java>
+    <touch file="${compile-clojure-flag}"/>
   </target>
 
   <target name="compile-tests"

--- a/build.xml
+++ b/build.xml
@@ -32,7 +32,7 @@
 
   <property name="directlinking" value="true"/>
 
-  <target name="init" depends="clean">
+  <target name="init" depends="">
     <tstamp/>
     <mkdir dir="${build}"/>
     <mkdir dir="${build}/clojure"/>

--- a/build.xml
+++ b/build.xml
@@ -32,6 +32,9 @@
 
   <property name="directlinking" value="true"/>
 
+  <!-- Lazy compilation flag files -->
+  <property name="compile-java-flag" value="${target}/compile-java.flag"/>
+
   <target name="init" depends="">
     <tstamp/>
     <mkdir dir="${build}"/>
@@ -39,11 +42,19 @@
     <echo file="${version.properties}">version=${clojure.version.label}</echo>
   </target>
 
-  <target name="compile-java" depends="init"
+  <uptodate property="compile-java.uptodate"
+            targetfile="${compile-java-flag}">
+    <srcfiles dir= "${jsrc}" includes="**/*.java"/>
+  </uptodate>
+
+  <target name="compile-java"
+          depends="init"
+          unless="compile-java.uptodate"
           description="Compile Java sources.">
     <javac srcdir="${jsrc}" destdir="${build}" includeJavaRuntime="yes"
            includeAntRuntime="false"
            debug="true" source="1.6" target="1.6"/>
+    <touch file="${compile-java-flag}"/>
   </target>
 
   <target name="compile-clojure"

--- a/build.xml
+++ b/build.xml
@@ -257,7 +257,29 @@
           description="Build Clojure (compilation only, no tests)."
           depends="compile-java, compile-clojure"/>
 
-  <target name="jar" depends="build"
+  <target name="jar.check"
+          depends="compile-java.check,compile-clojure.check">
+    <condition property="jar.files.uptodate">
+      <uptodate targetfile="${clojure_jar}">
+        <srcfiles dir="${src}" includes="**/*.clj"/>
+        <srcfiles dir="${src}" includes="**/*.cljc"/>
+        <srcfiles dir="${src}" includes="**/*.edn"/>
+        <srcfiles dir="${build}" includes="**/*.class"/>
+      </uptodate>
+    </condition>
+
+    <condition property="jar.uptodate">
+      <and>
+        <istrue value="${compile-java.uptodate}"/>
+        <istrue value="${compile-clojure.uptodate}"/>
+        <istrue value="${jar.files.uptodate}"/>
+      </and>
+    </condition>
+  </target>
+  
+  <target name="jar"
+          depends="build,jar.check"
+          unless="jar.uptodate"
           description="Create clojure jar file.">
     <jar jarfile="${clojure_jar}" basedir="${build}">
       <fileset dir="${cljsrc}">

--- a/build.xml
+++ b/build.xml
@@ -36,6 +36,7 @@
   <property name="compile-java-flag" value="${target}/compile-java.flag"/>
   <property name="compile-clojure-flag" value="${target}/compile-clojure.flag"/>
   <property name="compile-tests-flag" value="${target}/compile-tests.flag"/>
+  <property name="test-example-flag" value="${target}/test-example.flag"/>
 
   <target name="init" depends="">
     <tstamp/>
@@ -161,10 +162,31 @@
     <touch file="${compile-tests-flag}"/>
   </target>
 
+  <target name="test-example.check">
+    <condition property="test-example.files.uptodate">
+      <uptodate targetfile="${test-example-flag}">
+        <srcfiles dir="${test}" includes="**/*.clj"/>
+        <srcfiles dir="${test}" includes="**/*.cljc"/>
+        <srcfiles dir="${test}" includes="**/*.edn"/>
+      </uptodate>
+    </condition>
+    
+    <condition property="test-example.uptodate">
+      <or>
+        <istrue value="${maven.test.skip}"/>
+        <and>
+          <istrue value="${compile-tests.uptodate}"/>
+          <istrue value="${compile-clojure.uptodate}"/>
+          <istrue value="${test-example.files.uptodate}"/>
+        </and>
+      </or>
+    </condition>
+  </target>
+  
   <target name="test-example"
           description="Run clojure tests without recompiling clojure."
-          depends="compile-tests"
-          unless="maven.test.skip">
+          depends="compile-tests,test-example.check"
+          unless="test-example.uptodate">
     <java classname="clojure.main"
           failonerror="true"
           fork="true"
@@ -181,6 +203,7 @@
       </classpath>
       <arg value="${test-script}"/>
     </java>
+    <touch file="${test-example-flag}"/>
   </target>
 
   <target name="test-generative"

--- a/build.xml
+++ b/build.xml
@@ -34,6 +34,7 @@
 
   <!-- Lazy compilation flag files -->
   <property name="compile-java-flag" value="${target}/compile-java.flag"/>
+  <property name="compile-clojure-flag" value="${target}/compile-clojure.flag"/>
 
   <target name="init" depends="">
     <tstamp/>
@@ -42,13 +43,15 @@
     <echo file="${version.properties}">version=${clojure.version.label}</echo>
   </target>
 
-  <uptodate property="compile-java.uptodate"
-            targetfile="${compile-java-flag}">
-    <srcfiles dir= "${jsrc}" includes="**/*.java"/>
-  </uptodate>
+  <target name="compile-java.check">
+    <uptodate property="compile-java.uptodate"
+              targetfile="${compile-java-flag}">
+      <srcfiles dir= "${jsrc}" includes="**/*.java"/>
+    </uptodate>
+  </target>
 
   <target name="compile-java"
-          depends="init"
+          depends="init,compile-java.check"
           unless="compile-java.uptodate"
           description="Compile Java sources.">
     <javac srcdir="${jsrc}" destdir="${build}" includeJavaRuntime="yes"

--- a/build.xml
+++ b/build.xml
@@ -44,10 +44,11 @@
   </target>
 
   <target name="compile-java.check">
-    <uptodate property="compile-java.uptodate"
-              targetfile="${compile-java-flag}">
-      <srcfiles dir= "${jsrc}" includes="**/*.java"/>
-    </uptodate>
+    <condition property="compile-java.uptodate">
+      <uptodate targetfile="${compile-java-flag}">
+        <srcfiles dir= "${jsrc}" includes="**/*.java"/>
+      </uptodate>
+    </condition>
   </target>
 
   <target name="compile-java"

--- a/build.xml
+++ b/build.xml
@@ -35,6 +35,7 @@
   <!-- Lazy compilation flag files -->
   <property name="compile-java-flag" value="${target}/compile-java.flag"/>
   <property name="compile-clojure-flag" value="${target}/compile-clojure.flag"/>
+  <property name="compile-tests-flag" value="${target}/compile-tests.flag"/>
 
   <target name="init" depends="">
     <tstamp/>
@@ -120,9 +121,26 @@
     <touch file="${compile-clojure-flag}"/>
   </target>
 
+  <target name="compile-tests.check"
+          depends="compile-clojure.check">
+    <uptodate property="compile-tests.files.uptodate">
+      <srcfiles dir="${test}" includes="**/*.clj"/>
+      <srcfiles dir="${test}" includes="**/*.cljc"/>
+      <srcfiles dir="${test}" includes="**/*.edn"/>
+      <mapper type="merge" to="${compile-tests-flag}"/>
+    </uptodate>
+    <condition property="compile-tests.uptodate">
+      <and>
+        <istrue value="${compile-clojure.uptodate}"/>
+        <istrue value="${compile-tests.files.uptodate}"/>
+      </and>
+    </condition>
+  </target>
+
   <target name="compile-tests"
           description="Compile the subset of tests that require compilation."
-          unless="maven.test.skip">
+          depends="compile-clojure,compile-tests.check"
+          unless="compile-tests.uptodate">
     <mkdir dir="${test-classes}"/>
     <javac srcdir="${jtestsrc}" destdir="${test-classes}" includeJavaRuntime="yes"
            debug="true" source="1.6" target="1.6" includeantruntime="no"/>
@@ -140,6 +158,7 @@
       <arg value="clojure.test-clojure.compilation.load-ns"/>
       <arg value="clojure.test-clojure.annotations"/>
     </java>
+    <touch file="${compile-tests-flag}"/>
   </target>
 
   <target name="test-example"


### PR DESCRIPTION
This changeset, hinted at by #53, makes an effort not to rebuild or
retest if the build system has confidence that it just did that
task. Enables `mvn deploy` for deploying snapshots to escape redoing
everything that just got done during test.
