### PR TITLE
Namespace reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,21 @@ entire project although few JDK8 features are used at this time.
     the `Var` is bound.
   - `clojure.core/defonce` now returns the defined `Var` same as `def`.
   - Add tests of `clojure.core/defonce` with regards to all of the above behavior.
+- [#60](https://github.com/jaunt-lang/jaunt/pull/60) Versioned namespaces in support of reloading (@arrdem).
+  - This changeset reworks the namespace macro and namespace system to provide better reloading
+    support with fewer gotchas requiring a repl restart.
+    - Namespace aliases are now cleared when reloading. This enables users to `(:require :as ...)`
+      reusing names without restarting the system.
+    - Namespaces now have a concept of version, being the number of times they have been
+      reset/reevaluated (`clojure.lang.Namespace.getRev()`).
+    - Vars track the version of the Namespace in which they are defined, synchronizing versions
+      whenever their root binding is altered say by a `def` form.
+    - Namespace bound Vars can now report if they were defined in the current version of their
+      parent Namespace (`clojure.lang.Var.isStale()`).
+    - The compiler emits warnings when analyzing uses of Vars which are not up to date with their
+      parent Namespace. This allows users to detect uses of deleted defs without a system
+      restart. This warning is controlled by the compiler flag `:warn-on-stale`, which is `true` by
+      default.
 - [#87](https://github.com/jaunt-lang/jaunt/pull/87) Send build notifications to gitter (@arrdem).
 - [#86](https://github.com/jaunt-lang/jaunt/pull/86) Fix false changelog linter failures on develop, master, release/* (@arrdem).
 - [#84](https://github.com/jaunt-lang/jaunt/pull/84) Whole bag of project changes (@arrdem).

--- a/build.xml
+++ b/build.xml
@@ -95,7 +95,7 @@
       <sysproperty key="clojure.compile.path" value="${build}"/>
       <!--<sysproperty key="clojure.compiler.elide-meta" value="[:doc :file :line :added]"/>-->
       <!--<sysproperty key="clojure.compiler.disable-locals-clearing" value="true"/>-->
-      <!--<sysproperty key="clojure.compile.warn-on-reflection" value="true"/>-->
+      <sysproperty key="clojure.compiler.warn-on-stale" value="false"/>
       <sysproperty key="clojure.compiler.direct-linking" value="true"/>
       <sysproperty key="java.awt.headless" value="true"/>
       <arg value="clojure.core"/>

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6567,6 +6567,7 @@
   :warn-on-deprecated - on by default. Switches warnings for using ^:deprecated vars.
   :warn-on-access-violation - on by default. Switches warnings for using ^:private vars from other namespaces.
   :warn-on-earmuffs - on by default. Switches warnings for non-dynamic earmuffed vars.
+  :warn-on-stale - on by default. Switches warnings for referencing stale vars.
   :pedantic - off by default. Enables all warning switches.
 
   Alpha, subject to change."

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5827,9 +5827,11 @@
                                            (not-any? #(= :refer-clojure (first %)) references))
                                   `((clojure.core/refer* *ns* '~'clojure.core)))
                               ~@(map process-reference references)))
-        res-form         `(let [~'__ns (clojure.core/in-ns '~name)
+        res-form         `(let [~'^clojure.lang.Namespace __ns (clojure.core/in-ns '~name)
                                 ~'__fn ~(binding [*ns* (find-ns 'clojure.core)]
                                           (eval fn-form))]
+                            (if (.isModule ~'__ns)
+                              (.reset ~'__ns))
                             ~@(when name-metadata
                                 `((.resetMeta ~'__ns ~name-metadata)))
                             (~'__fn)

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -7818,13 +7818,15 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; data readers ;;;;;;;;;;;;;;;;;;
 
-(def ^{:added "0.1.0"} default-data-readers
+(def
+  ^{:added "0.1.0"}
+  default-data-readers
   "Default map of data reader functions provided by Clojure. May be
   overridden by binding *data-readers*."
   {'inst #'clojure.instant/read-instant-date
    'uuid #'clojure.uuid/default-uuid-reader})
 
-(def ^{:added "0.1.0" :dynamic true} *data-readers*
+(add-doc-and-meta *data-readers*
   "Map from reader tag symbols to data reader Vars.
 
   When Clojure starts, it searches for files named 'data_readers.clj'
@@ -7851,14 +7853,16 @@
   Clojure. Default reader tags are defined in
   clojure.core/default-data-readers but may be overridden in
   data_readers.clj or by rebinding this Var."
-  {})
+  {:added   "0.1.0"
+   :dynamic true
+   :once    true})
 
-(def ^{:added "0.1.0" :dynamic true} *default-data-reader-fn*
+(add-doc-and-meta *default-data-reader-fn*
   "When no data reader is found for a tag and *default-data-reader-fn*
   is non-nil, it will be called with two arguments,
   the tag and the value.  If *default-data-reader-fn* is nil (the
   default), an exception will be thrown for the unknown tag."
-  nil)
+  {:added "0.1.0"})
 
 (defn- data-reader-urls []
   (let [cl (.. Thread currentThread getContextClassLoader)]

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -238,8 +238,10 @@ public class Compiler implements Opcodes {
       }
     }
 
-    COMPILER_OPTIONS = Var.intern(RT.CLOJURE_NS,
-                                  Symbol.intern("*compiler-options*"), compilerOptions).setDynamic();
+    COMPILER_OPTIONS =
+      Var.intern(RT.CLOJURE_NS,
+                 Symbol.intern("*compiler-options*"),
+                 compilerOptions).setOnce().setDynamic();
   }
 
   static Object elideMeta(Object m) {
@@ -6475,6 +6477,11 @@ public class Compiler implements Opcodes {
           && !Util.equals(nsc, v.ns)
           && warnOnAccessViolation()) {
         RT.errPrintWriter().println("Warning: using private var in other ns: " + v.toString() + loc);
+      }
+
+      if (v.isStale()) {
+        RT.errPrintWriter().println("Warning: using stale var: " + v.toString()
+                                    + String.format(" (var: %d, ns: %d)", v.getRev(), v.ns.getRev()) + loc);
       }
 
       registerVar(v);

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -388,13 +388,13 @@ public class Compiler implements Opcodes {
   static public IPersistentSet getUsedVars(Var v) {
     IPersistentSet uses = PersistentHashSet.EMPTY;
 
-    if(v.isBound()) {
+    if (v.isBound()) {
       Object o = v.get();
-      if(o instanceof AFn) {
+      if (o instanceof AFn) {
         IPersistentMap meta = RT.meta(o);
         uses = (IPersistentSet) RT.get(meta, RT.USES_KEY);
       }
-      if(uses == null) {
+      if (uses == null) {
         uses = (IPersistentSet) RT.get(RT.meta(v), RT.USES_KEY, PersistentHashSet.EMPTY);
       }
     }
@@ -406,19 +406,19 @@ public class Compiler implements Opcodes {
     IPersistentSet acc = getUsedVars(v);
     PersistentQueue worklist = PersistentQueue.EMPTY;
 
-    for(Object o : acc) {
+    for (Object o : acc) {
       worklist = worklist.cons(o);
     }
 
     acc = (IPersistentSet) acc.cons(v);
 
     Object o;
-    while((o = worklist.peek()) != null) {
+    while ((o = worklist.peek()) != null) {
       worklist = worklist.pop();
       IPersistentSet newbies = getUsedVars((Var) o);
 
-      for(Object n : newbies) {
-        if(!acc.contains(n)) {
+      for (Object n : newbies) {
+        if (!acc.contains(n)) {
           acc = (IPersistentSet) acc.cons(n);
           worklist = worklist.cons(n);
         }
@@ -3642,7 +3642,7 @@ public class Compiler implements Opcodes {
             ,CONSTANT_IDS, new IdentityHashMap()
             ,KEYWORDS, PersistentHashMap.EMPTY
             ,VARS, PersistentHashMap.EMPTY
-	    ,USE_SET, PersistentHashSet.EMPTY
+            ,USE_SET, PersistentHashSet.EMPTY
             ,KEYWORD_CALLSITES, PersistentVector.EMPTY
             ,PROTOCOL_CALLSITES, PersistentVector.EMPTY
             ,VAR_CALLSITES, emptyVarCallSites()
@@ -6898,8 +6898,8 @@ public class Compiler implements Opcodes {
     Var.pushThreadBindings(
       RT.map(
         RT.CURRENT_NS, null
-	,RT.FN_LOADER_VAR, loader
-	,RT.READEVAL, RT.T
+        ,RT.FN_LOADER_VAR, loader
+        ,RT.READEVAL, RT.T
       ));
   }
 

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -392,6 +392,7 @@ public class Compiler implements Opcodes {
     public final int line;
     public final int column;
     final static Method bindRootMethod = Method.getMethod("void bindRoot(Object)");
+    final static Method resetRevMethod = Method.getMethod("void resetRev()");
     final static Method setTagMethod = Method.getMethod("void setTag(clojure.lang.Symbol)");
     final static Method setMetaMethod = Method.getMethod("void setMeta(clojure.lang.IPersistentMap)");
     final static Method setDynamicMethod = Method.getMethod("clojure.lang.Var setDynamic(boolean)");
@@ -428,6 +429,8 @@ public class Compiler implements Opcodes {
       try {
         if (initProvided) {
           var.bindRoot(init.eval());
+        } else {
+          var.resetRev();
         }
         if (meta != null) {
           IPersistentMap metaMap = (IPersistentMap) meta.eval();
@@ -477,6 +480,9 @@ public class Compiler implements Opcodes {
           init.emit(C.EXPRESSION, objx, gen);
         }
         gen.invokeVirtual(VAR_TYPE, bindRootMethod);
+      } else {
+        gen.dup();
+        gen.invokeVirtual(VAR_TYPE, resetRevMethod);
       }
 
       if (context == C.STATEMENT) {
@@ -508,6 +514,7 @@ public class Compiler implements Opcodes {
           throw Util.runtimeException("First argument to def must be a Symbol");
         }
         Symbol sym = (Symbol) RT.second(form);
+        boolean initProvided = RT.count(form) == 3;
         Var v = lookupVar(sym, true);
         if (v == null) {
           throw Util.runtimeException("Can't refer to qualified var that doesn't exist");
@@ -535,6 +542,7 @@ public class Compiler implements Opcodes {
                                      +"but its name suggests otherwise. Please either indicate ^:dynamic %1$s or change the name. (%2$s:%3$d)\n",
                                      sym, RT.SOURCE_PATH.get(), RT.LINE.get());
         }
+        boolean isPrivate = RT.booleanCast(RT.get(mm, privateKey));
         if (RT.booleanCast(RT.get(mm, arglistsKey))) {
           IPersistentMap vm = v.meta();
           //vm = (IPersistentMap) RT.assoc(vm,staticKey,RT.T);

--- a/src/jvm/clojure/lang/Namespace.java
+++ b/src/jvm/clojure/lang/Namespace.java
@@ -1,4 +1,4 @@
-M<>/**
+/**
  *   Copyright (c) Rich Hickey. All rights reserved.
  *   The use and distribution terms for this software are covered by the
  *   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -206,7 +206,8 @@ public class RT {
                new OutputStreamWriter(System.out)).setOnce().setDynamic();
 
   final static public Var IN =
-    Var.intern(CLOJURE_NS, Symbol.intern("*in*"),
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*in*"),
                new LineNumberingPushbackReader(new InputStreamReader(System.in))).setOnce().setDynamic();
 
   final static public Var ERR =
@@ -255,7 +256,7 @@ public class RT {
     Var.intern(CLOJURE_NS,
                Symbol.intern("*math-context*"),
                null).setOnce().setDynamic();
-  
+
   final static public Var USE_CONTEXT_CLASSLOADER =
     Var.intern(CLOJURE_NS,
                Symbol.intern("*use-context-classloader*"),

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -234,7 +234,7 @@ public class RT {
   final static public Var DEFAULT_DATA_READER_FN =
     Var.intern(CLOJURE_NS,
                Symbol.intern("*default-data-reader-fn*"),
-               RT.map()).setOnce().setDynamic();
+               null).setOnce().setDynamic();
 
   final static public Var DEFAULT_DATA_READERS =
     Var.intern(CLOJURE_NS,
@@ -328,7 +328,10 @@ public class RT {
     }
   };
 
-  final static Var IN_NS_VAR = Var.intern(CLOJURE_NS, IN_NAMESPACE, inNamespace);
+  final static Var IN_NS_VAR =
+    Var.intern(CLOJURE_NS,
+               IN_NAMESPACE,
+               inNamespace).setOnce();
 
   final static IFn bootNamespace = new AFn() {
     public Object invoke(Object __form, Object __env, Object arg1) {
@@ -351,7 +354,10 @@ public class RT {
     }
   };
 
-  final static Var LOAD_FILE_VAR = Var.intern(CLOJURE_NS, LOAD_FILE, bootLoadFile);
+  final static Var LOAD_FILE_VAR =
+    Var.intern(CLOJURE_NS,
+               LOAD_FILE,
+               bootLoadFile).setOnce();
 
   public static List<String> processCommandLine(String[] args) {
     List<String> arglist = Arrays.asList(args);
@@ -411,6 +417,7 @@ public class RT {
     OUT.setTag(Symbol.intern("java.io.Writer"));
     CURRENT_NS.setTag(Symbol.intern("clojure.lang.Namespace"));
     MATH_CONTEXT.setTag(Symbol.intern("java.math.MathContext"));
+
     try {
       doInit();
     } catch (Exception e) {

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -164,92 +164,152 @@ public class RT {
   static public final Namespace CLOJURE_NS =
     Namespace.findOrCreate(Symbol.intern("clojure.core"));
 
+  static final public Var COLUMN =
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*column*"),
+               0).setOnce().setDynamic();
+
+  static final public Var LINE =
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*line*"),
+               0).setOnce().setDynamic();
+
+  static final public Var ADD_ANNOTATIONS =
+    Var.intern(CLOJURE_NS, Symbol.intern("add-annotations"));
+
+  static final public Var INSTANCE =
+    Var.intern(CLOJURE_NS, Symbol.intern("instance?"));
+
+  static final public Var COMPILE_FILES =
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*compile-files*"),
+               F).setOnce().setDynamic();
+
+  static final public Var COMPILE_PATH =
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*compile-path*"),
+               null).setOnce().setDynamic();
+
+  static final public Var SOURCE_PATH =
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*file*"),
+               "NO_SOURCE_PATH").setOnce().setDynamic();
+
+  static final public Var SOURCE =
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*source-path*"),
+               "NO_SOURCE_FILE").setOnce().setDynamic();
+
   final static public Var OUT =
-    Var.intern(CLOJURE_NS, Symbol.intern("*out*"), new OutputStreamWriter(System.out)).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*out*"),
+               new OutputStreamWriter(System.out)).setOnce().setDynamic();
 
   final static public Var IN =
     Var.intern(CLOJURE_NS, Symbol.intern("*in*"),
-               new LineNumberingPushbackReader(new InputStreamReader(System.in))).setDynamic();
+               new LineNumberingPushbackReader(new InputStreamReader(System.in))).setOnce().setDynamic();
 
   final static public Var ERR =
-    Var.intern(CLOJURE_NS, Symbol.intern("*err*"),
-               new PrintWriter(new OutputStreamWriter(System.err), true)).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*err*"),
+               new PrintWriter(new OutputStreamWriter(System.err), true)).setOnce().setDynamic();
 
   final static public Var AGENT =
-    Var.intern(CLOJURE_NS, Symbol.intern("*agent*"),
-               null).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*agent*"),
+               null).setOnce().setDynamic();
+
+  static Object readeval = readTrueFalseUnknown(System.getProperty("clojure.read.eval","true"));
 
   final static public Var READEVAL =
-    Var.intern(CLOJURE_NS, Symbol.intern("*read-eval*"),
-               readTrueFalseUnknown(System.getProperty("clojure.read.eval","true"))).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*read-eval*"),
+               readeval).setOnce().setDynamic();
 
   final static public Var DATA_READERS =
-    Var.intern(CLOJURE_NS, Symbol.intern("*data-readers*"),
-               map()).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*data-readers*"),
+               RT.map()).setOnce().setDynamic();
 
   final static public Var DEFAULT_DATA_READER_FN =
-    Var.intern(CLOJURE_NS, Symbol.intern("*default-data-reader-fn*"),
-               map()).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*default-data-reader-fn*"),
+               RT.map()).setOnce().setDynamic();
 
   final static public Var DEFAULT_DATA_READERS =
-    Var.intern(CLOJURE_NS, Symbol.intern("default-data-readers"),
-               map());
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("default-data-readers"),
+               RT.map());
 
   final static public Var SUPPRESS_READ =
-    Var.intern(CLOJURE_NS, Symbol.intern("*suppress-read*"),
-               null).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*suppress-read*"),
+               null).setOnce().setDynamic();
 
   final static public Var ASSERT =
-    Var.intern(CLOJURE_NS, Symbol.intern("*assert*"),
-               T).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*assert*"),
+               T).setOnce().setDynamic();
 
   final static public Var MATH_CONTEXT =
-    Var.intern(CLOJURE_NS, Symbol.intern("*math-context*"),
-               null).setDynamic();
-
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*math-context*"),
+               null).setOnce().setDynamic();
+  
   final static public Var USE_CONTEXT_CLASSLOADER =
-    Var.intern(CLOJURE_NS, Symbol.intern("*use-context-classloader*"),
-               T).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*use-context-classloader*"),
+               T).setOnce().setDynamic();
 
   static final public Var UNCHECKED_MATH =
-    Var.intern(CLOJURE_NS, Symbol.intern("*unchecked-math*"),
-               F).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*unchecked-math*"),
+               F).setOnce().setDynamic();
 
   final static Var CMD_LINE_ARGS =
-    Var.intern(CLOJURE_NS, Symbol.intern("*command-line-args*"),
-               null).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*command-line-args*"),
+               null).setOnce().setDynamic();
 
   final public static Var CURRENT_NS =
-    Var.intern(CLOJURE_NS, Symbol.intern("*ns*"),
-               CLOJURE_NS).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*ns*"),
+               CLOJURE_NS).setOnce().setDynamic();
 
   final static Var FLUSH_ON_NEWLINE =
-    Var.intern(CLOJURE_NS, Symbol.intern("*flush-on-newline*"),
-               T).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*flush-on-newline*"),
+               T).setOnce().setDynamic();
 
   final static Var PRINT_META =
-    Var.intern(CLOJURE_NS, Symbol.intern("*print-meta*"),
-               F).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*print-meta*"),
+               F).setOnce().setDynamic();
 
   final static Var PRINT_READABLY =
-    Var.intern(CLOJURE_NS, Symbol.intern("*print-readably*"),
-               T).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*print-readably*"),
+               T).setOnce().setDynamic();
 
   final static Var PRINT_DUP =
-    Var.intern(CLOJURE_NS, Symbol.intern("*print-dup*"),
-               F).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*print-dup*"),
+               F).setOnce().setDynamic();
 
   final static Var WARN_ON_REFLECTION =
-    Var.intern(CLOJURE_NS, Symbol.intern("*warn-on-reflection*"),
-               F).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*warn-on-reflection*"),
+               F).setOnce().setDynamic();
 
   final static Var ALLOW_UNRESOLVED_VARS =
-    Var.intern(CLOJURE_NS, Symbol.intern("*allow-unresolved-vars*"),
-               F).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*allow-unresolved-vars*"),
+               F).setOnce().setDynamic();
 
   final static Var FN_LOADER_VAR =
-    Var.intern(CLOJURE_NS, Symbol.intern("*fn-loader*"),
-               null).setDynamic();
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("*fn-loader*"),
+               null).setOnce().setDynamic();
 
   static final Var PRINT_INITIALIZED =
     Var.intern(CLOJURE_NS,
@@ -315,9 +375,9 @@ public class RT {
 
   public static String getPos() {
     return String.format("(%s:%d:%d)",
-                         Compiler.SOURCE_PATH.get(),
-                         Compiler.LINE.get(),
-                         Compiler.COLUMN.get());
+                         SOURCE_PATH.get(),
+                         LINE.get(),
+                         COLUMN.get());
   }
 
   static public final Object[] EMPTY_ARRAY = new Object[] {};
@@ -472,7 +532,7 @@ public class RT {
       }
     }
     if (!loaded && cljURL != null) {
-      if (booleanCast(Compiler.COMPILE_FILES.deref())) {
+      if (booleanCast(COMPILE_FILES.deref())) {
         compile(scriptfile);
       } else {
         loadResourceScript(RT.class, scriptfile);

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -209,8 +209,7 @@ public class RT {
                new OutputStreamWriter(System.out)).setOnce().setDynamic();
 
   final static public Var IN =
-    Var.intern(CLOJURE_NS,
-               Symbol.intern("*in*"),
+    Var.intern(CLOJURE_NS, Symbol.intern("*in*"),
                new LineNumberingPushbackReader(new InputStreamReader(System.in))).setOnce().setDynamic();
 
   final static public Var ERR =
@@ -352,7 +351,10 @@ public class RT {
     }
   };
 
-  final static Var NS_VAR = Var.intern(CLOJURE_NS, NAMESPACE, bootNamespace).setMacro();
+  final static Var NS_VAR =
+    Var.intern(CLOJURE_NS,
+               NAMESPACE,
+               bootNamespace).setMacro();
 
   final static IFn bootLoadFile = new AFn() {
     public Object invoke(Object arg1) {

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -336,7 +336,13 @@ public class RT {
   final static IFn bootNamespace = new AFn() {
     public Object invoke(Object __form, Object __env, Object arg1) {
       Symbol nsname = (Symbol) arg1;
-      Namespace ns = Namespace.findOrCreate(nsname);
+      Namespace ns = Namespace.find(nsname);
+      if (ns != null && ns.isModule()) {
+        ns.reset();
+      } else {
+        ns = Namespace.findOrCreate(nsname);
+      }
+      ns.resetMeta(nsname.meta());
       CURRENT_NS.set(ns);
       return ns;
     }

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -44,6 +44,9 @@ public class RT {
   final static Keyword DOC_KEY = Keyword.intern("doc");
   final static Keyword UNKNOWN_KEY = Keyword.intern("unknown");
 
+  public static final Keyword USES_KEY = Keyword.intern("clojure.core.compiler", "uses");
+  public static final Keyword REACHES_KEY = Keyword.intern("clojure.core.compiler", "reaches");
+
   final static Symbol LOAD_FILE = Symbol.intern("load-file");
   final static Symbol IN_NAMESPACE = Symbol.intern("in-ns");
   final static Symbol NAMESPACE = Symbol.intern("ns");

--- a/src/jvm/clojure/lang/Var.java
+++ b/src/jvm/clojure/lang/Var.java
@@ -246,7 +246,7 @@ public final class Var
   public synchronized long getRev() {
     return rev;
   }
-  
+
   public synchronized void resetRev() {
     rev = nsRev();
   }

--- a/src/jvm/clojure/lang/Var.java
+++ b/src/jvm/clojure/lang/Var.java
@@ -72,8 +72,6 @@ public final class Var
     }
   };
 
-  static public volatile int rev = 0;
-
   static Keyword privateKey = Keyword.intern(null, "private");
   static Keyword dynamicKey = Keyword.intern(null, "dynamic");
   static Keyword onceKey = Keyword.intern(null, "once");
@@ -90,6 +88,8 @@ public final class Var
   volatile boolean _once = false;
   volatile boolean _macro = false;
   transient final AtomicBoolean threadBound;
+  private volatile long rev = 0;
+  private volatile long valrev = 0;
   public final Symbol sym;
   public final Namespace ns;
 
@@ -217,6 +217,7 @@ public final class Var
     this.sym = sym;
     this.threadBound = new AtomicBoolean(false);
     this.root = new Unbound(this);
+    this.rev = nsRev();
     setMeta(PersistentHashMap.EMPTY);
   }
 
@@ -235,6 +236,23 @@ public final class Var
       return root;
     }
     return deref();
+  }
+
+  private long nsRev() {
+    long v = ns == null ? -1 : ns.getRev();
+    return v;
+  }
+
+  public synchronized long getRev() {
+    return rev;
+  }
+  
+  public synchronized void resetRev() {
+    rev = nsRev();
+  }
+
+  public boolean isStale() {
+    return !isOnce() && rev < nsRev();
   }
 
   final public Object deref() {
@@ -356,8 +374,9 @@ public final class Var
     validate(getValidator(), root);
     Object oldroot = this.root;
     this.root = root;
-    ++rev;
-    alterMeta(dissoc, RT.list(macroKey));
+    ++valrev;
+    resetRev();
+    setMacro(false);
     notifyWatches(oldroot,this.root);
   }
 
@@ -365,13 +384,15 @@ public final class Var
     validate(getValidator(), root);
     Object oldroot = this.root;
     this.root = root;
-    ++rev;
+    ++valrev;
+    resetRev();
     notifyWatches(oldroot,root);
   }
 
   synchronized public void unbindRoot() {
     this.root = new Unbound(this);
-    ++rev;
+    ++valrev;
+    rev = -1;
   }
 
   synchronized public void commuteRoot(IFn fn) {
@@ -379,8 +400,9 @@ public final class Var
     validate(getValidator(), newRoot);
     Object oldroot = root;
     this.root = newRoot;
-    ++rev;
-    notifyWatches(oldroot, newRoot);
+    ++valrev;
+    resetRev();
+    notifyWatches(oldroot,newRoot);
   }
 
   synchronized public Object alterRoot(IFn fn, ISeq args) {
@@ -388,8 +410,9 @@ public final class Var
     validate(getValidator(), newRoot);
     Object oldroot = root;
     this.root = newRoot;
-    ++rev;
-    notifyWatches(oldroot, newRoot);
+    ++valrev;
+    resetRev();
+    notifyWatches(oldroot,newRoot);
     return newRoot;
   }
 

--- a/test/clojure/test_clojure/protocols.clj
+++ b/test/clojure/test_clojure/protocols.clj
@@ -45,16 +45,18 @@
   (getKey [_] k)
   (getValue [_] v))
 
+(defn at-least? [l r]
+  (every? #(= (get l %) (get r %)) (keys l)))
+
 (deftest protocols-test
   (testing "protocol fns have useful metadata"
-    (let [common-meta {:ns (find-ns 'clojure.test-clojure.protocols.examples)
+    (let [common-meta {:ns       (find-ns 'clojure.test-clojure.protocols.examples)
                        :protocol #'ExampleProtocol}]
-      (are [m f] (= (merge (quote m) common-meta)
-                    (meta (var f)))
-        {:name foo :arglists ([a]) :doc "method with one arg"} foo
-        {:name bar :arglists ([a b]) :doc "method with two args"} bar
+      (are [m f] (at-least? (merge (quote m) common-meta) (meta (var f)))
+        {:name foo :arglists ([a]) :doc "method with one arg"}                            foo
+        {:name bar :arglists ([a b]) :doc "method with two args"}                         bar
         {:name baz :arglists ([a] [a b]) :doc "method with multiple arities" :tag String} baz
-        {:name with-quux :arglists ([a]) :doc "method name with a hyphen"} with-quux)))
+        {:name with-quux :arglists ([a]) :doc "method name with a hyphen"}                with-quux)))
   (testing "protocol fns throw IllegalArgumentException if no impl matches"
     (is (thrown-with-msg?
          IllegalArgumentException

--- a/test/clojure/test_clojure/rt.clj
+++ b/test/clojure/test_clojure/rt.clj
@@ -74,7 +74,7 @@
   (alter-meta! #'example-var assoc :macro true)
   (is (contains? (meta #'example-var) :macro))
   (.bindRoot #'example-var 0)
-  (is (not (contains? (meta #'example-var) :macro))))
+  (is (not (get (meta #'example-var) :macro))))
 
 (deftest last-var-wins-for-core
   (testing "you can replace a core name, with warning"

--- a/test/clojure/test_clojure/rt.clj
+++ b/test/clojure/test_clojure/rt.clj
@@ -67,7 +67,23 @@
   (testing "reflection cannot resolve constructor"
     (should-print-err-message
      #"Reflection warning, .*:\d+:\d+ - call to java\.lang\.String ctor can't be resolved\.\r?\n"
-     (defn foo [] (String. 1 2 3)))))
+     (defn foo [] (String. 1 2 3))))
+  (testing "stale var warnings"
+    (should-print-err-message
+     #"Warning: using stale var: #'foo/b.*\n"
+     (do (ns foo)
+         (def b 2)
+         (ns foo)
+         b))
+    (binding [*compiler-options* (assoc *compiler-options* :warn-on-stale false)]
+      (eval '(do (ns foo)
+                 (def b 2)
+                 (ns foo)
+                 (ns baz)
+                 (defn b [] foo/b))))
+    (should-print-err-message
+     #"Warning: var: #'baz/b reaches stale vars: #\{#'foo/b\}.*\n"
+     (baz/b))))
 
 (def example-var)
 (deftest binding-root-clears-macro-metadata


### PR DESCRIPTION
This changeset aims to rework the namespace macro and namespace system so as to provide better reloading support with fewer gotchas requiring a repl restart. In order to implement this goal, two major changes are required. First, the aliases map of a namespace needs to be cleared when reloading (#6) and second the vars in a namespace should somehow become invalidated when reloading a namespace (#5). Really this is more work to better support the illusion that Clojure's code loading unit can be a file.

Difficulties with this changeset:
- How to handle reloading `^:once` (defonce) vars. The once contract is
  provided to support defs whose values will not be altered at least by
  their definition. In order to honor this contract, the new reload
  "cleanup" of a namespace cannot alter the value of a `^:once` var or
  otherwise destroy it.
- How to hide/destroy/garbage collect a var? If a `(def foo ...)`
  existed and was removed, it doesn't make sense for it to show up in
  `ns-publics` or anything else but there isn't a good way to actually
  destroy or delete a var since they're interned and will be referred to
  at least by generated classes. Re-valuing vars to `Var$Unbound` makes
  some sense, because it's an existing concept of an unbound or invalid
  var. However this creates issues especially when interacting with a
  live app. If you you actually unbind a bunch of stuff while an app is
  live... nasty things may happen. Something more subtle may be in
  order. Maybe a concept of the Var's version with respect to the
  version of the namespace. But that's going to have performance
  implications which may be unacceptable.

Fixes #5, #6
