### PR TITLE
Var metadata contracts

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6210,12 +6210,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; var documentation ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(alter-meta! #'*agent* assoc :added "1.0")
 (alter-meta! #'in-ns assoc :added "1.0")
 (alter-meta! #'load-file assoc :added "1.0")
 
 (defmacro add-doc-and-meta {:private true} [name docstring meta]
   `(alter-meta! (var ~name) merge (assoc ~meta :doc ~docstring)))
+
+(add-doc-and-meta *agent*
+  "The agent currently running an action on this thread, else nil"
+  {:added "1.0"
+   :tag   clojure.lang.Agent})
 
 (add-doc-and-meta *file*
   "The path of the file being evaluated, as a String.

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -3582,8 +3582,6 @@
        (number? x) (BigDecimal/valueOf (long x))
        :else (BigDecimal. x)))
 
-(def ^:dynamic ^{:private true} print-initialized false)
-
 (defmulti print-method (fn [x writer]
                          (let [t (get (meta x) :type)]
                            (if (keyword? t) t (class x)))))

--- a/src/clj/clojure/core_print.clj
+++ b/src/clj/clojure/core_print.clj
@@ -487,4 +487,7 @@
   (when (:splicing? o) (.write w "@"))
   (print-method (:form o) w))
 
-(def ^{:private true} print-initialized true)
+(def
+  ^{:private true
+    :dynamic true}
+  print-initialized true)

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -232,7 +232,10 @@ public class RT {
   final static Var IN_NS_VAR = Var.intern(CLOJURE_NS, Symbol.intern("in-ns"), F);
   final static Var NS_VAR = Var.intern(CLOJURE_NS, Symbol.intern("ns"), F);
   final static Var FN_LOADER_VAR = Var.intern(CLOJURE_NS, Symbol.intern("*fn-loader*"), null).setDynamic();
-  static final Var PRINT_INITIALIZED = Var.intern(CLOJURE_NS, Symbol.intern("print-initialized"));
+  static final Var PRINT_INITIALIZED =
+    Var.intern(CLOJURE_NS,
+               Symbol.intern("print-initialized"),
+               F).setPublic(false).setDynamic();
   static final Var PR_ON = Var.intern(CLOJURE_NS, Symbol.intern("pr-on"));
 //final static Var IMPORTS = Var.intern(CLOJURE_NS, Symbol.intern("*imports*"), DEFAULT_IMPORTS);
   final static IFn inNamespace = new AFn() {

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -273,6 +273,13 @@ public class RT {
     }
   }
 
+  public static String getPos() {
+    return String.format("(%s:%d:%d)",
+                         Compiler.SOURCE_PATH.get(),
+                         Compiler.LINE.get(),
+                         Compiler.COLUMN.get());
+  }
+
   static public final Object[] EMPTY_ARRAY = new Object[] {};
   static public final Comparator DEFAULT_COMPARATOR = new DefaultComparator();
 

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -312,8 +312,6 @@ public class RT {
     Symbol namesym = Symbol.intern("name");
     OUT.setTag(Symbol.intern("java.io.Writer"));
     CURRENT_NS.setTag(Symbol.intern("clojure.lang.Namespace"));
-    AGENT.setMeta(map(DOC_KEY, "The agent currently running an action on this thread, else nil"));
-    AGENT.setTag(Symbol.intern("clojure.lang.Agent"));
     MATH_CONTEXT.setTag(Symbol.intern("java.math.MathContext"));
     Var nv = Var.intern(CLOJURE_NS, NAMESPACE, bootNamespace);
     nv.setMacro();

--- a/src/jvm/clojure/lang/Var.java
+++ b/src/jvm/clojure/lang/Var.java
@@ -63,7 +63,6 @@ public final class Var
     protected Object clone() {
       return new Frame(this.bindings, null);
     }
-
   }
 
   static final ThreadLocal<Frame> dvals = new ThreadLocal<Frame>() {
@@ -76,20 +75,25 @@ public final class Var
   static public volatile int rev = 0;
 
   static Keyword privateKey = Keyword.intern(null, "private");
-  static IPersistentMap privateMeta = new PersistentArrayMap(new Object[] {privateKey, Boolean.TRUE});
+  static Keyword dynamicKey = Keyword.intern(null, "dynamic");
+  static Keyword onceKey = Keyword.intern(null, "once");
   static Keyword macroKey = Keyword.intern(null, "macro");
   static Keyword nameKey = Keyword.intern(null, "name");
   static Keyword nsKey = Keyword.intern(null, "ns");
-//static Keyword tagKey = Keyword.intern(null, "tag");
+
+  static IPersistentMap privateMeta = new PersistentArrayMap(new Object[] {privateKey, Boolean.TRUE});
 
   volatile Object root;
 
-  volatile boolean dynamic = false;
+  volatile boolean _dynamic = false;
+  volatile boolean _private = false;
+  volatile boolean _once = false;
+  volatile boolean _macro = false;
   transient final AtomicBoolean threadBound;
   public final Symbol sym;
   public final Namespace ns;
 
-//IPersistentMap _meta;
+  private IPersistentMap _meta;
 
   public static Object getThreadBindingFrame() {
     return dvals.get();
@@ -103,18 +107,44 @@ public final class Var
     dvals.set((Frame) frame);
   }
 
-  public Var setDynamic() {
-    this.dynamic = true;
-    return this;
+  synchronized public IPersistentMap meta() {
+    return _meta;
   }
 
-  public Var setDynamic(boolean b) {
-    this.dynamic = b;
-    return this;
+  synchronized public IPersistentMap alterMeta(IFn alter, ISeq args)  {
+    _meta = alterMetaHook((IPersistentMap)alter.applyTo(new Cons(_meta, args)));
+    return _meta;
   }
 
-  public final boolean isDynamic() {
-    return dynamic;
+  synchronized public IPersistentMap resetMeta(IPersistentMap m) {
+    _meta = alterMetaHook(m);
+    return m;
+  }
+
+  synchronized private IPersistentMap alterMetaHook(IPersistentMap m) {
+    boolean dp = RT.booleanCast(m.valAt(dynamicKey));
+    if (isDynamic() && !dp)
+      RT.errPrintWriter().println(
+        String.format("Warning: Var %s loosing ^:dynamic %s",
+                      toString(), RT.getPos()));
+    this._dynamic = dp;
+
+    boolean pp = RT.booleanCast(m.valAt(privateKey));
+    if (_private && !pp)
+      RT.errPrintWriter().println(
+        String.format("Warning: Var %s loosing ^:private %s",
+                      toString(), RT.getPos()));
+    this._private = pp;
+
+    boolean op = RT.booleanCast(m.valAt(onceKey));
+    if (_once && !op)
+      RT.errPrintWriter().println(
+        String.format("Warning: Var %s loosing ^:once %s",
+                      toString(), RT.getPos()));
+    this._once = op;
+
+    this._macro = RT.booleanCast(m.valAt(macroKey));
+    return m;
   }
 
   public static Var intern(Namespace ns, Symbol sym, Object root) {
@@ -128,7 +158,6 @@ public final class Var
     }
     return dvout;
   }
-
 
   public String toString() {
     if (ns != null) {
@@ -174,7 +203,6 @@ public final class Var
   public static Var intern(Namespace ns, Symbol sym) {
     return ns.intern(sym);
   }
-
 
   public static Var create() {
     return new Var(null, null);
@@ -255,20 +283,43 @@ public final class Var
     resetMeta(m.assoc(nameKey, sym).assoc(nsKey, ns));
   }
 
-  public void setMacro() {
-    alterMeta(assoc, RT.list(macroKey, RT.T));
+  public Var setDynamic() {
+    return setDynamic(true);
+  }
+
+  public Var setDynamic(boolean b) {
+    resetMeta(meta().assoc(dynamicKey, b));
+    return this;
+  }
+
+  public final boolean isDynamic() {
+    return _dynamic;
+  }
+
+  public Var setMacro() {
+    return setMacro(true);
+  }
+
+  private Var setMacro(boolean b) {
+    resetMeta(meta().assoc(macroKey, b));
+    return this;
   }
 
   public boolean isMacro() {
-    return RT.booleanCast(meta().valAt(macroKey));
+    return _macro;
   }
 
-//public void setExported(boolean state){
-//  _meta = _meta.assoc(privateKey, state);
-//}
+  public Var setPublic() {
+    return setPublic(true);
+  }
+
+  public Var setPublic(boolean b) {
+    resetMeta(meta().assoc(privateKey, !b));
+    return this;
+  }
 
   public boolean isPublic() {
-    return !RT.booleanCast(meta().valAt(privateKey));
+    return !_private;
   }
 
   final public Object getRawRoot() {
@@ -287,7 +338,7 @@ public final class Var
     return !(root instanceof Unbound);
   }
 
-//binding root always clears macro flag
+  //binding root always clears macro flag
   synchronized public void bindRoot(Object root) {
     validate(getValidator(), root);
     Object oldroot = this.root;
@@ -316,7 +367,7 @@ public final class Var
     Object oldroot = root;
     this.root = newRoot;
     ++rev;
-    notifyWatches(oldroot,newRoot);
+    notifyWatches(oldroot, newRoot);
   }
 
   synchronized public Object alterRoot(IFn fn, ISeq args) {
@@ -325,7 +376,7 @@ public final class Var
     Object oldroot = root;
     this.root = newRoot;
     ++rev;
-    notifyWatches(oldroot,newRoot);
+    notifyWatches(oldroot, newRoot);
     return newRoot;
   }
 
@@ -335,7 +386,7 @@ public final class Var
     for (ISeq bs = bindings.seq(); bs != null; bs = bs.next()) {
       IMapEntry e = (IMapEntry) bs.first();
       Var v = (Var) e.key();
-      if (!v.dynamic) {
+      if (!v.isDynamic()) {
         throw new IllegalStateException(String.format("Can't dynamically bind non-dynamic var: %s/%s", v.ns, v.sym));
       }
       v.validate(v.getValidator(), e.val());

--- a/test/clojure/test_clojure/rt.clj
+++ b/test/clojure/test_clojure/rt.clj
@@ -104,25 +104,33 @@
       (is (nil? ('subset? (ns-publics ns))))
       (is (= #'clojure.set/subset? ('subset? (ns-refers ns)))))))
 
+(defmacro silenced [& forms]
+  `(binding [*err* (new java.io.StringWriter)]
+     ~@forms))
+
 (deftest var-meta-tests
   (testing "Var.resetMeta should clear flags, getters"
     (let [v (def a-test-v)]
-      (do (.resetMeta v {})
+      (do (silenced
+           (.resetMeta v {}))
           (is (.isPublic v))
           (is (not (.isDynamic v)))
           (is (not (.isMacro v))))
 
-      (do (.resetMeta v {:private true})
+      (do (silenced
+           (.resetMeta v {:private true}))
           (is (not (.isPublic v)))
           (is (not (.isDynamic v)))
           (is (not (.isMacro v))))
 
-      (do (.resetMeta v {:dynamic true})
+      (do (silenced
+           (.resetMeta v {:dynamic true}))
           (is (.isPublic v))
           (is (.isDynamic v))
           (is (not (.isMacro v))))
 
-      (do (.resetMeta v {:macro true})
+      (do (silenced
+           (.resetMeta v {:macro true}))
           (is (.isPublic v))
           (is (not (.isDynamic v)))
           (is (.isMacro v))))))

--- a/test/clojure/test_clojure/rt.clj
+++ b/test/clojure/test_clojure/rt.clj
@@ -103,3 +103,26 @@
                    (.refer ns 'subset? #'clojure.set/intersection)))
       (is (nil? ('subset? (ns-publics ns))))
       (is (= #'clojure.set/subset? ('subset? (ns-refers ns)))))))
+
+(deftest var-meta-tests
+  (testing "Var.resetMeta should clear flags, getters"
+    (let [v (def a-test-v)]
+      (do (.resetMeta v {})
+          (is (.isPublic v))
+          (is (not (.isDynamic v)))
+          (is (not (.isMacro v))))
+
+      (do (.resetMeta v {:private true})
+          (is (not (.isPublic v)))
+          (is (not (.isDynamic v)))
+          (is (not (.isMacro v))))
+
+      (do (.resetMeta v {:dynamic true})
+          (is (.isPublic v))
+          (is (.isDynamic v))
+          (is (not (.isMacro v))))
+
+      (do (.resetMeta v {:macro true})
+          (is (.isPublic v))
+          (is (not (.isDynamic v)))
+          (is (.isMacro v))))))


### PR DESCRIPTION
This changeset implements #42 and provides both Var metadata property
caching (`^:dynamic`, `^:private` etc.) and correct cache updating when
metada changes.

As a consequence of this change, it becomes necessary to patch core so
that it correctly manages Var state changes.
