### PR TITLE
Use *line*, *file*

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5707,8 +5707,8 @@
       (.setStackTrace exception trace)
       (throw (clojure.lang.Compiler$CompilerException.
               *file*
-              (.deref clojure.lang.Compiler/LINE)
-              (.deref clojure.lang.Compiler/COLUMN)
+              *line*
+              *column*
               exception)))))
 
 (defn- libspec?

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -287,8 +287,8 @@
     (when (seq non-syms)
       (throw (clojure.lang.Compiler$CompilerException.
               *file*
-              (.deref clojure.lang.Compiler/LINE)
-              (.deref clojure.lang.Compiler/COLUMN)
+              *line*
+              *column*
               (AssertionError.
                (str "defrecord and deftype fields must be symbols, "
                     *ns* "." name " had: "


### PR DESCRIPTION
This patch swaps out direct use of the line and file vars defined in the
compiler for the much more robust use of the same vars via their names.
