### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,34 @@ be accepted if there is a good reason for them.
 ## Administration
 
 Currently, Clojarr is administered at my (Reid McKenzie's) sole
-discretion. Pull requests, issues and email are all considered requests for
-work/support and will only be adressed when and if it suits me to address them
-or an explicit support contract has been issued.
+discretion. Contributions, bug reports, and feature requests are
+welcomed.
 
-This is not to say that contributions, bug reports, and feature requests are
-not welcome, only to clearly state my expectations for the project and its
-management.
+It must be stated this is a hobby project for me. I'll respond to
+issues and pull requests as I have free time to consider and address
+them.
+ 
+The EPL license reads
+
+> THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR
+> CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT
+> LIMITATION, ANY WARRANTIES OR CONDITIONS OF ... FITNESS FOR A
+> PARTICULAR PURPOSE.
+
+And that is the extent of the guarantees I offer with regards to this
+software. It is my goal to maintain Clojarr in such a way that
+[CIDER](https://github.com/clojure-emacs/cider) works, and that most
+compatibility with Clojure is maintained but this is not a hard
+guarantee. If you want a Clojure compatible language, you're gonna
+have to use Clojure.
+
+In the future when there are other active contributors, it is my
+desire to hand off issues and patch reviews to volunteer contributors
+as they may choose to donate time. The precise mechanism by which
+contributors may approve changes is undecided, but the goal is for
+significant contributors who have demonstrated that they share some
+degree of respect for compatibility will be able to approve and merge
+changes without my involvement.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -90,3 +90,36 @@ distributed under the Apache License, in /licenses/apache.txt
 
 This program uses the ASM bytecode engineering library which is
 distributed under the license in /licenses/inria.txt
+
+## FAQ
+
+> Will you support $LIBRARY/$PRODUCT?
+
+No. They may work just fine, and you're welcome to offer changes
+continuing or preserving support as well as to assist in preventing
+breakages but no degree of compatibility with Clojure, Cognitect
+product or surrounding ecosystem is guaranteed or represented.
+
+> Will you add $FEATURE/$PATCH from Clojure?
+
+No. Under the EPL you may port changes from Clojure to
+Clojarr. However I make no promises of merging or porting upstream
+changes.
+
+> Will you add $FEATURE to the language?
+
+Maybe. For the most part, it seems that `clojure.core` is shall we say
+"right sized". In the Scheme tradition, the compiler works and the
+core is large enough that users can and have built just about
+everything else you could want as a library. This leads me to believe
+that for the most part adding features to the language isn't called
+for.
+
+That said, I don't think the language is perfect. The Java
+implementation could use some spit and shoeshine in my present
+estimation. The compiler could be smarter. The various "internal" APIs
+could be reviewed, documented and published so that users can rely on
+them. There are some things which clearly deserve to be added such as
+type predicates which are nearly universally defined by users, but I
+expect this project to largely be one of refinement rather than one of
+novel development.


### PR DESCRIPTION
This changeset clarifies the support guarantees with respect to Clojure,
and adds an FAQ to the same end
