### PR TITLE
Allow clojure.repl/source to read ::ns/sym abbrevs

### DIFF
--- a/test/clojure/test_clojure/repl.clj
+++ b/test/clojure/test_clojure/repl.clj
@@ -12,6 +12,7 @@
 
 (deftest test-source
   (is (= "(defn foo [])" (source-fn 'clojure.test-clojure.repl.example/foo)))
+  (is (= "(defn qux [] ::s/foo)" (source-fn 'clojure.test-clojure.repl.example/qux)))
   (is (= (platform-newlines "(defn foo [])\n") (with-out-str (source clojure.test-clojure.repl.example/foo))))
   (is (nil? (source-fn 'non-existent-fn))))
 
@@ -23,8 +24,8 @@
 
 (deftest test-dir
   (is (thrown? Exception (dir-fn 'non-existent-ns)))
-  (is (= '[bar foo] (dir-fn 'clojure.test-clojure.repl.example)))
-  (is (= (platform-newlines "bar\nfoo\n") (with-out-str (dir clojure.test-clojure.repl.example)))))
+  (is (= '[bar foo qux] (dir-fn 'clojure.test-clojure.repl.example)))
+  (is (= (platform-newlines "bar\nfoo\nqux\n") (with-out-str (dir clojure.test-clojure.repl.example)))))
 
 (deftest test-apropos
   (testing "with a regular expression"

--- a/test/clojure/test_clojure/repl/example.clj
+++ b/test/clojure/test_clojure/repl/example.clj
@@ -1,5 +1,7 @@
-(ns clojure.test-clojure.repl.example)
+(ns clojure.test-clojure.repl.example
+  (:require [clojure.string :as s]))
 
 ;; sample namespace for repl tests, don't add anything here
 (defn foo [])
 (defn bar [])
+(defn qux [] ::s/foo)


### PR DESCRIPTION
This changeset fixes #41, allowing clojure.repl/source (really its
implementation fn source-fn) to safely read expressions which may make
use of `*ns*` specific reader aliases.
