### PR TITLE
Add cljfmt as a linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Change Log
 
 ### upcoming
+- [#72](https://github.com/jaunt-lang/jaunt/pull/72) Impose cljfmt linting of clj sources (@arrdem).
 - [#105](https://github.com/jaunt-lang/jaunt/pull/105) Run CircleCI tests in parallel (@arrdem).
   - Adds `etc/bin/run-tests.sh`
     - If on CircleCI, tests will be run "normally" (CircleCI is configured to use two containers

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   java:
     version: oraclejdk8
+  environment:
+    _JAVA_OPTIONS: -Xmx2g
 
 dependencies:
   cache_directories:
@@ -15,6 +17,7 @@ test:
   pre:
     - bash etc/bin/check-whitespace.sh
     - bash etc/bin/check-changelog.sh
+    - lein cljfmt check
   override:
     - bash etc/bin/run-tests.sh:
         parallel: true

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,12 @@
+(defproject org.jaunt-lang/jaunt (slurp "VERSION")
+  :source-paths      ["src/clj"]
+  :java-source-paths ["src/jvm" "test/java"]
+  :test-paths        ["test/clojure"]
+  :resource-paths    ["src/resources"]
+  :profiles {:dev {:plugins [[lein-cljfmt "0.4.1"]]
+                   :cljfmt  {:indents {fn*                 [[:inner 0]]
+                                       as->                [[:inner 0]]
+                                       with-debug-bindings [[:inner 0]]
+                                       merge-meta          [[:inner 0]]
+                                       add-doc-and-meta    [[:inner 0]]}}}})
+

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -1,209 +1,237 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-(ns ^{:doc "The core Clojure language."
-       :author "Rich Hickey"}
-  clojure.core)
+(ns ^{:doc    "The core Clojure language."
+      :author "Rich Hickey"}
+ clojure.core)
 
 (def unquote)
 (def unquote-splicing)
 
 (def
- ^{:arglists '([& items])
-   :doc "Creates a new list containing the items."
-   :added "1.0"}
-  list (. clojure.lang.PersistentList creator))
+  ^{:arglists '([& items])
+    :doc      "Creates a new list containing the items."
+    :added    "1.0"}
+  list
+  clojure.lang.PersistentList/creator)
 
 (def
- ^{:arglists '([x seq])
-    :doc "Returns a new seq where x is the first element and seq is
-    the rest."
-   :added "1.0"
-   :static true}
+  ^{:arglists '([x seq])
+    :doc      "Returns a new seq where x is the first element and seq is the rest."
+    :added    "1.0"
+    :static   true}
+  cons
+  (fn* ^:static cons [x seq]
+    (clojure.lang.RT/cons x seq)))
 
- cons (fn* ^:static cons [x seq] (. clojure.lang.RT (cons x seq))))
-
-;during bootstrap we don't have destructuring let, loop or fn, will redefine later
+;; during bootstrap we don't have destructuring let, loop or fn, will redefine later
 (def
   ^{:macro true
     :added "1.0"}
-  let (fn* let [&form &env & decl] (cons 'let* decl)))
+  let
+  (fn* let [&form &env & decl]
+    (cons 'let* decl)))
 
 (def
- ^{:macro true
-   :added "1.0"}
- loop (fn* loop [&form &env & decl] (cons 'loop* decl)))
+  ^{:macro true
+    :added "1.0"}
+  loop
+  (fn* loop [&form &env & decl]
+    (cons 'loop* decl)))
 
 (def
- ^{:macro true
-   :added "1.0"}
- fn (fn* fn [&form &env & decl] 
-         (.withMeta ^clojure.lang.IObj (cons 'fn* decl) 
-                    (.meta ^clojure.lang.IMeta &form))))
+  ^{:macro true
+    :added "1.0"}
+  fn
+  (fn* fn [&form &env & decl]
+    (.withMeta ^clojure.lang.IObj (cons 'fn* decl)
+               (.meta ^clojure.lang.IMeta &form))))
 
 (def
- ^{:arglists '([coll])
-   :doc "Returns the first item in the collection. Calls seq on its
-    argument. If coll is nil, returns nil."
-   :added "1.0"
-   :static true}
- first (fn ^:static first [coll] (. clojure.lang.RT (first coll))))
+  ^{:arglists '([coll])
+    :doc      "Returns the first item in the collection. Calls seq on its argument. If coll is nil, returns nil."
+    :added    "1.0"
+    :static   true}
+  first
+  (fn ^:static first [coll]
+    (clojure.lang.RT/first coll)))
 
 (def
- ^{:arglists '([coll])
-   :tag clojure.lang.ISeq
-   :doc "Returns a seq of the items after the first. Calls seq on its
-  argument.  If there are no more items, returns nil."
-   :added "1.0"
-   :static true}  
- next (fn ^:static next [x] (. clojure.lang.RT (next x))))
+  ^{:arglists '([coll])
+    :tag      clojure.lang.ISeq
+    :doc      "Returns a seq of the items after the first. Calls seq on its argument.  If there are no more items, returns nil."
+    :added    "1.0"
+    :static   true}
+  next
+  (fn ^:static next [x]
+    (clojure.lang.RT/next x)))
 
 (def
- ^{:arglists '([coll])
-   :tag clojure.lang.ISeq
-   :doc "Returns a possibly empty seq of the items after the first. Calls seq on its
-  argument."
-   :added "1.0"
-   :static true}  
- rest (fn ^:static rest [x] (. clojure.lang.RT (more x))))
+  ^{:arglists '([coll])
+    :tag      clojure.lang.ISeq
+    :doc      "Returns a possibly empty seq of the items after the first. Calls seq on its argument."
+    :added    "1.0"
+    :static   true}
+  rest
+  (fn ^:static rest [x]
+    (clojure.lang.RT/more x)))
 
 (def
- ^{:arglists '([coll x] [coll x & xs])
-   :doc "conj[oin]. Returns a new collection with the xs
-    'added'. (conj nil item) returns (item).  The 'addition' may
-    happen at different 'places' depending on the concrete type."
-   :added "1.0"
-   :static true}
- conj (fn ^:static conj
-        ([] [])
-        ([coll] coll)
-        ([coll x] (clojure.lang.RT/conj coll x))
-        ([coll x & xs]
-         (if xs
-           (recur (clojure.lang.RT/conj coll x) (first xs) (next xs))
-           (clojure.lang.RT/conj coll x)))))
+  ^{:arglists '([coll x] [coll x & xs])
+    :doc      "conj[oin]. Returns a new collection with the xs 'added'. (conj nil item) returns (item).  The 'addition' may happen at different 'places' depending on the concrete type."
+    :added    "1.0"
+    :static   true}
+  conj
+  (fn ^:static conj
+    ([] [])
+    ([coll] coll)
+    ([coll x]
+     (clojure.lang.RT/conj coll x))
+    ([coll x & xs]
+     (if xs
+       (recur (clojure.lang.RT/conj coll x) (first xs) (next xs))
+       (clojure.lang.RT/conj coll x)))))
 
 (def
- ^{:doc "Same as (first (next x))"
-   :arglists '([x])
-   :added "1.0"
-   :static true}
- second (fn ^:static second [x] (first (next x))))
+  ^{:doc      "Same as (first (next x))"
+    :arglists '([x])
+    :added    "1.0"
+    :static   true}
+  second
+  (fn ^:static second [x]
+    (first (next x))))
 
 (def
- ^{:doc "Same as (first (first x))"
-   :arglists '([x])
-   :added "1.0"
-   :static true}
- ffirst (fn ^:static ffirst [x] (first (first x))))
+  ^{:doc      "Same as (first (first x))"
+    :arglists '([x])
+    :added    "1.0"
+    :static   true}
+  ffirst
+  (fn ^:static ffirst [x]
+    (first (first x))))
 
 (def
- ^{:doc "Same as (next (first x))"
-   :arglists '([x])
-   :added "1.0"
-   :static true}
- nfirst (fn ^:static nfirst [x] (next (first x))))
+  ^{:doc "Same as (next (first x))"
+    :arglists '([x])
+    :added "1.0"
+    :static true}
+  nfirst
+  (fn ^:static nfirst [x]
+    (next (first x))))
 
 (def
- ^{:doc "Same as (first (next x))"
-   :arglists '([x])
-   :added "1.0"
-   :static true}
- fnext (fn ^:static fnext [x] (first (next x))))
+  ^{:doc      "Same as (first (next x))"
+    :arglists '([x])
+    :added    "1.0"
+    :static   true}
+  fnext
+  (fn ^:static fnext [x]
+    (first (next x))))
 
 (def
- ^{:doc "Same as (next (next x))"
-   :arglists '([x])
-   :added "1.0"
-   :static true}
- nnext (fn ^:static nnext [x] (next (next x))))
+  ^{:doc "Same as (next (next x))"
+    :arglists '([x])
+    :added "1.0"
+    :static true}
+  nnext
+  (fn ^:static nnext [x]
+    (next (next x))))
 
 (def
- ^{:arglists '(^clojure.lang.ISeq [coll])
-   :doc "Returns a seq on the collection. If the collection is
-    empty, returns nil.  (seq nil) returns nil. seq also works on
-    Strings, native Java arrays (of reference types) and any objects
-    that implement Iterable. Note that seqs cache values, thus seq
-    should not be used on any Iterable whose iterator repeatedly
-    returns the same mutable object."
-   :tag clojure.lang.ISeq
-   :added "1.0"
-   :static true}
- seq (fn ^:static seq ^clojure.lang.ISeq [coll] (. clojure.lang.RT (seq coll))))
+  ^{:arglists '(^clojure.lang.ISeq [coll])
+    :doc      "Returns a seq on the collection. If the collection is empty, returns nil.  (seq nil) returns nil. seq also works on Strings, native Java arrays (of reference types) and any objects that implement Iterable. Note that seqs cache values, thus seq should not be used on any Iterable whose iterator repeatedly returns the same mutable object."
+    :tag      clojure.lang.ISeq
+    :added    "1.0"
+    :static   true}
+  seq
+  (fn ^:static seq
+    ^clojure.lang.ISeq [coll]
+    (. clojure.lang.RT (seq coll))))
 
 (def
- ^{:arglists '([^Class c x])
-   :doc "Evaluates x and tests if it is an instance of the class
-    c. Returns true or false"
-   :added "1.0"}
- instance? (fn instance? [^Class c x] (. c (isInstance x))))
+  ^{:arglists '([^Class c x])
+    :doc      "Evaluates x and tests if it is an instance of the class c. Returns true or false"
+    :added    "1.0"}
+  instance?
+  (fn instance? [^Class c x]
+    (. c (isInstance x))))
 
 (def
- ^{:arglists '([x])
-   :doc "Return true if x implements ISeq"
-   :added "1.0"
-   :static true}
- seq? (fn ^:static seq? [x] (instance? clojure.lang.ISeq x)))
+  ^{:arglists '([x])
+    :doc      "Return true if x implements ISeq"
+    :added    "1.0"
+    :static   true}
+  seq?
+  (fn ^:static seq? [x]
+    (instance? clojure.lang.ISeq x)))
 
 (def
- ^{:arglists '([x])
-   :doc "Return true if x is a Character"
-   :added "1.0"
-   :static true}
- char? (fn ^:static char? [x] (instance? Character x)))
+  ^{:arglists '([x])
+    :doc      "Return true if x is a Character"
+    :added    "1.0"
+    :static   true}
+  char?
+  (fn ^:static char? [x]
+    (instance? Character x)))
 
 (def
- ^{:arglists '([x])
-   :doc "Return true if x is a String"
-   :added "1.0"
-   :static true}
- string? (fn ^:static string? [x] (instance? String x)))
+  ^{:arglists '([x])
+    :doc      "Return true if x is a String"
+    :added    "1.0"
+    :static   true}
+  string?
+  (fn ^:static string? [x]
+    (instance? String x)))
 
 (def
- ^{:arglists '([x])
-   :doc "Return true if x implements IPersistentMap"
-   :added "1.0"
-   :static true}
- map? (fn ^:static map? [x] (instance? clojure.lang.IPersistentMap x)))
+  ^{:arglists '([x])
+    :doc      "Return true if x implements IPersistentMap"
+    :added    "1.0"
+    :static   true}
+  map?
+  (fn ^:static map? [x]
+    (instance? clojure.lang.IPersistentMap x)))
 
 (def
- ^{:arglists '([x])
-   :doc "Return true if x implements IPersistentVector"
-   :added "1.0"
-   :static true}
- vector? (fn ^:static vector? [x] (instance? clojure.lang.IPersistentVector x)))
+  ^{:arglists '([x])
+    :doc      "Return true if x implements IPersistentVector"
+    :added    "1.0"
+    :static   true}
+  vector?
+  (fn ^:static vector? [x]
+    (instance? clojure.lang.IPersistentVector x)))
 
 (def
- ^{:arglists '([x])
-   :doc "Return true if x is a Var"
-   :added "1.0"
-   :static true}
-  var? (fn ^:static var? [x] (instance? clojure.lang.Var x)))
+  ^{:arglists '([x])
+    :doc      "Return true if x is a Var"
+    :added    "1.0"
+    :static   true}
+  var?
+  (fn ^:static var? [x]
+    (instance? clojure.lang.Var x)))
 
 (def
- ^{:arglists '([map key val] [map key val & kvs])
-   :doc "assoc[iate]. When applied to a map, returns a new map of the
-    same (hashed/sorted) type, that contains the mapping of key(s) to
-    val(s). When applied to a vector, returns a new vector that
-    contains val at index. Note - index must be <= (count vector)."
-   :added "1.0"
-   :static true}
- assoc
- (fn ^:static assoc
-   ([map key val] (clojure.lang.RT/assoc map key val))
-   ([map key val & kvs]
-    (let [ret (clojure.lang.RT/assoc map key val)]
-      (if kvs
-        (if (next kvs)
-          (recur ret (first kvs) (second kvs) (nnext kvs))
-          (throw (IllegalArgumentException.
-                  "assoc expects even number of arguments after map/vector, found odd number")))
-        ret)))))
+  ^{:arglists '([map key val] [map key val & kvs])
+    :doc      "assoc[iate]. When applied to a map, returns a new map of the same (hashed/sorted) type, that contains the mapping of key(s) to val(s). When applied to a vector, returns a new vector that contains val at index. Note - index must be <= (count vector)."
+    :added    "1.0"
+    :static   true}
+  assoc
+  (fn ^:static assoc
+    ([map key val]
+     (clojure.lang.RT/assoc map key val))
+    ([map key val & kvs]
+     (let [ret (clojure.lang.RT/assoc map key val)]
+       (if kvs
+         (if (next kvs)
+           (recur ret (first kvs) (second kvs) (nnext kvs))
+           (throw (IllegalArgumentException.
+                   "assoc expects even number of arguments after map/vector, found odd number")))
+         ret)))))
 
 ;;;;;;;;;;;;;;;;; metadata ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (def
@@ -218,8 +246,7 @@
 
 (def
   ^{:arglists '([^clojure.lang.IObj obj m])
-    :doc      "Returns an object of the same type and value as obj, with
-    map m as its metadata."
+    :doc      "Returns an object of the same type and value as obj, with map m as its metadata."
     :added    "1.0"
     :static   true}
   with-meta
@@ -227,45 +254,52 @@
     (. x (withMeta m))))
 
 (def
-  ^{:doc   "Checks to see if the supplied object is marked deprecated."
-    :added "1.9"}
+  ^{:arglists '([obj])
+    :doc      "Checks to see if the supplied object is marked deprecated."
+    :added    "1.9"
+    :static   true}
   deprecated?
-  (fn [o]
+  (fn ^:static deprecated? [o]
     (let [d' (clojure.lang.RT/booleanCast (:deprecated (meta o)))]
       (if d' d'
           (if (var? o)
             (deprecated? (.ns ^clojure.lang.Var o)))))))
 
 (def
-  ^{:doc   "Checks to see if the supplied object is marked private."
-    :added "1.9"}
+  ^{:arglists '([obj])
+    :doc      "Checks to see if the supplied object is marked private."
+    :added    "1.9"
+    :static   true}
   private?
-  (fn [o]
+  (fn ^:static private? [o]
     (clojure.lang.RT/booleanCast (:private (meta o)))))
 
-(def ^{:private true :dynamic true}
-  assert-valid-fdecl (fn [fdecl]))
+(def
+  ^{:private true
+    :dynamic true}
+  assert-valid-fdecl
+  (fn [fdecl]))
 
 (def
- ^{:private true}
- sigs
- (fn [fdecl]
-   (assert-valid-fdecl fdecl)
-   (let [asig 
-         (fn [fdecl]
-           (let [arglist (first fdecl)
-                 ;elide implicit macro args
-                 arglist (if (clojure.lang.Util/equals '&form (first arglist)) 
-                           (clojure.lang.RT/subvec arglist 2 (clojure.lang.RT/count arglist))
-                           arglist)
-                 body (next fdecl)]
-             (if (map? (first body))
-               (if (next body)
-                 (with-meta arglist (conj (if (meta arglist) (meta arglist) {}) (first body)))
-                 arglist)
-               arglist)))
-         resolve-tag (fn [argvec]
-                        (let [m (meta argvec)
+  ^{:private true}
+  sigs
+  (fn [fdecl]
+    (assert-valid-fdecl fdecl)
+    (let [asig
+          (fn [fdecl]
+            (let [arglist (first fdecl)
+                  ;; elide implicit macro args
+                  arglist (if (clojure.lang.Util/equals '&form (first arglist))
+                            (clojure.lang.RT/subvec arglist 2 (clojure.lang.RT/count arglist))
+                            arglist)
+                  body    (next fdecl)]
+              (if (map? (first body))
+                (if (next body)
+                  (with-meta arglist (conj (if (meta arglist) (meta arglist) {}) (first body)))
+                  arglist)
+                arglist)))
+          resolve-tag (fn [argvec]
+                        (let [m                        (meta argvec)
                               ^clojure.lang.Symbol tag (:tag m)]
                           (if (instance? clojure.lang.Symbol tag)
                             (if (clojure.lang.Util/equiv (.indexOf (.getName tag) ".") -1)
@@ -277,74 +311,72 @@
                                 argvec)
                               argvec)
                             argvec)))]
-     (if (seq? (first fdecl))
-       (loop [ret [] fdecls fdecl]
-         (if fdecls
-           (recur (conj ret (resolve-tag (asig (first fdecls)))) (next fdecls))
-           (seq ret)))
-       (list (resolve-tag (asig fdecl)))))))
+      (if (seq? (first fdecl))
+        (loop [ret [] fdecls fdecl]
+          (if fdecls
+            (recur (conj ret (resolve-tag (asig (first fdecls)))) (next fdecls))
+            (seq ret)))
+        (list (resolve-tag (asig fdecl)))))))
 
+(def
+  ^{:arglists '([coll])
+    :doc      "Return the last item in coll, in linear time"
+    :added    "1.0"
+    :static   true}
+  last
+  (fn ^:static last [s]
+    (if (next s)
+      (recur (next s))
+      (first s))))
 
-(def 
- ^{:arglists '([coll])
-   :doc "Return the last item in coll, in linear time"
-   :added "1.0"
-   :static true}
- last (fn ^:static last [s]
-        (if (next s)
-          (recur (next s))
-          (first s))))
+(def
+  ^{:arglists '([coll])
+    :doc      "Return a seq of all but the last item in coll, in linear time"
+    :added    "1.0"
+    :static   true}
+  butlast
+  (fn ^:static butlast [s]
+    (loop [ret [] s s]
+      (if (next s)
+        (recur (conj ret (first s)) (next s))
+        (seq ret)))))
 
-(def 
- ^{:arglists '([coll])
-   :doc "Return a seq of all but the last item in coll, in linear time"
-   :added "1.0"
-   :static true}
- butlast (fn ^:static butlast [s]
-           (loop [ret [] s s]
-             (if (next s)
-               (recur (conj ret (first s)) (next s))
-               (seq ret)))))
-
-(def 
-
- ^{:doc "Same as (def name (fn [params* ] exprs*)) or (def
-    name (fn ([params* ] exprs*)+)) with any doc-string or attrs added
-    to the var metadata. prepost-map defines a map with optional keys
-    :pre and :post that contain collections of pre or post conditions."
-   :arglists '([name doc-string? attr-map? [params*] prepost-map? body]
-                [name doc-string? attr-map? ([params*] prepost-map? body)+ attr-map?])
-   :added "1.0"}
- defn (fn defn [&form &env name & fdecl]
-        ;; Note: Cannot delegate this check to def because of the call to (with-meta name ..)
-        (if (instance? clojure.lang.Symbol name)
-          nil
-          (throw (IllegalArgumentException. "First argument to defn must be a symbol")))
-        (let [m (if (string? (first fdecl))
+(def
+  ^{:doc      "Same as (def name (fn [params* ] exprs*)) or (def name (fn ([params* ] exprs*)+)) with any doc-string or attrs added to the var metadata. prepost-map defines a map with optional keys :pre and :post that contain collections of pre or post conditions."
+    :arglists '([name doc-string? attr-map? [params*] prepost-map? body]
+                [name doc-string? attr-map? ([params*] prepost-map? body) + attr-map?])
+    :added    "1.0"}
+  defn
+  (fn defn [&form &env name & fdecl]
+    ;; Note: Cannot delegate this check to def because of the call to (with-meta name ..)
+    (if (instance? clojure.lang.Symbol name)
+      nil
+      (throw (IllegalArgumentException. "First argument to defn must be a symbol")))
+    (let [m     (if (string? (first fdecl))
                   {:doc (first fdecl)}
                   {})
-              fdecl (if (string? (first fdecl))
-                      (next fdecl)
-                      fdecl)
-              m (if (map? (first fdecl))
+          fdecl (if (string? (first fdecl))
+                  (next fdecl)
+                  fdecl)
+          m     (if (map? (first fdecl))
                   (conj m (first fdecl))
                   m)
-              fdecl (if (map? (first fdecl))
-                      (next fdecl)
-                      fdecl)
-              fdecl (if (vector? (first fdecl))
-                      (list fdecl)
-                      fdecl)
-              m (if (map? (last fdecl))
+          fdecl (if (map? (first fdecl))
+                  (next fdecl)
+                  fdecl)
+          fdecl (if (vector? (first fdecl))
+                  (list fdecl)
+                  fdecl)
+          m     (if (map? (last fdecl))
                   (conj m (last fdecl))
                   m)
-              fdecl (if (map? (last fdecl))
-                      (butlast fdecl)
-                      fdecl)
-              m (conj {:arglists (list 'quote (sigs fdecl))} m)
-              m (let [inline (:inline m)
-                      ifn (first inline)
-                      iname (second inline)]
+          fdecl (if (map? (last fdecl))
+                  (butlast fdecl)
+                  fdecl)
+          m     (conj {:arglists (list 'quote (sigs fdecl))} m)
+          m     (let [inline (:inline m)
+                      ifn    (first inline)
+                      iname  (second inline)]
                   ;; same as: (if (and (= 'fn ifn) (not (symbol? iname))) ...)
                   (if (if (clojure.lang.Util/equiv 'fn ifn)
                         (if (instance? clojure.lang.Symbol iname) false true))
@@ -352,48 +384,49 @@
                     (assoc m :inline (cons ifn (cons (clojure.lang.Symbol/intern (.concat (.getName ^clojure.lang.Symbol name) "__inliner"))
                                                      (next inline))))
                     m))
-              m (conj (if (meta name) (meta name) {}) m)]
-          (list 'def (with-meta name m)
-                ;;todo - restore propagation of fn name
-                ;;must figure out how to convey primitive hints to self calls first
-								;;(cons `fn fdecl)
-								(with-meta (cons `fn fdecl) {:rettag (:tag m)})))))
+          m     (conj (if (meta name) (meta name) {}) m)]
+      (list 'def (with-meta name m)
+            ;;todo - restore propagation of fn name
+            ;;must figure out how to convey primitive hints to self calls first
+            ;;(cons `fn fdecl)
+            (with-meta (cons `fn fdecl) {:rettag (:tag m)})))))
 
 (. (var defn) (setMacro))
 
 (defn to-array
   "Returns an array of Objects containing the contents of coll, which
   can be any Collection.  Maps to java.util.Collection.toArray()."
-  {:tag "[Ljava.lang.Object;"
-   :added "1.0"
+  {:tag    "[Ljava.lang.Object;"
+   :added  "1.0"
    :static true}
-  [coll] (. clojure.lang.RT (toArray coll)))
+  [coll]
+  (clojure.lang.RT/toArray coll))
 
 (defn cast
   "Throws a ClassCastException if x is not a c, else returns x."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
-  [^Class c x] 
+  [^Class c x]
   (. c (cast x)))
- 
+
 (defn vector
   "Creates a new vector containing the args."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
   ([] [])
   ([a] [a])
   ([a b] [a b])
   ([a b c] [a b c])
   ([a b c d] [a b c d])
-	([a b c d e] [a b c d e])
-	([a b c d e f] [a b c d e f])
+  ([a b c d e] [a b c d e])
+  ([a b c d e f] [a b c d e f])
   ([a b c d e f & args]
-     (. clojure.lang.LazilyPersistentVector (create (cons a (cons b (cons c (cons d (cons e (cons f args))))))))))
+   (. clojure.lang.LazilyPersistentVector (create (cons a (cons b (cons c (cons d (cons e (cons f args))))))))))
 
 (defn vec
   "Creates a new vector containing the contents of coll. Java arrays
   will be aliased and should not be modified."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
   ([coll]
    (if (vector? coll)
@@ -406,16 +439,16 @@
   "keyval => key val
   Returns a new hash map with supplied mappings.  If any keys are
   equal, they are handled as if by repeated uses of assoc."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
   ([] {})
   ([& keyvals]
-   (. clojure.lang.PersistentHashMap (create keyvals))))
+   (clojure.lang.PersistentHashMap/create keyvals)))
 
 (defn hash-set
   "Returns a new hash set with supplied keys.  Any equal keys are
   handled as if by repeated uses of conj."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
   ([] #{})
   ([& keys]
@@ -425,8 +458,10 @@
   "keyval => key val
   Returns a new sorted map with supplied mappings.  If any keys are
   equal, they are handled as if by repeated uses of assoc."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
+  ([]
+   clojure.lang.PersistentTreeMap/EMPTY)
   ([& keyvals]
    (clojure.lang.PersistentTreeMap/create keyvals)))
 
@@ -435,16 +470,18 @@
   Returns a new sorted map with supplied mappings, using the supplied
   comparator.  If any keys are equal, they are handled as if by
   repeated uses of assoc."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
-  ([comparator & keyvals]
-   (clojure.lang.PersistentTreeMap/create comparator keyvals)))
+  [comparator & keyvals]
+  (clojure.lang.PersistentTreeMap/create comparator keyvals))
 
 (defn sorted-set
   "Returns a new sorted set with supplied keys.  Any equal keys are
   handled as if by repeated uses of conj."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
+  ([]
+   clojure.lang.PersistentTreeSet/EMPTY)
   ([& keys]
    (clojure.lang.PersistentTreeSet/create keys)))
 
@@ -452,67 +489,67 @@
   "Returns a new sorted set with supplied keys, using the supplied
   comparator.  Any equal keys are handled as if by repeated uses of
   conj."
-  {:added "1.1"
-   :static true} 
-  ([comparator & keys]
-   (clojure.lang.PersistentTreeSet/create comparator keys)))
+  {:added  "1.1"
+   :static true}
+  [comparator & keys]
+  (clojure.lang.PersistentTreeSet/create comparator keys))
 
- 
-;;;;;;;;;;;;;;;;;;;;
 (defn nil?
   "Returns true if x is nil, false otherwise."
-  {:tag Boolean
-   :added "1.0"
+  {:tag    Boolean
+   :added  "1.0"
    :static true
    :inline (fn [x] (list 'clojure.lang.Util/identical x nil))}
-  [x] (clojure.lang.Util/identical x nil))
+  [x]
+  (clojure.lang.Util/identical x nil))
+
+(def ^:private add-implicit-args
+  (fn [fd]
+    (let [args (first fd)]
+      (cons (vec (cons '&form (cons '&env args))) (next fd)))))
+
+(def ^:private add-args
+  (fn [acc ds]
+    (if (nil? ds)
+      acc
+      (let [d (first ds)]
+        (if (map? d)
+          (conj acc d)
+          (recur (conj acc (add-implicit-args d)) (next ds)))))))
 
 (def
-
- ^{:doc "Like defn, but the resulting function name is declared as a
-  macro and will be used as a macro by the compiler when it is
-  called."
-   :arglists '([name doc-string? attr-map? [params*] body]
-                 [name doc-string? attr-map? ([params*] body)+ attr-map?])
-   :added "1.0"}
- defmacro (fn [&form &env 
-                name & args]
-             (let [prefix (loop [p (list name) args args]
-                            (let [f (first args)]
-                              (if (string? f)
-                                (recur (cons f p) (next args))
-                                (if (map? f)
-                                  (recur (cons f p) (next args))
-                                  p))))
-                   fdecl (loop [fd args]
-                           (if (string? (first fd))
-                             (recur (next fd))
-                             (if (map? (first fd))
-                               (recur (next fd))
-                               fd)))
-                   fdecl (if (vector? (first fdecl))
-                           (list fdecl)
-                           fdecl)
-                   add-implicit-args (fn [fd]
-                             (let [args (first fd)]
-                               (cons (vec (cons '&form (cons '&env args))) (next fd))))
-                   add-args (fn [acc ds]
-                              (if (nil? ds)
-                                acc
-                                (let [d (first ds)]
-                                  (if (map? d)
-                                    (conj acc d)
-                                    (recur (conj acc (add-implicit-args d)) (next ds))))))
-                   fdecl (seq (add-args [] fdecl))
-                   decl (loop [p prefix d fdecl]
-                          (if p
-                            (recur (next p) (cons (first p) d))
-                            d))]
-               (list 'do
-                     (cons `defn decl)
-                     (list '. (list 'var name) '(setMacro))
-                     (list 'var name)))))
-
+  ^{:doc      "Like defn, but the resulting function name is declared as a macro and will be used as a macro by the compiler when it is called."
+    :arglists '([name doc-string? attr-map? [params*] body]
+                [name doc-string? attr-map? ([params*] body) + attr-map?])
+    :added    "1.0"}
+  defmacro
+  (fn [&form &env
+       name & args]
+    (let [prefix (loop [p (list name) args args]
+                   (let [f (first args)]
+                     (if (string? f)
+                       (recur (cons f p) (next args))
+                       (if (map? f)
+                         (recur (cons f p) (next args))
+                         p))))
+          fdecl  (loop [fd args]
+                   (if (string? (first fd))
+                     (recur (next fd))
+                     (if (map? (first fd))
+                       (recur (next fd))
+                       fd)))
+          fdecl  (if (vector? (first fdecl))
+                   (list fdecl)
+                   fdecl) 
+          fdecl  (seq (add-args [] fdecl))
+          decl   (loop [p prefix d fdecl]
+                   (if p
+                     (recur (next p) (cons (first p) d))
+                     d))]
+      (list 'do
+            (cons `defn decl)
+            (list '. (list 'var name) '(setMacro))
+            (list 'var name)))))
 
 (. (var defmacro) (setMacro))
 
@@ -526,73 +563,92 @@
   "Evaluates test. If logical false, evaluates body in an implicit do."
   {:added "1.0"}
   [test & body]
-    (list 'if test nil (cons 'do body)))
+  (list 'if test nil (cons 'do body)))
 
 (defn false?
   "Returns true if x is the value false, false otherwise."
-  {:tag Boolean,
-   :added "1.0"
-   :static true}
-  [x] (clojure.lang.Util/identical x false))
+  {:tag            Boolean
+   :added          "1.0"
+   :inline-arities #{1}
+   :inline         (fn [xe] (list 'clojure.lang.Util/identical xe false))
+   :static         true}
+  [x]
+  (clojure.lang.Util/identical x false))
 
 (defn true?
   "Returns true if x is the value true, false otherwise."
-  {:tag Boolean,
-   :added "1.0"
-   :static true}
-  [x] (clojure.lang.Util/identical x true))
+  {:tag            Boolean
+   :added          "1.0"
+   :inline-arities #{1}
+   :inline         (fn [xe] (list 'clojure.lang.Util/identical xe true))
+   :static         true}
+  [x]
+  (clojure.lang.Util/identical x true))
 
 (defn not
   "Returns true if x is logical false, false otherwise."
-  {:tag Boolean
-   :added "1.0"
-   :static true}
-  [x] (if x false true))
+  {:tag            Boolean
+   :added          "1.0"
+   :inline-arities #{1}
+   :inline         (fn [xe] (list 'if xe false true))
+   :static         true}
+  [x]
+  (if x false true))
 
 (defn some?
   "Returns true if x is not nil, false otherwise."
-  {:tag Boolean
-   :added "1.6"
-   :static true}
-  [x] (not (nil? x)))
+  {:tag            Boolean
+   :added          "1.6"
+   :inline-arities #{1}
+   :inline         (fn [xe]
+                     (list 'clojure.core/not
+                           (list 'clojure.core/nil? xe)))
+   :static         true}
+  [x]
+  (not (nil? x)))
 
 (defn str
   "With no args, returns the empty string. With one arg x, returns
   x.toString().  (str nil) returns the empty string. With more than
   one arg, returns the concatenation of the str values of the args."
-  {:tag String
-   :added "1.0"
+  {:tag    String
+   :added  "1.0"
    :static true}
   (^String [] "")
   (^String [^Object x]
    (if (nil? x) "" (. x (toString))))
   (^String [x & ys]
-     ((fn [^StringBuilder sb more]
-          (if more
-            (recur (. sb  (append (str (first more)))) (next more))
-            (str sb)))
-      (new StringBuilder (str x)) ys)))
-
+   ((fn [^StringBuilder sb more]
+      (if more
+        (recur (. sb  (append (str (first more)))) (next more))
+        (str sb)))
+    (new StringBuilder (str x)) ys)))
 
 (defn symbol?
   "Return true if x is a Symbol"
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
-  [x] (instance? clojure.lang.Symbol x))
+  [x]
+  (instance? clojure.lang.Symbol x))
 
 (defn keyword?
   "Return true if x is a Keyword"
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
-  [x] (instance? clojure.lang.Keyword x))
+  [x]
+  (instance? clojure.lang.Keyword x))
 
 (defn symbol
   "Returns a Symbol with the given namespace and name."
-  {:tag clojure.lang.Symbol
-   :added "1.0"
+  {:tag    clojure.lang.Symbol
+   :added  "1.0"
    :static true}
-  ([name] (if (symbol? name) name (clojure.lang.Symbol/intern name)))
-  ([ns name] (clojure.lang.Symbol/intern ns name)))
+  ([name]
+   (if (symbol? name)
+     name
+     (clojure.lang.Symbol/intern name)))
+  ([ns name]
+   (clojure.lang.Symbol/intern ns name)))
 
 (defn gensym
   "Returns a new symbol with a unique name. If a prefix string is
@@ -601,7 +657,9 @@
   {:added "1.0"
    :static true}
   ([] (gensym "G__"))
-  ([prefix-string] (. clojure.lang.Symbol (intern (str prefix-string (str (. clojure.lang.RT (nextID))))))))
+  ([prefix-string]
+   (clojure.lang.Symbol/intern
+    (str prefix-string (clojure.lang.RT/nextID)))))
 
 (defmacro cond
   "Takes a set of test/expr pairs. It evaluates each test one at a
@@ -610,47 +668,52 @@
   other tests or exprs. (cond) returns nil."
   {:added "1.0"}
   [& clauses]
-    (when clauses
-      (list 'if (first clauses)
-            (if (next clauses)
-                (second clauses)
-                (throw (IllegalArgumentException.
-                         "cond requires an even number of forms")))
-            (cons 'clojure.core/cond (next (next clauses))))))
+  (when clauses
+    (list 'if (first clauses)
+          (if (next clauses)
+            (second clauses)
+            (throw (IllegalArgumentException.
+                    "cond requires an even number of forms")))
+          (cons 'clojure.core/cond (next (next clauses))))))
 
 (defn keyword
   "Returns a Keyword with the given namespace and name.  Do not use :
   in the keyword strings, it will be added automatically."
-  {:tag clojure.lang.Keyword
-   :added "1.0"
+  {:tag    clojure.lang.Keyword
+   :added  "1.0"
    :static true}
-  ([name] (cond (keyword? name) name
-                (symbol? name) (clojure.lang.Keyword/intern ^clojure.lang.Symbol name)
-                (string? name) (clojure.lang.Keyword/intern ^String name)))
-  ([ns name] (clojure.lang.Keyword/intern ns name)))
+  ([name]
+   (cond
+     (keyword? name) name
+     (symbol? name)  (clojure.lang.Keyword/intern ^clojure.lang.Symbol name)
+     (string? name)  (clojure.lang.Keyword/intern ^String name)))
+  ([ns name]
+   (clojure.lang.Keyword/intern ns name)))
 
 (defn find-keyword
   "Returns a Keyword with the given namespace and name if one already
   exists.  This function will not intern a new keyword. If the keyword
   has not already been interned, it will return nil.  Do not use :
   in the keyword strings, it will be added automatically."
-  {:tag clojure.lang.Keyword
-   :added "1.3"
+  {:tag    clojure.lang.Keyword
+   :added  "1.3"
    :static true}
-  ([name] (cond (keyword? name) name
-                (symbol? name) (clojure.lang.Keyword/find ^clojure.lang.Symbol name)
-                (string? name) (clojure.lang.Keyword/find ^String name)))
-  ([ns name] (clojure.lang.Keyword/find ns name)))
-
+  ([name]
+   (cond
+     (keyword? name) name
+     (symbol? name)  (clojure.lang.Keyword/find ^clojure.lang.Symbol name)
+     (string? name)  (clojure.lang.Keyword/find ^String name)))
+  ([ns name]
+   (clojure.lang.Keyword/find ns name)))
 
 (defn spread
   {:private true
-   :static true}
+   :static  true}
   [arglist]
   (cond
-   (nil? arglist) nil
-   (nil? (next arglist)) (seq (first arglist))
-   :else (cons (first arglist) (spread (next arglist)))))
+    (nil? arglist)        nil
+    (nil? (next arglist)) (seq (first arglist))
+    :else                 (cons (first arglist) (spread (next arglist)))))
 
 (defn list*
   "Creates a new seq containing the items prepended to the rest, the
@@ -662,29 +725,29 @@
   ([a b args] (cons a (cons b args)))
   ([a b c args] (cons a (cons b (cons c args))))
   ([a b c d & more]
-     (cons a (cons b (cons c (cons d (spread more)))))))
+   (cons a (cons b (cons c (cons d (spread more)))))))
 
 (defn apply
   "Applies fn f to the argument list formed by prepending intervening arguments to args."
   {:added "1.0"
    :static true}
   ([^clojure.lang.IFn f args]
-     (. f (applyTo (seq args))))
+   (. f (applyTo (seq args))))
   ([^clojure.lang.IFn f x args]
-     (. f (applyTo (list* x args))))
+   (. f (applyTo (list* x args))))
   ([^clojure.lang.IFn f x y args]
-     (. f (applyTo (list* x y args))))
+   (. f (applyTo (list* x y args))))
   ([^clojure.lang.IFn f x y z args]
-     (. f (applyTo (list* x y z args))))
+   (. f (applyTo (list* x y z args))))
   ([^clojure.lang.IFn f a b c d & args]
-     (. f (applyTo (cons a (cons b (cons c (cons d (spread args)))))))))
+   (. f (applyTo (cons a (cons b (cons c (cons d (spread args)))))))))
 
 (defn vary-meta
- "Returns an object of the same type and value as obj, with
+  "Returns an object of the same type and value as obj, with
   (apply f (meta obj) args) as its metadata."
- {:added "1.0"
+  {:added "1.0"
    :static true}
- [obj f & args]
+  [obj f & args]
   (with-meta obj (apply f (meta obj) args)))
 
 (defmacro lazy-seq
@@ -694,7 +757,7 @@
   seq calls. See also - realized?"
   {:added "1.0"}
   [& body]
-  (list 'new 'clojure.lang.LazySeq (list* '^{:once true} fn* [] body)))    
+  (list 'new 'clojure.lang.LazySeq (list* '^{:once true} fn* [] body)))
 
 (defn ^:static ^clojure.lang.ChunkBuffer chunk-buffer ^clojure.lang.ChunkBuffer [capacity]
   (clojure.lang.ChunkBuffer. capacity))
@@ -718,7 +781,7 @@
   (if (clojure.lang.Numbers/isZero (clojure.lang.RT/count chunk))
     rest
     (clojure.lang.ChunkedCons. chunk rest)))
-  
+
 (defn ^:static chunked-seq? [s]
   (instance? clojure.lang.IChunkedSeq s))
 
@@ -729,25 +792,25 @@
   ([] (lazy-seq nil))
   ([x] (lazy-seq x))
   ([x y]
-    (lazy-seq
-      (let [s (seq x)]
-        (if s
-          (if (chunked-seq? s)
-            (chunk-cons (chunk-first s) (concat (chunk-rest s) y))
-            (cons (first s) (concat (rest s) y)))
-          y))))
+   (lazy-seq
+    (let [s (seq x)]
+      (if s
+        (if (chunked-seq? s)
+          (chunk-cons (chunk-first s) (concat (chunk-rest s) y))
+          (cons (first s) (concat (rest s) y)))
+        y))))
   ([x y & zs]
-     (let [cat (fn cat [xys zs]
-                 (lazy-seq
-                   (let [xys (seq xys)]
-                     (if xys
-                       (if (chunked-seq? xys)
-                         (chunk-cons (chunk-first xys)
-                                     (cat (chunk-rest xys) zs))
-                         (cons (first xys) (cat (rest xys) zs)))
-                       (when zs
-                         (cat (first zs) (next zs)))))))]
-       (cat (concat x y) zs))))
+   (let [cat (fn cat [xys zs]
+               (lazy-seq
+                (let [xys (seq xys)]
+                  (if xys
+                    (if (chunked-seq? xys)
+                      (chunk-cons (chunk-first xys)
+                                  (cat (chunk-rest xys) zs))
+                      (cons (first xys) (cat (rest xys) zs)))
+                    (when zs
+                      (cat (first zs) (next zs)))))))]
+     (cat (concat x y) zs))))
 
 ;;;;;;;;;;;;;;;;at this point all the support for syntax-quote exists;;;;;;;;;;;;;;;;;;;;;;
 (defmacro delay
@@ -757,47 +820,52 @@
   calls. See also - realized?"
   {:added "1.0"}
   [& body]
-    (list 'new 'clojure.lang.Delay (list* `^{:once true} fn* [] body)))
+  (list 'new 'clojure.lang.Delay (list* `^{:once true} fn* [] body)))
 
 (defn delay?
   "returns true if x is a Delay created with delay"
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
-  [x] (instance? clojure.lang.Delay x))
+  [x]
+  (instance? clojure.lang.Delay x))
 
 (defn force
   "If x is a Delay, returns the (possibly cached) value of its expression, else returns x"
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
-  [x] (. clojure.lang.Delay (force x)))
+  [x]
+  (. clojure.lang.Delay (force x)))
 
 (defmacro if-not
-  "Evaluates test. If logical false, evaluates and returns then expr, 
+  "Evaluates test. If logical false, evaluates and returns then expr,
   otherwise else expr, if supplied, else nil."
   {:added "1.0"}
-  ([test then] `(if-not ~test ~then nil))
+  ([test then]
+   `(if-not ~test ~then nil))
   ([test then else]
    `(if (not ~test) ~then ~else)))
 
 (defn identical?
   "Tests if 2 arguments are the same object"
-  {:inline (fn [x y] `(. clojure.lang.Util identical ~x ~y))
+  {:inline         (fn [x y] `(. clojure.lang.Util identical ~x ~y))
    :inline-arities #{2}
-   :added "1.0"}
-  ([x y] (clojure.lang.Util/identical x y)))
+   :added          "1.0"}
+  [x y]
+  (clojure.lang.Util/identical x y))
 
-;equiv-based
+;; equiv-based
 (defn =
   "Equality. Returns true if x equals y, false if not. Same as
   Java x.equals(y) except it also works for nil, and compares
   numbers and collections in a type-independent manner.  Clojure's immutable data
   structures define equals() (and thus =) as a value, not an identity,
   comparison."
-  {:inline (fn [x y] `(. clojure.lang.Util equiv ~x ~y))
+  {:inline         (fn [x y] `(. clojure.lang.Util equiv ~x ~y))
    :inline-arities #{2}
-   :added "1.0"}
+   :added          "1.0"}
   ([x] true)
-  ([x y] (clojure.lang.Util/equiv x y))
+  ([x y]
+   (clojure.lang.Util/equiv x y))
   ([x y & more]
    (if (clojure.lang.Util/equiv x y)
      (if (next more)
@@ -805,35 +873,16 @@
        (clojure.lang.Util/equiv y (first more)))
      false)))
 
-;equals-based
-#_(defn =
-  "Equality. Returns true if x equals y, false if not. Same as Java
-  x.equals(y) except it also works for nil. Boxed numbers must have
-  same type. Clojure's immutable data structures define equals() (and
-  thus =) as a value, not an identity, comparison."
-  {:inline (fn [x y] `(. clojure.lang.Util equals ~x ~y))
-   :inline-arities #{2}
-   :added "1.0"}
-  ([x] true)
-  ([x y] (clojure.lang.Util/equals x y))
-  ([x y & more]
-   (if (= x y)
-     (if (next more)
-       (recur y (first more) (next more))
-       (= y (first more)))
-     false)))
-
 (defn not=
   "Same as (not (= obj1 obj2))"
-  {:tag Boolean
-   :added "1.0"
+  {:tag    Boolean
+   :added  "1.0"
    :static true}
   ([x] false)
-  ([x y] (not (= x y)))
+  ([x y]
+   (not (= x y)))
   ([x y & more]
    (not (apply = x y more))))
-
-
 
 (defn compare
   "Comparator. Returns a negative number, zero, or a positive number
@@ -841,10 +890,10 @@
   y. Same as Java x.compareTo(y) except it also works for nil, and
   compares numbers and collections in a type-independent manner. x
   must implement Comparable"
-  {
-   :inline (fn [x y] `(. clojure.lang.Util compare ~x ~y))
-   :added "1.0"}
-  [x y] (. clojure.lang.Util (compare x y)))
+  {:inline (fn [x y] `(clojure.lang.Util/compare ~x ~y))
+   :added  "1.0"}
+  [x y]
+  (clojure.lang.Util/compare x y))
 
 (defmacro and
   "Evaluates exprs one at a time, from left to right. If a form
@@ -867,51 +916,56 @@
   ([] nil)
   ([x] x)
   ([x & next]
-      `(let [or# ~x]
-         (if or# or# (or ~@next)))))
+   `(let [or# ~x]
+      (if or# or# (or ~@next)))))
 
 ;;;;;;;;;;;;;;;;;;; sequence fns  ;;;;;;;;;;;;;;;;;;;;;;;
 (defn zero?
   "Returns true if num is zero, else false"
-  {
-   :inline (fn [x] `(. clojure.lang.Numbers (isZero ~x)))
-   :added "1.0"}
-  [x] (. clojure.lang.Numbers (isZero x)))
+  {:inline (fn [x] `(clojure.lang.Numbers/isZero ~x))
+   :added  "1.0"}
+  [x]
+  (clojure.lang.Numbers/isZero x))
 
 (defn count
   "Returns the number of items in the collection. (count nil) returns
   0.  Also works on strings, arrays, and Java Collections and Maps"
-  {
-   :inline (fn  [x] `(. clojure.lang.RT (count ~x)))
-   :added "1.0"}
-  [coll] (clojure.lang.RT/count coll))
+  {:inline (fn [x] `(clojure.lang.RT/count ~x))
+   :added  "1.0"}
+  [coll]
+  (clojure.lang.RT/count coll))
 
 (defn int
   "Coerce to int"
-  {
-   :inline (fn  [x] `(. clojure.lang.RT (~(if *unchecked-math* 'uncheckedIntCast 'intCast) ~x)))
-   :added "1.0"}
-  [x] (. clojure.lang.RT (intCast x)))
+  {:inline (fn [x]
+             `(. clojure.lang.RT (~(if *unchecked-math*
+                                     'uncheckedIntCast 'intCast) ~x)))
+   :added  "1.0"}
+  [x]
+  (clojure.lang.RT/intCast x))
 
 (defn nth
   "Returns the value at the index. get returns nil if index out of
   bounds, nth throws an exception unless not-found is supplied.  nth
   also works for strings, Java arrays, regex Matchers and Lists, and,
   in O(n) time, for sequences."
-  {:inline (fn  [c i & nf] `(. clojure.lang.RT (nth ~c ~i ~@nf)))
+  {:inline         (fn  [c i & nf] `(. clojure.lang.RT (nth ~c ~i ~@nf)))
    :inline-arities #{2 3}
-   :added "1.0"}
-  ([coll index] (. clojure.lang.RT (nth coll index)))
-  ([coll index not-found] (. clojure.lang.RT (nth coll index not-found))))
+   :added          "1.0"}
+  ([coll index]
+   (clojure.lang.RT/nth coll index))
+  ([coll index not-found]
+   (clojure.lang.RT/nth coll index not-found)))
 
 (defn <
   "Returns non-nil if nums are in monotonically increasing order,
   otherwise false."
-  {:inline (fn [x y] `(. clojure.lang.Numbers (lt ~x ~y)))
+  {:inline         (fn [x y] `(clojure.lang.Numbers/lt ~x ~y))
    :inline-arities #{2}
-   :added "1.0"}
+   :added          "1.0"}
   ([x] true)
-  ([x y] (. clojure.lang.Numbers (lt x y)))
+  ([x y]
+   (clojure.lang.Numbers/lt x y))
   ([x y & more]
    (if (< x y)
      (if (next more)
@@ -922,151 +976,158 @@
 (defn inc'
   "Returns a number one greater than num. Supports arbitrary precision.
   See also: inc"
-  {:inline (fn [x] `(. clojure.lang.Numbers (incP ~x)))
-   :added "1.0"}
-  [x] (. clojure.lang.Numbers (incP x)))
+  {:inline (fn [x] `(clojure.lang.Numbers/incP ~x))
+   :added  "1.0"}
+  [x]
+  (clojure.lang.Numbers/incP x))
 
 (defn inc
   "Returns a number one greater than num. Does not auto-promote
   longs, will throw on overflow. See also: inc'"
   {:inline (fn [x] `(. clojure.lang.Numbers (~(if *unchecked-math* 'unchecked_inc 'inc) ~x)))
-   :added "1.2"}
-  [x] (. clojure.lang.Numbers (inc x)))
+   :added  "1.2"}
+  [x]
+  (clojure.lang.Numbers/inc x))
 
 ;; reduce is defined again later after InternalReduce loads
-(defn ^:private ^:static
-  reduce1
-       ([f coll]
-             (let [s (seq coll)]
-               (if s
-         (reduce1 f (first s) (next s))
-                 (f))))
-       ([f val coll]
-          (let [s (seq coll)]
-            (if s
-              (if (chunked-seq? s)
-                (recur f 
-                       (.reduce (chunk-first s) f val)
-                       (chunk-next s))
-                (recur f (f val (first s)) (next s)))
-         val))))
+(defn ^:private ^:static reduce1
+  ([f coll]
+   (let [s (seq coll)]
+     (if s
+       (reduce1 f (first s) (next s))
+       (f))))
+  ([f val coll]
+   (let [s (seq coll)]
+     (if s
+       (if (chunked-seq? s)
+         (recur f
+                (.reduce (chunk-first s) f val)
+                (chunk-next s))
+         (recur f (f val (first s)) (next s)))
+       val))))
 
 (defn reverse
   "Returns a seq of the items in coll in reverse order. Not lazy."
   {:added "1.0"
    :static true}
   [coll]
-    (reduce1 conj () coll))
+  (reduce1 conj () coll))
 
 ;;math stuff
 (defn ^:private nary-inline
-  ([op] (nary-inline op op))
+  ([op]
+   (nary-inline op op))
   ([op unchecked-op]
-     (fn
-       ([x] (let [op (if *unchecked-math* unchecked-op op)]
-              `(. clojure.lang.Numbers (~op ~x))))
-       ([x y] (let [op (if *unchecked-math* unchecked-op op)]
-                `(. clojure.lang.Numbers (~op ~x ~y))))
-       ([x y & more]
-          (let [op (if *unchecked-math* unchecked-op op)]
-            (reduce1
-             (fn [a b] `(. clojure.lang.Numbers (~op ~a ~b)))
-             `(. clojure.lang.Numbers (~op ~x ~y)) more))))))
+   (fn
+     ([x]
+      (let [op (if *unchecked-math* unchecked-op op)]
+        `(. clojure.lang.Numbers (~op ~x))))
+     ([x y]
+      (let [op (if *unchecked-math* unchecked-op op)]
+        `(. clojure.lang.Numbers (~op ~x ~y))))
+     ([x y & more]
+      (let [op (if *unchecked-math* unchecked-op op)]
+        (reduce1
+         (fn [a b] `(. clojure.lang.Numbers (~op ~a ~b)))
+         `(. clojure.lang.Numbers (~op ~x ~y)) more))))))
 
-(defn ^:private >1? [n] (clojure.lang.Numbers/gt n 1))
-(defn ^:private >0? [n] (clojure.lang.Numbers/gt n 0))
+(defn ^:private >1? [n]
+  (clojure.lang.Numbers/gt n 1))
+
+(defn ^:private >0? [n]
+  (clojure.lang.Numbers/gt n 0))
 
 (defn +'
-  "Returns the sum of nums. (+') returns 0. Supports arbitrary precision.
-  See also: +"
-  {:inline (nary-inline 'addP)
+  "Returns the sum of nums. (+') returns 0. Supports arbitrary precision. See also: +"
+  {:inline         (nary-inline 'addP)
    :inline-arities >1?
-   :added "1.0"}
+   :added          "1.0"}
   ([] 0)
   ([x] (cast Number x))
-  ([x y] (. clojure.lang.Numbers (addP x y)))
+  ([x y]
+   (clojure.lang.Numbers/addP x y))
   ([x y & more]
    (reduce1 +' (+' x y) more)))
 
 (defn +
-  "Returns the sum of nums. (+) returns 0. Does not auto-promote
-  longs, will throw on overflow. See also: +'"
-  {:inline (nary-inline 'add 'unchecked_add)
+  "Returns the sum of nums. (+) returns 0. Does not auto-promote longs, will throw on overflow. See also: +'"
+  {:inline         (nary-inline 'add 'unchecked_add)
    :inline-arities >1?
-   :added "1.2"}
+   :added          "1.2"}
   ([] 0)
   ([x] (cast Number x))
-  ([x y] (. clojure.lang.Numbers (add x y)))
+  ([x y]
+   (clojure.lang.Numbers/add x y))
   ([x y & more]
-     (reduce1 + (+ x y) more)))
+   (reduce1 + (+ x y) more)))
 
 (defn *'
-  "Returns the product of nums. (*') returns 1. Supports arbitrary precision.
-  See also: *"
-  {:inline (nary-inline 'multiplyP)
+  "Returns the product of nums. (*') returns 1. Supports arbitrary precision. See also: *"
+  {:inline         (nary-inline 'multiplyP)
    :inline-arities >1?
-   :added "1.0"}
+   :added          "1.0"}
   ([] 1)
   ([x] (cast Number x))
-  ([x y] (. clojure.lang.Numbers (multiplyP x y)))
+  ([x y]
+   (clojure.lang.Numbers/multiplyP x y))
   ([x y & more]
    (reduce1 *' (*' x y) more)))
 
 (defn *
-  "Returns the product of nums. (*) returns 1. Does not auto-promote
-  longs, will throw on overflow. See also: *'"
-  {:inline (nary-inline 'multiply 'unchecked_multiply)
+  "Returns the product of nums. (*) returns 1. Does not auto-promote longs, will throw on overflow. See also: *'"
+  {:inline         (nary-inline 'multiply 'unchecked_multiply)
    :inline-arities >1?
-   :added "1.2"}
+   :added          "1.2"}
   ([] 1)
   ([x] (cast Number x))
-  ([x y] (. clojure.lang.Numbers (multiply x y)))
+  ([x y]
+   (clojure.lang.Numbers/multiply x y))
   ([x y & more]
-     (reduce1 * (* x y) more)))
+   (reduce1 * (* x y) more)))
 
 (defn /
-  "If no denominators are supplied, returns 1/numerator,
-  else returns numerator divided by all of the denominators."
-  {:inline (nary-inline 'divide)
+  "If no denominators are supplied, returns 1/numerator, else returns numerator divided by all of the denominators."
+  {:inline         (nary-inline 'divide)
    :inline-arities >1?
-   :added "1.0"}
+   :added          "1.0"}
   ([x] (/ 1 x))
-  ([x y] (. clojure.lang.Numbers (divide x y)))
+  ([x y]
+   (clojure.lang.Numbers/divide x y))
   ([x y & more]
    (reduce1 / (/ x y) more)))
 
 (defn -'
-  "If no ys are supplied, returns the negation of x, else subtracts
-  the ys from x and returns the result. Supports arbitrary precision.
-  See also: -"
-  {:inline (nary-inline 'minusP)
+  "If no ys are supplied, returns the negation of x, else subtracts the ys from x and returns the result. Supports arbitrary precision. See also: -"
+  {:inline         (nary-inline 'minusP)
    :inline-arities >0?
-   :added "1.0"}
-  ([x] (. clojure.lang.Numbers (minusP x)))
-  ([x y] (. clojure.lang.Numbers (minusP x y)))
+   :added          "1.0"}
+  ([x]
+   (clojure.lang.Numbers/minusP x))
+  ([x y]
+   (clojure.lang.Numbers/minusP x y))
   ([x y & more]
    (reduce1 -' (-' x y) more)))
 
 (defn -
-  "If no ys are supplied, returns the negation of x, else subtracts
-  the ys from x and returns the result. Does not auto-promote
-  longs, will throw on overflow. See also: -'"
-  {:inline (nary-inline 'minus 'unchecked_minus)
+  "If no ys are supplied, returns the negation of x, else subtracts the ys from x and returns the result. Does not auto-promote longs, will throw on overflow. See also: -'"
+  {:inline         (nary-inline 'minus 'unchecked_minus)
    :inline-arities >0?
-   :added "1.2"}
-  ([x] (. clojure.lang.Numbers (minus x)))
-  ([x y] (. clojure.lang.Numbers (minus x y)))
+   :added          "1.2"}
+  ([x]
+   (clojure.lang.Numbers/minus x))
+  ([x y]
+   (clojure.lang.Numbers/minus x y))
   ([x y & more]
-     (reduce1 - (- x y) more)))
+   (reduce1 - (- x y) more)))
 
 (defn <=
-  "Returns non-nil if nums are in monotonically non-decreasing order,
-  otherwise false."
-  {:inline (fn [x y] `(. clojure.lang.Numbers (lte ~x ~y)))
+  "Returns non-nil if nums are in monotonically non-decreasing order, otherwise false."
+  {:inline         (fn [x y] `(clojure.lang.Numbers/lte ~x ~y))
    :inline-arities #{2}
-   :added "1.0"}
+   :added          "1.0"}
   ([x] true)
-  ([x y] (. clojure.lang.Numbers (lte x y)))
+  ([x y]
+   (clojure.lang.Numbers/lte x y))
   ([x y & more]
    (if (<= x y)
      (if (next more)
@@ -1075,13 +1136,13 @@
      false)))
 
 (defn >
-  "Returns non-nil if nums are in monotonically decreasing order,
-  otherwise false."
-  {:inline (fn [x y] `(. clojure.lang.Numbers (gt ~x ~y)))
+  "Returns non-nil if nums are in monotonically decreasing order, otherwise false."
+  {:inline         (fn [x y] `(clojure.lang.Numbers/gt ~x ~y))
    :inline-arities #{2}
-   :added "1.0"}
+   :added          "1.0"}
   ([x] true)
-  ([x y] (. clojure.lang.Numbers (gt x y)))
+  ([x y]
+   (clojure.lang.Numbers/gt x y))
   ([x y & more]
    (if (> x y)
      (if (next more)
@@ -1090,13 +1151,13 @@
      false)))
 
 (defn >=
-  "Returns non-nil if nums are in monotonically non-increasing order,
-  otherwise false."
-  {:inline (fn [x y] `(. clojure.lang.Numbers (gte ~x ~y)))
+  "Returns non-nil if nums are in monotonically non-increasing order, otherwise false."
+  {:inline         (fn [x y] `(clojure.lang.Numbers/gte ~x ~y))
    :inline-arities #{2}
-   :added "1.0"}
+   :added          "1.0"}
   ([x] true)
-  ([x y] (. clojure.lang.Numbers (gte x y)))
+  ([x y]
+   (clojure.lang.Numbers/gte x y))
   ([x y & more]
    (if (>= x y)
      (if (next more)
@@ -1105,13 +1166,13 @@
      false)))
 
 (defn ==
-  "Returns non-nil if nums all have the equivalent
-  value (type-independent), otherwise false"
-  {:inline (fn [x y] `(. clojure.lang.Numbers (equiv ~x ~y)))
+  "Returns non-nil if nums all have the equivalent value (type-independent), otherwise false"
+  {:inline         (fn [x y] `(clojure.lang.Numbers/equiv ~x ~y))
    :inline-arities #{2}
-   :added "1.0"}
+   :added          "1.0"}
   ([x] true)
-  ([x y] (. clojure.lang.Numbers (equiv x y)))
+  ([x y]
+   (clojure.lang.Numbers/equiv x y))
   ([x y & more]
    (if (== x y)
      (if (next more)
@@ -1121,44 +1182,49 @@
 
 (defn max
   "Returns the greatest of the nums."
-  {:added "1.0"
+  {:added          "1.0"
    :inline-arities >1?
-   :inline (nary-inline 'max)}
+   :inline         (nary-inline 'max)}
   ([x] x)
-  ([x y] (. clojure.lang.Numbers (max x y)))
+  ([x y]
+   (clojure.lang.Numbers/max x y))
   ([x y & more]
    (reduce1 max (max x y) more)))
 
 (defn min
   "Returns the least of the nums."
-  {:added "1.0"
+  {:added          "1.0"
    :inline-arities >1?
-   :inline (nary-inline 'min)}
+   :inline         (nary-inline 'min)}
   ([x] x)
-  ([x y] (. clojure.lang.Numbers (min x y)))
+  ([x y]
+   (clojure.lang.Numbers/min x y))
   ([x y & more]
    (reduce1 min (min x y) more)))
 
 (defn dec'
   "Returns a number one less than num. Supports arbitrary precision.
   See also: dec"
-  {:inline (fn [x] `(. clojure.lang.Numbers (decP ~x)))
-   :added "1.0"}
-  [x] (. clojure.lang.Numbers (decP x)))
+  {:inline (fn [x] `(clojure.lang.Numbers/decP ~x))
+   :added  "1.0"}
+  [x]
+  (clojure.lang.Numbers/decP x))
 
 (defn dec
   "Returns a number one less than num. Does not auto-promote
   longs, will throw on overflow. See also: dec'"
   {:inline (fn [x] `(. clojure.lang.Numbers (~(if *unchecked-math* 'unchecked_dec 'dec) ~x)))
-   :added "1.2"}
-  [x] (. clojure.lang.Numbers (dec x)))
+   :added  "1.2"}
+  [x]
+  (clojure.lang.Numbers/dec x))
 
 (defn unchecked-inc-int
   "Returns a number one greater than x, an int.
   Note - uses a primitive operator subject to overflow."
-  {:inline (fn [x] `(. clojure.lang.Numbers (unchecked_int_inc ~x)))
-   :added "1.0"}
-  [x] (. clojure.lang.Numbers (unchecked_int_inc x)))
+  {:inline (fn [x] `(clojure.lang.Numbers/unchecked_int_inc ~x))
+   :added  "1.0"}
+  [x]
+  (clojure.lang.Numbers/unchecked_int_inc x))
 
 (defn unchecked-inc
   "Returns a number one greater than x, a long.
@@ -1253,15 +1319,13 @@
 
 (defn pos?
   "Returns true if num is greater than zero, else false"
-  {
-   :inline (fn [x] `(. clojure.lang.Numbers (isPos ~x)))
+  {:inline (fn [x] `(. clojure.lang.Numbers (isPos ~x)))
    :added "1.0"}
   [x] (. clojure.lang.Numbers (isPos x)))
 
 (defn neg?
   "Returns true if num is less than zero, else false"
-  {
-   :inline (fn [x] `(. clojure.lang.Numbers (isNeg ~x)))
+  {:inline (fn [x] `(. clojure.lang.Numbers (isNeg ~x)))
    :added "1.0"}
   [x] (. clojure.lang.Numbers (isNeg x)))
 
@@ -1271,7 +1335,7 @@
    :static true
    :inline (fn [x y] `(. clojure.lang.Numbers (quotient ~x ~y)))}
   [num div]
-    (. clojure.lang.Numbers (quotient num div)))
+  (. clojure.lang.Numbers (quotient num div)))
 
 (defn rem
   "remainder of dividing numerator by denominator."
@@ -1279,16 +1343,16 @@
    :static true
    :inline (fn [x y] `(. clojure.lang.Numbers (remainder ~x ~y)))}
   [num div]
-    (. clojure.lang.Numbers (remainder num div)))
+  (. clojure.lang.Numbers (remainder num div)))
 
 (defn rationalize
   "returns the rational value of num"
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
   [num]
   (. clojure.lang.Numbers (rationalize num)))
 
-;;Bit ops
+;; Bit ops
 
 (defn bit-not
   "Bitwise complement"
@@ -1296,15 +1360,14 @@
    :added "1.0"}
   [x] (. clojure.lang.Numbers not x))
 
-
 (defn bit-and
   "Bitwise and"
-   {:inline (nary-inline 'and)
-    :inline-arities >1?
-    :added "1.0"}
-   ([x y] (. clojure.lang.Numbers and x y))
-   ([x y & more]
-      (reduce1 bit-and (bit-and x y) more)))
+  {:inline (nary-inline 'and)
+   :inline-arities >1?
+   :added "1.0"}
+  ([x y] (. clojure.lang.Numbers and x y))
+  ([x y & more]
+   (reduce1 bit-and (bit-and x y) more)))
 
 (defn bit-or
   "Bitwise or"
@@ -1313,7 +1376,7 @@
    :added "1.0"}
   ([x y] (. clojure.lang.Numbers or x y))
   ([x y & more]
-    (reduce1 bit-or (bit-or x y) more)))
+   (reduce1 bit-or (bit-or x y) more)))
 
 (defn bit-xor
   "Bitwise exclusive or"
@@ -1322,7 +1385,7 @@
    :added "1.0"}
   ([x y] (. clojure.lang.Numbers xor x y))
   ([x y & more]
-    (reduce1 bit-xor (bit-xor x y) more)))
+   (reduce1 bit-xor (bit-xor x y) more)))
 
 (defn bit-and-not
   "Bitwise and with complement"
@@ -1332,8 +1395,7 @@
    :static true}
   ([x y] (. clojure.lang.Numbers andNot x y))
   ([x y & more]
-    (reduce1 bit-and-not (bit-and-not x y) more)))
-
+   (reduce1 bit-and-not (bit-and-not x y) more)))
 
 (defn bit-clear
   "Clear bit at index n"
@@ -1358,7 +1420,6 @@
   {:added "1.0"
    :static true}
   [x n] (. clojure.lang.Numbers testBit x n))
-
 
 (defn bit-shift-left
   "Bitwise shift left"
@@ -1394,7 +1455,7 @@
   "Returns true if n is even, throws an exception if n is not an integer"
   {:added "1.0"
    :static true}
-   [n] (if (integer? n)
+  [n] (if (integer? n)
         (zero? (bit-and (clojure.lang.RT/uncheckedLongCast n) 1))
         (throw (IllegalArgumentException. (str "Argument must be an integer: " n)))))
 
@@ -1404,7 +1465,6 @@
    :static true}
   [n] (not (even? n)))
 
-
 ;;
 
 (defn complement
@@ -1412,8 +1472,8 @@
   has the same effects, if any, and returns the opposite truth value."
   {:added "1.0"
    :static true}
-  [f] 
-  (fn 
+  [f]
+  (fn
     ([] (not (f)))
     ([x] (not (f x)))
     ([x y] (not (f x y)))
@@ -1456,7 +1516,7 @@
   "Return true if x is a map entry"
   {:added "1.8"}
   [x]
-	(instance? java.util.Map$Entry x))
+  (instance? java.util.Map$Entry x))
 
 (defn contains?
   "Returns true if key is present in the given collection, otherwise
@@ -1519,15 +1579,15 @@
   {:added "1.0"
    :static true}
   [map keyseq]
-    (loop [ret {} keys (seq keyseq)]
-      (if keys
-        (let [entry (. clojure.lang.RT (find map (first keys)))]
-          (recur
-           (if entry
-             (conj ret entry)
-             ret)
-           (next keys)))
-        (with-meta ret (meta map)))))
+  (loop [ret {} keys (seq keyseq)]
+    (if keys
+      (let [entry (. clojure.lang.RT (find map (first keys)))]
+        (recur
+         (if entry
+           (conj ret entry)
+           ret)
+         (next keys)))
+      (with-meta ret (meta map)))))
 
 (defn keys
   "Returns a sequence of the map's keys, in the same order as (seq map)."
@@ -1546,14 +1606,14 @@
   {:added "1.0"
    :static true}
   [^java.util.Map$Entry e]
-    (. e (getKey)))
+  (. e (getKey)))
 
 (defn val
   "Returns the value in the map entry."
   {:added "1.0"
    :static true}
   [^java.util.Map$Entry e]
-    (. e (getValue)))
+  (. e (getValue)))
 
 (defn rseq
   "Returns, in constant time, a seq of the items in rev (which
@@ -1561,7 +1621,7 @@
   {:added "1.0"
    :static true}
   [^clojure.lang.Reversible rev]
-    (. rev (rseq)))
+  (. rev (rseq)))
 
 (defn name
   "Returns the name String of a string, symbol or keyword."
@@ -1577,7 +1637,7 @@
    :added "1.0"
    :static true}
   [^clojure.lang.Named x]
-    (. x (getNamespace)))
+  (. x (getNamespace)))
 
 (defmacro locking
   "Executes exprs in an implicit do, while holding the monitor of x.
@@ -1586,10 +1646,10 @@
   [x & body]
   `(let [lockee# ~x]
      (try
-      (monitor-enter lockee#)
-      ~@body
-      (finally
-       (monitor-exit lockee#)))))
+       (monitor-enter lockee#)
+       ~@body
+       (finally
+         (monitor-exit lockee#)))))
 
 (defmacro ..
   "form => fieldName-symbol or (instanceMethodName-symbol args*)
@@ -1636,8 +1696,8 @@
     (if forms
       (let [form (first forms)
             threaded (if (seq? form)
-              (with-meta `(~(first form) ~@(next form)  ~x) (meta form))
-              (list form x))]
+                       (with-meta `(~(first form) ~@(next form)  ~x) (meta form))
+                       (list form x))]
         (recur threaded (next forms)))
       x)))
 
@@ -1649,10 +1709,10 @@
   [options & valid-keys]
   (when (seq (apply disj (apply hash-set (keys options)) valid-keys))
     (throw
-      (IllegalArgumentException.
-        (apply str "Only these options are valid: "
-          (first valid-keys)
-          (map #(str ", " %) (rest valid-keys)))))))
+     (IllegalArgumentException.
+      (apply str "Only these options are valid: "
+             (first valid-keys)
+             (map #(str ", " %) (rest valid-keys)))))))
 
 ;;multimethods
 (def ^:private global-hierarchy)
@@ -1712,7 +1772,7 @@
       `(let [v# (def ~mm-name)]
          (when-not (and (.hasRoot v#) (instance? clojure.lang.MultiFn (deref v#)))
            (def ~(with-meta mm-name m)
-                (new clojure.lang.MultiFn ~(name mm-name) ~dispatch-fn ~default ~hierarchy)))))))
+             (new clojure.lang.MultiFn ~(name mm-name) ~dispatch-fn ~default ~hierarchy)))))))
 
 (defmacro defmethod
   "Creates and installs a new method of multimethod associated with dispatch-value. "
@@ -1723,19 +1783,19 @@
 (defn remove-all-methods
   "Removes all of the methods of multimethod."
   {:added "1.2"
-   :static true} 
- [^clojure.lang.MultiFn multifn]
- (.reset multifn))
+   :static true}
+  [^clojure.lang.MultiFn multifn]
+  (.reset multifn))
 
 (defn remove-method
   "Removes the method of multimethod associated with dispatch-value."
   {:added "1.0"
    :static true}
- [^clojure.lang.MultiFn multifn dispatch-val]
- (. multifn removeMethod dispatch-val))
+  [^clojure.lang.MultiFn multifn dispatch-val]
+  (. multifn removeMethod dispatch-val))
 
 (defn prefer-method
-  "Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y 
+  "Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y
    when there is a conflict"
   {:added "1.0"
    :static true}
@@ -1767,24 +1827,24 @@
   [& pairs]
   `(do (when-not ~(first pairs)
          (throw (IllegalArgumentException.
-                  (str (first ~'&form) " requires " ~(second pairs) " in " ~'*ns* ":" (:line (meta ~'&form))))))
-     ~(let [more (nnext pairs)]
-        (when more
-          (list* `assert-args more)))))
+                 (str (first ~'&form) " requires " ~(second pairs) " in " ~'*ns* ":" (:line (meta ~'&form))))))
+       ~(let [more (nnext pairs)]
+          (when more
+            (list* `assert-args more)))))
 
 (defmacro if-let
   "bindings => binding-form test
 
-  If test is true, evaluates then with binding-form bound to the value of 
+  If test is true, evaluates then with binding-form bound to the value of
   test, if not, yields else"
   {:added "1.0"}
   ([bindings then]
    `(if-let ~bindings ~then nil))
   ([bindings then else & oldform]
    (assert-args
-     (vector? bindings) "a vector for its binding"
-     (nil? oldform) "1 or 2 forms after binding vector"
-     (= 2 (count bindings)) "exactly 2 forms in binding vector")
+    (vector? bindings) "a vector for its binding"
+    (nil? oldform) "1 or 2 forms after binding vector"
+    (= 2 (count bindings)) "exactly 2 forms in binding vector")
    (let [form (bindings 0) tst (bindings 1)]
      `(let [temp# ~tst]
         (if temp#
@@ -1799,9 +1859,9 @@
   {:added "1.0"}
   [bindings & body]
   (assert-args
-     (vector? bindings) "a vector for its binding"
-     (= 2 (count bindings)) "exactly 2 forms in binding vector")
-   (let [form (bindings 0) tst (bindings 1)]
+   (vector? bindings) "a vector for its binding"
+   (= 2 (count bindings)) "exactly 2 forms in binding vector")
+  (let [form (bindings 0) tst (bindings 1)]
     `(let [temp# ~tst]
        (when temp#
          (let [~form temp#]
@@ -1817,9 +1877,9 @@
    `(if-some ~bindings ~then nil))
   ([bindings then else & oldform]
    (assert-args
-     (vector? bindings) "a vector for its binding"
-     (nil? oldform) "1 or 2 forms after binding vector"
-     (= 2 (count bindings)) "exactly 2 forms in binding vector")
+    (vector? bindings) "a vector for its binding"
+    (nil? oldform) "1 or 2 forms after binding vector"
+    (= 2 (count bindings)) "exactly 2 forms in binding vector")
    (let [form (bindings 0) tst (bindings 1)]
      `(let [temp# ~tst]
         (if (nil? temp#)
@@ -1835,9 +1895,9 @@
   {:added "1.6"}
   [bindings & body]
   (assert-args
-     (vector? bindings) "a vector for its binding"
-     (= 2 (count bindings)) "exactly 2 forms in binding vector")
-   (let [form (bindings 0) tst (bindings 1)]
+   (vector? bindings) "a vector for its binding"
+   (= 2 (count bindings)) "exactly 2 forms in binding vector")
+  (let [form (bindings 0) tst (bindings 1)]
     `(let [temp# ~tst]
        (if (nil? temp#)
          nil
@@ -1851,14 +1911,14 @@
   Takes a map of Var/value pairs. Binds each Var to the associated value for
   the current thread. Each call *MUST* be accompanied by a matching call to
   pop-thread-bindings wrapped in a try-finally!
-  
+
       (push-thread-bindings bindings)
       (try
         ...
         (finally
           (pop-thread-bindings)))"
   {:added "1.1"
-   :static true} 
+   :static true}
   [bindings]
   (clojure.lang.Var/pushThreadBindings bindings))
 
@@ -1889,13 +1949,13 @@
   {:added "1.0"}
   [bindings & body]
   (assert-args
-    (vector? bindings) "a vector for its binding"
-    (even? (count bindings)) "an even number of forms in binding vector")
+   (vector? bindings) "a vector for its binding"
+   (even? (count bindings)) "an even number of forms in binding vector")
   (let [var-ize (fn [var-vals]
                   (loop [ret [] vvs (seq var-vals)]
                     (if vvs
                       (recur  (conj (conj ret `(var ~(first vvs))) (second vvs))
-                             (next (next vvs)))
+                              (next (next vvs)))
                       (seq ret))))]
     `(let []
        (push-thread-bindings (hash-map ~@(var-ize bindings)))
@@ -1958,22 +2018,22 @@
    :added "1.3"}
   [f]
   (let [frame (clojure.lang.Var/cloneThreadBindingFrame)]
-    (fn 
+    (fn
       ([]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f))
+       (clojure.lang.Var/resetThreadBindingFrame frame)
+       (f))
       ([x]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x))
+       (clojure.lang.Var/resetThreadBindingFrame frame)
+       (f x))
       ([x y]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x y))
+       (clojure.lang.Var/resetThreadBindingFrame frame)
+       (f x y))
       ([x y z]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x y z))
-      ([x y z & args] 
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (apply f x y z args)))))
+       (clojure.lang.Var/resetThreadBindingFrame frame)
+       (f x y z))
+      ([x y z & args]
+       (clojure.lang.Var/resetThreadBindingFrame frame)
+       (apply f x y z args)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Refs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn ^{:private true}
@@ -2008,17 +2068,16 @@
   default if no error-handler is given) -- see set-error-mode! for
   details."
   {:added "1.0"
-   :static true
-   }
+   :static true}
   ([state & options]
-     (let [a (new clojure.lang.Agent state)
-           opts (apply hash-map options)]
-       (setup-reference a options)
-       (when (:error-handler opts)
-         (.setErrorHandler a (:error-handler opts)))
-       (.setErrorMode a (or (:error-mode opts)
-                            (if (:error-handler opts) :continue :fail)))
-       a)))
+   (let [a (new clojure.lang.Agent state)
+         opts (apply hash-map options)]
+     (setup-reference a options)
+     (when (:error-handler opts)
+       (.setErrorHandler a (:error-handler opts)))
+     (.setErrorMode a (or (:error-mode opts)
+                          (if (:error-handler opts) :continue :fail)))
+     a)))
 
 (defn set-agent-send-executor!
   "Sets the ExecutorService to be used by send"
@@ -2119,8 +2178,7 @@
   any, will NOT be notified of the new state.  Throws an exception if
   the agent is not failed."
   {:added "1.2"
-   :static true
-   }
+   :static true}
   [^clojure.lang.Agent a, new-state & options]
   (let [opts (apply hash-map options)]
     (.restart a new-state (if (:clear-actions opts) true false))))
@@ -2150,7 +2208,7 @@
   error-handler may be called (see set-error-handler!), after which,
   if the mode is :continue, the agent will continue as if neither the
   action that caused the error nor the error itself ever happened.
-  
+
   If the mode is :fail, the agent will become failed and will stop
   accepting new 'send' and 'send-off' actions, and any previously
   queued actions will be held until a 'restart-agent'.  Deref will
@@ -2217,26 +2275,25 @@
   of after a read fault). History is limited, and the limit can be set
   with :max-history."
   {:added "1.0"
-   :static true
-   }
+   :static true}
   ([x] (new clojure.lang.Ref x))
-  ([x & options] 
+  ([x & options]
    (let [r  ^clojure.lang.Ref (setup-reference (ref x) options)
          opts (apply hash-map options)]
-    (when (:max-history opts)
-      (.setMaxHistory r (:max-history opts)))
-    (when (:min-history opts)
-      (.setMinHistory r (:min-history opts)))
-    r)))
+     (when (:max-history opts)
+       (.setMaxHistory r (:max-history opts)))
+     (when (:min-history opts)
+       (.setMinHistory r (:min-history opts)))
+     r)))
 
 (defn ^:private deref-future
   ([^java.util.concurrent.Future fut]
-     (.get fut))
+   (.get fut))
   ([^java.util.concurrent.Future fut timeout-ms timeout-val]
-     (try (.get fut timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)
-          (catch java.util.concurrent.TimeoutException e
-            timeout-val))))
-     
+   (try (.get fut timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)
+        (catch java.util.concurrent.TimeoutException e
+          timeout-val))))
+
 (defn deref
   "Also reader macro: @ref/@agent/@var/@atom/@delay/@future/@promise. Within a transaction,
   returns the in-transaction-value of ref, else returns the
@@ -2254,9 +2311,9 @@
            (.deref ^clojure.lang.IDeref ref)
            (deref-future ref)))
   ([ref timeout-ms timeout-val]
-     (if (instance? clojure.lang.IBlockingDeref ref)
-       (.deref ^clojure.lang.IBlockingDeref ref timeout-ms timeout-val)
-       (deref-future ref timeout-ms timeout-val))))
+   (if (instance? clojure.lang.IBlockingDeref ref)
+     (.deref ^clojure.lang.IBlockingDeref ref timeout-ms timeout-val)
+     (deref-future ref timeout-ms timeout-val))))
 
 (defn atom
   "Creates and returns an Atom with an initial value of x and zero or
@@ -2318,7 +2375,7 @@
   "Gets the validator-fn for a var/ref/agent/atom."
   {:added "1.0"
    :static true}
- [^clojure.lang.IRef iref] (. iref (getValidator)))
+  [^clojure.lang.IRef iref] (. iref (getValidator)))
 
 (defn alter-meta!
   "Atomically sets the metadata for a namespace/var/ref/agent/atom to be:
@@ -2328,13 +2385,13 @@
   f must be free of side-effects"
   {:added "1.0"
    :static true}
- [^clojure.lang.IReference iref f & args] (.alterMeta iref f args))
+  [^clojure.lang.IReference iref f & args] (.alterMeta iref f args))
 
 (defn reset-meta!
   "Atomically resets the metadata for a namespace/var/ref/agent/atom"
   {:added "1.0"
    :static true}
- [^clojure.lang.IReference iref metadata-map] (.resetMeta iref metadata-map))
+  [^clojure.lang.IReference iref metadata-map] (.resetMeta iref metadata-map))
 
 (defn commute
   "Must be called in a transaction. Sets the in-transaction-value of
@@ -2355,7 +2412,7 @@
    :static true}
 
   [^clojure.lang.Ref ref fun & args]
-    (. ref (commute fun args)))
+  (. ref (commute fun args)))
 
 (defn alter
   "Must be called in a transaction. Sets the in-transaction-value of
@@ -2367,7 +2424,7 @@
   {:added "1.0"
    :static true}
   [^clojure.lang.Ref ref fun & args]
-    (. ref (alter fun args)))
+  (. ref (alter fun args)))
 
 (defn ref-set
   "Must be called in a transaction. Sets the value of ref.
@@ -2375,32 +2432,32 @@
   {:added "1.0"
    :static true}
   [^clojure.lang.Ref ref val]
-    (. ref (set val)))
+  (. ref (set val)))
 
 (defn ref-history-count
   "Returns the history count of a ref"
   {:added "1.1"
    :static true}
   [^clojure.lang.Ref ref]
-    (.getHistoryCount ref))
+  (.getHistoryCount ref))
 
 (defn ref-min-history
   "Gets the min-history of a ref, or sets it and returns the ref"
   {:added "1.1"
    :static true}
   ([^clojure.lang.Ref ref]
-    (.getMinHistory ref))
+   (.getMinHistory ref))
   ([^clojure.lang.Ref ref n]
-    (.setMinHistory ref n)))
+   (.setMinHistory ref n)))
 
 (defn ref-max-history
   "Gets the max-history of a ref, or sets it and returns the ref"
   {:added "1.1"
    :static true}
   ([^clojure.lang.Ref ref]
-    (.getMaxHistory ref))
+   (.getMaxHistory ref))
   ([^clojure.lang.Ref ref n]
-    (.setMaxHistory ref n)))
+   (.setMaxHistory ref n)))
 
 (defn ensure
   "Must be called in a transaction. Protects the ref from modification
@@ -2409,8 +2466,8 @@
   {:added "1.0"
    :static true}
   [^clojure.lang.Ref ref]
-    (. ref (touch))
-    (. ref (deref)))
+  (. ref (touch))
+  (. ref (deref)))
 
 (defmacro sync
   "transaction-flags => TBD, pass nil for now
@@ -2424,7 +2481,6 @@
   [flags-ignored-for-now & body]
   `(. clojure.lang.LockingTransaction
       (runInTransaction (fn [] ~@body))))
-
 
 (defmacro io!
   "If an io! block occurs in a transaction, throws an
@@ -2470,7 +2526,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; fn stuff ;;;;;;;;;;;;;;;;
 
-
 (defn comp
   "Takes a set of functions and returns a fn that is the composition
   of those fns.  The returned fn takes a variable number of args,
@@ -2480,17 +2535,17 @@
    :static true}
   ([] identity)
   ([f] f)
-  ([f g] 
-     (fn 
-       ([] (f (g)))
-       ([x] (f (g x)))
-       ([x y] (f (g x y)))
-       ([x y z] (f (g x y z)))
-       ([x y z & args] (f (apply g x y z args)))))
+  ([f g]
+   (fn
+     ([] (f (g)))
+     ([x] (f (g x)))
+     ([x y] (f (g x y)))
+     ([x y z] (f (g x y z)))
+     ([x y z & args] (f (apply g x y z args)))))
   ([f g & fs]
-     (reduce1 comp (list* f g fs))))
+   (reduce1 comp (list* f g fs))))
 
-(defn juxt 
+(defn juxt
   "Takes a set of functions and returns a fn that is the juxtaposition
   of those fns.  The returned fn takes a variable number of args, and
   returns a vector containing the result of applying each fn to the
@@ -2498,35 +2553,35 @@
   ((juxt a b c) x) => [(a x) (b x) (c x)]"
   {:added "1.1"
    :static true}
-  ([f] 
-     (fn
-       ([] [(f)])
-       ([x] [(f x)])
-       ([x y] [(f x y)])
-       ([x y z] [(f x y z)])
-       ([x y z & args] [(apply f x y z args)])))
-  ([f g] 
-     (fn
-       ([] [(f) (g)])
-       ([x] [(f x) (g x)])
-       ([x y] [(f x y) (g x y)])
-       ([x y z] [(f x y z) (g x y z)])
-       ([x y z & args] [(apply f x y z args) (apply g x y z args)])))
-  ([f g h] 
-     (fn
-       ([] [(f) (g) (h)])
-       ([x] [(f x) (g x) (h x)])
-       ([x y] [(f x y) (g x y) (h x y)])
-       ([x y z] [(f x y z) (g x y z) (h x y z)])
-       ([x y z & args] [(apply f x y z args) (apply g x y z args) (apply h x y z args)])))
+  ([f]
+   (fn
+     ([] [(f)])
+     ([x] [(f x)])
+     ([x y] [(f x y)])
+     ([x y z] [(f x y z)])
+     ([x y z & args] [(apply f x y z args)])))
+  ([f g]
+   (fn
+     ([] [(f) (g)])
+     ([x] [(f x) (g x)])
+     ([x y] [(f x y) (g x y)])
+     ([x y z] [(f x y z) (g x y z)])
+     ([x y z & args] [(apply f x y z args) (apply g x y z args)])))
+  ([f g h]
+   (fn
+     ([] [(f) (g) (h)])
+     ([x] [(f x) (g x) (h x)])
+     ([x y] [(f x y) (g x y) (h x y)])
+     ([x y z] [(f x y z) (g x y z) (h x y z)])
+     ([x y z & args] [(apply f x y z args) (apply g x y z args) (apply h x y z args)])))
   ([f g h & fs]
-     (let [fs (list* f g h fs)]
-       (fn
-         ([] (reduce1 #(conj %1 (%2)) [] fs))
-         ([x] (reduce1 #(conj %1 (%2 x)) [] fs))
-         ([x y] (reduce1 #(conj %1 (%2 x y)) [] fs))
-         ([x y z] (reduce1 #(conj %1 (%2 x y z)) [] fs))
-         ([x y z & args] (reduce1 #(conj %1 (apply %2 x y z args)) [] fs))))))
+   (let [fs (list* f g h fs)]
+     (fn
+       ([] (reduce1 #(conj %1 (%2)) [] fs))
+       ([x] (reduce1 #(conj %1 (%2 x)) [] fs))
+       ([x y] (reduce1 #(conj %1 (%2 x y)) [] fs))
+       ([x y z] (reduce1 #(conj %1 (%2 x y z)) [] fs))
+       ([x y z & args] (reduce1 #(conj %1 (apply %2 x y z args)) [] fs))))))
 
 (defn partial
   "Takes a function f and fewer than the normal arguments to f, and
@@ -2573,17 +2628,17 @@
   {:added "1.0"
    :static true}
   ([coll]
-     (if (seq? coll) coll
-         (or (seq coll) ())))
+   (if (seq? coll) coll
+       (or (seq coll) ())))
   ([xform coll]
-     (or (clojure.lang.RT/chunkIteratorSeq
-         (clojure.lang.TransformerIterator/create xform (clojure.lang.RT/iter coll)))
+   (or (clojure.lang.RT/chunkIteratorSeq
+        (clojure.lang.TransformerIterator/create xform (clojure.lang.RT/iter coll)))
        ()))
   ([xform coll & colls]
-     (or (clojure.lang.RT/chunkIteratorSeq
-         (clojure.lang.TransformerIterator/createMulti
-           xform
-           (map #(clojure.lang.RT/iter %) (cons coll colls))))
+   (or (clojure.lang.RT/chunkIteratorSeq
+        (clojure.lang.TransformerIterator/createMulti
+         xform
+         (map #(clojure.lang.RT/iter %) (cons coll colls))))
        ())))
 
 (defn every?
@@ -2594,17 +2649,17 @@
    :static true}
   [pred coll]
   (cond
-   (nil? (seq coll)) true
-   (pred (first coll)) (recur pred (next coll))
-   :else false))
+    (nil? (seq coll)) true
+    (pred (first coll)) (recur pred (next coll))
+    :else false))
 
 (def
- ^{:tag Boolean
-   :doc "Returns false if (pred x) is logical true for every x in
+  ^{:tag Boolean
+    :doc "Returns false if (pred x) is logical true for every x in
   coll, else true."
-   :arglists '([pred coll])
-   :added "1.0"}
- not-every? (comp not every?))
+    :arglists '([pred coll])
+    :added "1.0"}
+  not-every? (comp not every?))
 
 (defn some
   "Returns the first logical true value of (pred x) for any x in coll,
@@ -2614,18 +2669,18 @@
   {:added "1.0"
    :static true}
   [pred coll]
-    (when (seq coll)
-      (or (pred (first coll)) (recur pred (next coll)))))
+  (when (seq coll)
+    (or (pred (first coll)) (recur pred (next coll)))))
 
 (def
- ^{:tag Boolean
-   :doc "Returns false if (pred x) is logical true for any x in coll,
+  ^{:tag Boolean
+    :doc "Returns false if (pred x) is logical true for any x in coll,
   else true."
-   :arglists '([pred coll])
-   :added "1.0"}
- not-any? (comp not some))
+    :arglists '([pred coll])
+    :added "1.0"}
+  not-any? (comp not some))
 
-;will be redefed later with arg checks
+;; will be redefed later with arg checks
 (defmacro dotimes
   "bindings => name n
 
@@ -2651,14 +2706,14 @@
   {:added "1.0"
    :static true}
   ([f]
-    (fn [rf]
-      (fn
-        ([] (rf))
-        ([result] (rf result))
-        ([result input]
-           (rf result (f input)))
-        ([result input & inputs]
-           (rf result (apply f input inputs))))))
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result input]
+        (rf result (f input)))
+       ([result input & inputs]
+        (rf result (apply f input inputs))))))
   ([f coll]
    (lazy-seq
     (when-let [s (seq coll)]
@@ -2667,7 +2722,7 @@
               size (int (count c))
               b (chunk-buffer size)]
           (dotimes [i size]
-              (chunk-append b (f (.nth c i))))
+            (chunk-append b (f (.nth c i))))
           (chunk-cons (chunk b) (map f (chunk-rest s))))
         (cons (f (first s)) (map f (rest s)))))))
   ([f c1 c2]
@@ -2684,10 +2739,10 @@
               (map f (rest s1) (rest s2) (rest s3)))))))
   ([f c1 c2 c3 & colls]
    (let [step (fn step [cs]
-                 (lazy-seq
-                  (let [ss (map seq cs)]
-                    (when (every? identity ss)
-                      (cons (map first ss) (step (map rest ss)))))))]
+                (lazy-seq
+                 (let [ss (map seq cs)]
+                   (when (every? identity ss)
+                     (cons (map first ss) (step (map rest ss)))))))]
      (map #(apply f %) (step (conj colls c3 c2 c1))))))
 
 (defmacro declare
@@ -2705,7 +2760,7 @@
    :static true}
   ([f] (comp (map f) cat))
   ([f & colls]
-     (apply concat (apply map f colls))))
+   (apply concat (apply map f colls))))
 
 (defn filter
   "Returns a lazy sequence of the items in coll for which
@@ -2714,14 +2769,14 @@
   {:added "1.0"
    :static true}
   ([pred]
-    (fn [rf]
-      (fn
-        ([] (rf))
-        ([result] (rf result))
-        ([result input]
-           (if (pred input)
-             (rf result input)
-             result)))))
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result input]
+        (if (pred input)
+          (rf result input)
+          result)))))
   ([pred coll]
    (lazy-seq
     (when-let [s (seq coll)]
@@ -2730,15 +2785,14 @@
               size (count c)
               b (chunk-buffer size)]
           (dotimes [i size]
-              (let [v (.nth c i)]
-                (when (pred v)
-                  (chunk-append b v))))
+            (let [v (.nth c i)]
+              (when (pred v)
+                (chunk-append b v))))
           (chunk-cons (chunk b) (filter pred (chunk-rest s))))
         (let [f (first s) r (rest s)]
           (if (pred f)
             (cons f (filter pred r))
             (filter pred r))))))))
-
 
 (defn remove
   "Returns a lazy sequence of the items in coll for which
@@ -2748,7 +2802,7 @@
    :static true}
   ([pred] (filter (complement pred)))
   ([pred coll]
-     (filter (complement pred) coll)))
+   (filter (complement pred) coll)))
 
 (defn reduced
   "Wraps x in a way such that a reduce will terminate with the value x"
@@ -2758,7 +2812,7 @@
 
 (defn reduced?
   "Returns true if x is the result of a call to reduced"
-  {:inline (fn [x] `(clojure.lang.RT/isReduced ~x ))
+  {:inline (fn [x] `(clojure.lang.RT/isReduced ~x))
    :inline-arities #{1}
    :added "1.5"}
   ([x] (clojure.lang.RT/isReduced x)))
@@ -2782,25 +2836,25 @@
   {:added "1.0"
    :static true}
   ([n]
-     (fn [rf]
-       (let [nv (volatile! n)]
-         (fn
-           ([] (rf))
-           ([result] (rf result))
-           ([result input]
-              (let [n @nv
-                    nn (vswap! nv dec)
-                    result (if (pos? n)
-                             (rf result input)
-                             result)]
-                (if (not (pos? nn))
-                  (ensure-reduced result)
-                  result)))))))
+   (fn [rf]
+     (let [nv (volatile! n)]
+       (fn
+         ([] (rf))
+         ([result] (rf result))
+         ([result input]
+          (let [n @nv
+                nn (vswap! nv dec)
+                result (if (pos? n)
+                         (rf result input)
+                         result)]
+            (if (not (pos? nn))
+              (ensure-reduced result)
+              result)))))))
   ([n coll]
-     (lazy-seq
-      (when (pos? n) 
-        (when-let [s (seq coll)]
-          (cons (first s) (take (dec n) (rest s))))))))
+   (lazy-seq
+    (when (pos? n)
+      (when-let [s (seq coll)]
+        (cons (first s) (take (dec n) (rest s))))))))
 
 (defn take-while
   "Returns a lazy sequence of successive items from coll while
@@ -2809,19 +2863,19 @@
   {:added "1.0"
    :static true}
   ([pred]
-     (fn [rf]
-       (fn
-         ([] (rf))
-         ([result] (rf result))
-         ([result input]
-            (if (pred input)
-              (rf result input)
-              (reduced result))))))
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result input]
+        (if (pred input)
+          (rf result input)
+          (reduced result))))))
   ([pred coll]
-     (lazy-seq
-      (when-let [s (seq coll)]
-        (when (pred (first s))
-          (cons (first s) (take-while pred (rest s))))))))
+   (lazy-seq
+    (when-let [s (seq coll)]
+      (when (pred (first s))
+        (cons (first s) (take-while pred (rest s))))))))
 
 (defn drop
   "Returns a lazy sequence of all but the first n items in coll.
@@ -2829,24 +2883,24 @@
   {:added "1.0"
    :static true}
   ([n]
-     (fn [rf]
-       (let [nv (volatile! n)]
-         (fn
-           ([] (rf))
-           ([result] (rf result))
-           ([result input]
-              (let [n @nv]
-                (vswap! nv dec)
-                (if (pos? n)
-                  result
-                  (rf result input))))))))
+   (fn [rf]
+     (let [nv (volatile! n)]
+       (fn
+         ([] (rf))
+         ([result] (rf result))
+         ([result input]
+          (let [n @nv]
+            (vswap! nv dec)
+            (if (pos? n)
+              result
+              (rf result input))))))))
   ([n coll]
-     (let [step (fn [n coll]
-                  (let [s (seq coll)]
-                    (if (and (pos? n) s)
-                      (recur (dec n) (rest s))
-                      s)))]
-       (lazy-seq (step n coll)))))
+   (let [step (fn [n coll]
+                (let [s (seq coll)]
+                  (if (and (pos? n) s)
+                    (recur (dec n) (rest s))
+                    s)))]
+     (lazy-seq (step n coll)))))
 
 (defn drop-last
   "Return a lazy sequence of all but the last n (default 1) items in coll"
@@ -2873,25 +2927,25 @@
   {:added "1.0"
    :static true}
   ([pred]
-     (fn [rf]
-       (let [dv (volatile! true)]
-         (fn
-           ([] (rf))
-           ([result] (rf result))
-           ([result input]
-              (let [drop? @dv]
-                (if (and drop? (pred input))
-                  result
-                  (do
-                    (vreset! dv nil)
-                    (rf result input)))))))))
+   (fn [rf]
+     (let [dv (volatile! true)]
+       (fn
+         ([] (rf))
+         ([result] (rf result))
+         ([result input]
+          (let [drop? @dv]
+            (if (and drop? (pred input))
+              result
+              (do
+                (vreset! dv nil)
+                (rf result input)))))))))
   ([pred coll]
-     (let [step (fn [pred coll]
-                  (let [s (seq coll)]
-                    (if (and s (pred (first s)))
-                      (recur pred (rest s))
-                      s)))]
-       (lazy-seq (step pred coll)))))
+   (let [step (fn [pred coll]
+                (let [s (seq coll)]
+                  (if (and s (pred (first s)))
+                    (recur pred (rest s))
+                    s)))]
+     (lazy-seq (step pred coll)))))
 
 (defn cycle
   "Returns a lazy (infinite!) sequence of repetitions of the items in coll."
@@ -2904,14 +2958,14 @@
   {:added "1.0"
    :static true}
   [n coll]
-    [(take n coll) (drop n coll)])
+  [(take n coll) (drop n coll)])
 
 (defn split-with
   "Returns a vector of [(take-while pred coll) (drop-while pred coll)]"
   {:added "1.0"
    :static true}
   [pred coll]
-    [(take-while pred coll) (drop-while pred coll)])
+  [(take-while pred coll) (drop-while pred coll)])
 
 (defn repeat
   "Returns a lazy (infinite!, or length n if supplied) sequence of xs."
@@ -2931,7 +2985,7 @@
   "Returns a lazy sequence of x, (f x), (f (f x)) etc. f must be free of side-effects"
   {:added "1.0"
    :static true}
-  [f x] (clojure.lang.Iterate/create f x) )
+  [f x] (clojure.lang.Iterate/create f x))
 
 (defn range
   "Returns a lazy seq of nums from start (inclusive) to end
@@ -2975,29 +3029,27 @@
   [f & maps]
   (when (some identity maps)
     (let [merge-entry (fn [m e]
-			(let [k (key e) v (val e)]
-			  (if (contains? m k)
-			    (assoc m k (f (get m k) v))
-			    (assoc m k v))))
+                        (let [k (key e) v (val e)]
+                          (if (contains? m k)
+                            (assoc m k (f (get m k) v))
+                            (assoc m k v))))
           merge2 (fn [m1 m2]
-		   (reduce1 merge-entry (or m1 {}) (seq m2)))]
+                   (reduce1 merge-entry (or m1 {}) (seq m2)))]
       (reduce1 merge2 maps))))
-
-
 
 (defn zipmap
   "Returns a map with the keys mapped to the corresponding vals."
   {:added "1.0"
    :static true}
   [keys vals]
-    (loop [map {}
-           ks (seq keys)
-           vs (seq vals)]
-      (if (and ks vs)
-        (recur (assoc map (first ks) (first vs))
-               (next ks)
-               (next vs))
-        map)))
+  (loop [map {}
+         ks (seq keys)
+         vs (seq vals)]
+    (if (and ks vs)
+      (recur (assoc map (first ks) (first vs))
+             (next ks)
+             (next vs))
+      map)))
 
 (defn line-seq
   "Returns the lines of text from rdr as a lazy sequence of strings.
@@ -3013,8 +3065,8 @@
   {:added "1.0"
    :static true}
   [pred]
-    (fn [x y]
-      (cond (pred x y) -1 (pred y x) 1 :else 0)))
+  (fn [x y]
+    (cond (pred x y) -1 (pred y x) 1 :else 0)))
 
 (defn sort
   "Returns a sorted sequence of the items in coll. If no comparator is
@@ -3083,20 +3135,20 @@
   {:added "1.0"
    :static true}
   [coll n]
-    (loop [n n xs (seq coll)]
-      (if (and xs (pos? n))
-        (recur (dec n) (next xs))
-        xs)))
+  (loop [n n xs (seq coll)]
+    (if (and xs (pos? n))
+      (recur (dec n) (next xs))
+      xs)))
 
 (defn nthrest
   "Returns the nth rest of coll, coll when n is 0."
   {:added "1.3"
    :static true}
   [coll n]
-    (loop [n n xs coll]
-      (if-let [xs (and (pos? n) (seq xs))]
-        (recur (dec n) (rest xs))
-        xs)))
+  (loop [n n xs coll]
+    (if-let [xs (and (pos? n) (seq xs))]
+      (recur (dec n) (rest xs))
+      xs)))
 
 (defn partition
   "Returns a lazy sequence of lists of n items each, at offsets step
@@ -3107,20 +3159,20 @@
   {:added "1.0"
    :static true}
   ([n coll]
-     (partition n n coll))
+   (partition n n coll))
   ([n step coll]
-     (lazy-seq
-       (when-let [s (seq coll)]
-         (let [p (doall (take n s))]
-           (when (= n (count p))
-             (cons p (partition n step (nthrest s step))))))))
+   (lazy-seq
+    (when-let [s (seq coll)]
+      (let [p (doall (take n s))]
+        (when (= n (count p))
+          (cons p (partition n step (nthrest s step))))))))
   ([n step pad coll]
-     (lazy-seq
-       (when-let [s (seq coll)]
-         (let [p (doall (take n s))]
-           (if (= n (count p))
-             (cons p (partition n step pad (nthrest s step)))
-             (list (take n (concat p pad)))))))))
+   (lazy-seq
+    (when-let [s (seq coll)]
+      (let [p (doall (take n s))]
+        (if (= n (count p))
+          (cons p (partition n step pad (nthrest s step)))
+          (list (take n (concat p pad)))))))))
 
 ;; evaluation
 
@@ -3137,8 +3189,8 @@
   {:added "1.0"}
   [seq-exprs & body]
   (assert-args
-     (vector? seq-exprs) "a vector for its binding"
-     (even? (count seq-exprs)) "an even number of forms in binding vector")
+   (vector? seq-exprs) "a vector for its binding"
+   (even? (count seq-exprs)) "an even number of forms in binding vector")
   (let [step (fn step [recform exprs]
                (if-not exprs
                  [true `(do ~@body)]
@@ -3160,15 +3212,15 @@
                                                ~recform)]))
                      (let [seq- (gensym "seq_")
                            chunk- (with-meta (gensym "chunk_")
-                                             {:tag 'clojure.lang.IChunk})
+                                    {:tag 'clojure.lang.IChunk})
                            count- (gensym "count_")
                            i- (gensym "i_")
                            recform `(recur (next ~seq-) nil 0 0)
                            steppair (step recform (nnext exprs))
                            needrec (steppair 0)
                            subform (steppair 1)
-                           recform-chunk 
-                             `(recur ~seq- ~chunk- ~count- (unchecked-inc ~i-))
+                           recform-chunk
+                           `(recur ~seq- ~chunk- ~count- (unchecked-inc ~i-))
                            steppair-chunk (step recform-chunk (nnext exprs))
                            subform-chunk (steppair-chunk 1)]
                        [true
@@ -3197,18 +3249,18 @@
    :static true}
   [& agents]
   (io! "await in transaction"
-    (when *agent*
-      (throw (new Exception "Can't await in agent action")))
-    (let [latch (new java.util.concurrent.CountDownLatch (count agents))
-          count-down (fn [agent] (. latch (countDown)) agent)]
-      (doseq [agent agents]
-        (send agent count-down))
-      (. latch (await)))))
+       (when *agent*
+         (throw (new Exception "Can't await in agent action")))
+       (let [latch (new java.util.concurrent.CountDownLatch (count agents))
+             count-down (fn [agent] (. latch (countDown)) agent)]
+         (doseq [agent agents]
+           (send agent count-down))
+         (. latch (await)))))
 
 (defn ^:static await1 [^clojure.lang.Agent a]
   (when (pos? (.getQueueCount a))
     (await a))
-    a)
+  a)
 
 (defn await-for
   "Blocks the current thread until all actions dispatched thus
@@ -3218,14 +3270,14 @@
   {:added "1.0"
    :static true}
   [timeout-ms & agents]
-    (io! "await-for in transaction"
-     (when *agent*
-       (throw (new Exception "Can't await in agent action")))
-     (let [latch (new java.util.concurrent.CountDownLatch (count agents))
-           count-down (fn [agent] (. latch (countDown)) agent)]
-       (doseq [agent agents]
+  (io! "await-for in transaction"
+       (when *agent*
+         (throw (new Exception "Can't await in agent action")))
+       (let [latch (new java.util.concurrent.CountDownLatch (count agents))
+             count-down (fn [agent] (. latch (countDown)) agent)]
+         (doseq [agent agents]
            (send agent count-down))
-       (. latch (await  timeout-ms (. java.util.concurrent.TimeUnit MILLISECONDS))))))
+         (. latch (await  timeout-ms (. java.util.concurrent.TimeUnit MILLISECONDS))))))
 
 (defmacro dotimes
   "bindings => name n
@@ -3235,8 +3287,8 @@
   {:added "1.0"}
   [bindings & body]
   (assert-args
-     (vector? bindings) "a vector for its binding"
-     (= 2 (count bindings)) "exactly 2 forms in binding vector")
+   (vector? bindings) "a vector for its binding"
+   (= 2 (count bindings)) "exactly 2 forms in binding vector")
   (let [i (first bindings)
         n (second bindings)]
     `(let [n# (long ~n)]
@@ -3245,25 +3297,15 @@
            ~@body
            (recur (unchecked-inc ~i)))))))
 
-#_(defn into
-  "Returns a new coll consisting of to-coll with all of the items of
-  from-coll conjoined."
-  {:added "1.0"}
-  [to from]
-    (let [ret to items (seq from)]
-      (if items
-        (recur (conj ret (first items)) (next items))
-        ret)))
-
 ;;;;;;;;;;;;;;;;;;;;; editable collections ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn transient 
+(defn transient
   "Returns a new, transient version of the collection, in constant time."
   {:added "1.1"
    :static true}
-  [^clojure.lang.IEditableCollection coll] 
+  [^clojure.lang.IEditableCollection coll]
   (.asTransient coll))
 
-(defn persistent! 
+(defn persistent!
   "Returns a new, persistent version of the transient collection, in
   constant time. The transient collection cannot be used after this
   call, any such use will throw an exception."
@@ -3280,7 +3322,7 @@
   ([] (transient []))
   ([coll] coll)
   ([^clojure.lang.ITransientCollection coll x]
-     (.conj coll x)))
+   (.conj coll x)))
 
 (defn assoc!
   "When applied to a transient map, adds mapping of key(s) to
@@ -3311,13 +3353,13 @@
   the collection is empty, throws an exception. Returns coll"
   {:added "1.1"
    :static true}
-  [^clojure.lang.ITransientVector coll] 
-  (.pop coll)) 
+  [^clojure.lang.ITransientVector coll]
+  (.pop coll))
 
 (defn disj!
   "disj[oin]. Returns a transient set of the same (hashed/sorted) type, that
   does not contain key(s)."
-  {:added "1.1"
+  {:added  "1.1"
    :static true}
   ([set] set)
   ([^clojure.lang.ITransientSet set key]
@@ -3328,7 +3370,7 @@
        (recur ret (first ks) (next ks))
        ret))))
 
-;redef into with batch support
+;; redef into with batch support
 (defn ^:private into1
   "Returns a new coll consisting of to-coll with all of the items of
   from-coll conjoined."
@@ -3339,7 +3381,7 @@
     (persistent! (reduce1 conj! (transient to) from))
     (reduce1 conj to from)))
 
-(defmacro import 
+(defmacro import
   "import-list => (package-symbol class-name-symbols*)
 
   For each name in class-name-symbols, adds a mapping from name to the
@@ -3347,15 +3389,15 @@
   macro in preference to calling this directly."
   {:added "1.0"}
   [& import-symbols-or-lists]
-  (let [specs (map #(if (and (seq? %) (= 'quote (first %))) (second %) %) 
+  (let [specs (map #(if (and (seq? %) (= 'quote (first %))) (second %) %)
                    import-symbols-or-lists)]
     `(do ~@(map #(list 'clojure.core/import* %)
-                (reduce1 (fn [v spec] 
-                          (if (symbol? spec)
-                            (conj v (name spec))
-                            (let [p (first spec) cs (rest spec)]
-                              (into1 v (map #(str p "." %) cs)))))
-                        [] specs)))))
+                (reduce1 (fn [v spec]
+                           (if (symbol? spec)
+                             (conj v (name spec))
+                             (let [p (first spec) cs (rest spec)]
+                               (into1 v (map #(str p "." %) cs)))))
+                         [] specs)))))
 
 (defn into-array
   "Returns an array with components set to the values in aseq. The array's
@@ -3366,13 +3408,13 @@
   {:added "1.0"
    :static true}
   ([aseq]
-     (clojure.lang.RT/seqToTypedArray (seq aseq)))
+   (clojure.lang.RT/seqToTypedArray (seq aseq)))
   ([type aseq]
-     (clojure.lang.RT/seqToTypedArray type (seq aseq))))
+   (clojure.lang.RT/seqToTypedArray type (seq aseq))))
 
 (defn ^{:private true}
   array [& items]
-    (into-array items))
+  (into-array items))
 
 (defn class
   "Returns the Class of x"
@@ -3380,7 +3422,7 @@
    :static true}
   ^Class [^Object x] (if (nil? x) x (. x (getClass))))
 
-(defn type 
+(defn type
   "Returns the :type metadata of x, or its Class if none"
   {:added "1.0"
    :static true}
@@ -3432,8 +3474,7 @@
 
 (defn boolean
   "Coerce to boolean"
-  {
-   :inline (fn  [x] `(. clojure.lang.RT (booleanCast ~x)))
+  {:inline (fn  [x] `(. clojure.lang.RT (booleanCast ~x)))
    :added "1.0"}
   [x] (clojure.lang.RT/booleanCast x))
 
@@ -3479,7 +3520,6 @@
    :added "1.3"}
   [^Number x] (clojure.lang.RT/uncheckedDoubleCast x))
 
-
 (defn number?
   "Returns true if x is a Number"
   {:added "1.0"
@@ -3491,10 +3531,10 @@
   "Modulus of num and div. Truncates toward negative infinity."
   {:added "1.0"
    :static true}
-  [num div] 
-  (let [m (rem num div)] 
+  [num div]
+  (let [m (rem num div)]
     (if (or (zero? m) (= (pos? num) (pos? div)))
-      m 
+      m
       (+ m div))))
 
 (defn ratio?
@@ -3533,7 +3573,7 @@
   (or (instance? Double n)
       (instance? Float n)))
 
-(defn rational? 
+(defn rational?
   "Returns true if n is a rational number"
   {:added "1.0"
    :static true}
@@ -3542,50 +3582,56 @@
 
 (defn bigint
   "Coerce to BigInt"
-  {:tag clojure.lang.BigInt
+  {:tag    clojure.lang.BigInt
    :static true
-   :added "1.3"}
-  [x] (cond
-       (instance? clojure.lang.BigInt x) x
-       (instance? BigInteger x) (clojure.lang.BigInt/fromBigInteger x)
-       (decimal? x) (bigint (.toBigInteger ^BigDecimal x))
-       (float? x)  (bigint (. BigDecimal valueOf (double x)))
-       (ratio? x) (bigint (.bigIntegerValue ^clojure.lang.Ratio x))
-       (number? x) (clojure.lang.BigInt/valueOf (long x))
-       :else (bigint (BigInteger. x))))
+   :added  "1.3"}
+  [x]
+  (cond
+    (instance? clojure.lang.BigInt x) x
+    (instance? BigInteger x)          (clojure.lang.BigInt/fromBigInteger x)
+    (decimal? x)                      (bigint (.toBigInteger ^BigDecimal x))
+    (float? x)                        (bigint (. BigDecimal valueOf (double x)))
+    (ratio? x)                        (bigint (.bigIntegerValue ^clojure.lang.Ratio x))
+    (number? x)                       (clojure.lang.BigInt/valueOf (long x))
+    :else                             (bigint (BigInteger. x))))
 
 (defn biginteger
   "Coerce to BigInteger"
-  {:tag BigInteger
-   :added "1.0"
+  {:tag    BigInteger
+   :added  "1.0"
    :static true}
-  [x] (cond
-       (instance? BigInteger x) x
-       (instance? clojure.lang.BigInt x) (.toBigInteger ^clojure.lang.BigInt x)
-       (decimal? x) (.toBigInteger ^BigDecimal x)
-       (float? x) (.toBigInteger (. BigDecimal valueOf (double x)))
-       (ratio? x) (.bigIntegerValue ^clojure.lang.Ratio x)
-       (number? x) (BigInteger/valueOf (long x))
-       :else (BigInteger. x)))
+  [x]
+  (cond
+    (instance? BigInteger x)          x
+    (instance? clojure.lang.BigInt x) (.toBigInteger ^clojure.lang.BigInt x)
+    (decimal? x)                      (.toBigInteger ^BigDecimal x)
+    (float? x)                        (.toBigInteger (. BigDecimal valueOf (double x)))
+    (ratio? x)                        (.bigIntegerValue ^clojure.lang.Ratio x)
+    (number? x)                       (BigInteger/valueOf (long x))
+    :else                             (BigInteger. x)))
 
 (defn bigdec
   "Coerce to BigDecimal"
-  {:tag BigDecimal
-   :added "1.0"
+  {:tag    BigDecimal
+   :added  "1.0"
    :static true}
-  [x] (cond
-       (decimal? x) x
-       (float? x) (. BigDecimal valueOf (double x))
-       (ratio? x) (/ (BigDecimal. (.numerator ^clojure.lang.Ratio x)) (.denominator ^clojure.lang.Ratio x))
-       (instance? clojure.lang.BigInt x) (.toBigDecimal ^clojure.lang.BigInt x)
-       (instance? BigInteger x) (BigDecimal. ^BigInteger x)
-       (number? x) (BigDecimal/valueOf (long x))
-       :else (BigDecimal. x)))
+  [x]
+  (cond
+    (decimal? x)                      x
+    (float? x)                        (. BigDecimal valueOf (double x))
+    (ratio? x)                        (/ (BigDecimal. (.numerator ^clojure.lang.Ratio x)) (.denominator ^clojure.lang.Ratio x))
+    (instance? clojure.lang.BigInt x) (.toBigDecimal ^clojure.lang.BigInt x)
+    (instance? BigInteger x)          (BigDecimal. ^BigInteger x)
+    (number? x)                       (BigDecimal/valueOf (long x))
+    :else                             (BigDecimal. x)))
 
-(defmulti print-method (fn [x writer]
-                         (let [t (get (meta x) :type)]
-                           (if (keyword? t) t (class x)))))
-(defmulti print-dup (fn [x writer] (class x)))
+(defmulti print-method
+  (fn [x writer]
+    (let [t (get (meta x) :type)]
+      (if (keyword? t) t (class x)))))
+
+(defmulti print-dup
+  (fn [x writer] (class x)))
 
 (defn pr-on
   {:private true
@@ -3605,7 +3651,7 @@
    :added "1.0"}
   ([] nil)
   ([x]
-     (pr-on x *out*))
+   (pr-on x *out*))
   ([x & more]
    (pr x)
    (. *out* (append \space))
@@ -3614,15 +3660,15 @@
      (apply pr more))))
 
 (def ^:private ^String system-newline
-     (System/getProperty "line.separator"))
+  (System/getProperty "line.separator"))
 
 (defn newline
   "Writes a platform-specific newline to *out*"
   {:added "1.0"
    :static true}
   []
-    (. *out* (append system-newline))
-    nil)
+  (. *out* (append system-newline))
+  nil)
 
 (defn flush
   "Flushes the output stream that is the current value of
@@ -3630,18 +3676,18 @@
   {:added "1.0"
    :static true}
   []
-    (. *out* (flush))
-    nil)
+  (. *out* (flush))
+  nil)
 
 (defn prn
   "Same as pr followed by (newline). Observes *flush-on-newline*"
   {:added "1.0"
    :static true}
   [& more]
-    (apply pr more)
-    (newline)
-    (when *flush-on-newline*
-      (flush)))
+  (apply pr more)
+  (newline)
+  (when *flush-on-newline*
+    (flush)))
 
 (defn print
   "Prints the object(s) to the output stream that is the current value
@@ -3649,16 +3695,16 @@
   {:added "1.0"
    :static true}
   [& more]
-    (binding [*print-readably* nil]
-      (apply pr more)))
+  (binding [*print-readably* nil]
+    (apply pr more)))
 
 (defn println
   "Same as print followed by (newline)"
   {:added "1.0"
    :static true}
   [& more]
-    (binding [*print-readably* nil]
-      (apply prn more)))
+  (binding [*print-readably* nil]
+    (apply prn more)))
 
 (defn read
   "Reads the next object from stream, which must be an instance of
@@ -3733,8 +3779,8 @@
   {:added "1.0"}
   [bindings & body]
   (assert-args
-     (vector? bindings) "a vector for its binding"
-     (even? (count bindings)) "an even number of forms in binding vector")
+   (vector? bindings) "a vector for its binding"
+   (even? (count bindings)) "an even number of forms in binding vector")
   (cond
     (= (count bindings) 0) `(do ~@body)
     (symbol? (bindings 0)) `(let ~(subvec bindings 0 2)
@@ -3743,7 +3789,7 @@
                                 (finally
                                   (. ~(bindings 0) close))))
     :else (throw (IllegalArgumentException.
-                   "with-open only allows Symbols in bindings"))))
+                  "with-open only allows Symbols in bindings"))))
 
 (defmacro doto
   "Evaluates x then calls all of the methods and functions with the
@@ -3753,14 +3799,14 @@
   (doto (new java.util.HashMap) (.put \"a\" 1) (.put \"b\" 2))"
   {:added "1.0"}
   [x & forms]
-    (let [gx (gensym)]
-      `(let [~gx ~x]
-         ~@(map (fn [f]
-                  (if (seq? f)
-                    `(~(first f) ~gx ~@(next f))
-                    `(~f ~gx)))
-                forms)
-         ~gx)))
+  (let [gx (gensym)]
+    `(let [~gx ~x]
+       ~@(map (fn [f]
+                (if (seq? f)
+                  `(~(first f) ~gx ~@(next f))
+                  `(~f ~gx)))
+              forms)
+       ~gx)))
 
 (defmacro memfn
   "Expands into code that creates a fn that expects to be passed an
@@ -3777,15 +3823,13 @@
 
 (defmacro time
   "Evaluates expr and prints the time it took.  Returns the value of
- expr."
+  expr."
   {:added "1.0"}
   [expr]
   `(let [start# (. System (nanoTime))
          ret# ~expr]
      (prn (str "Elapsed time: " (/ (double (- (. System (nanoTime)) start#)) 1000000.0) " msecs"))
      ret#))
-
-
 
 (import '(java.lang.reflect Array))
 
@@ -3829,13 +3873,13 @@
 (defmacro
   ^{:private true}
   def-aset [name method coerce]
-    `(defn ~name
-       {:arglists '([~'array ~'idx ~'val] [~'array ~'idx ~'idx2 & ~'idxv])}
-       ([array# idx# val#]
-        (. Array (~method array# idx# (~coerce val#)))
-        val#)
-       ([array# idx# idx2# & idxv#]
-        (apply ~name (aget array# idx#) idx2# idxv#))))
+  `(defn ~name
+     {:arglists '([~'array ~'idx ~'val] [~'array ~'idx ~'idx2 & ~'idxv])}
+     ([array# idx# val#]
+      (. Array (~method array# idx# (~coerce val#)))
+      val#)
+     ([array# idx# idx2# & idxv#]
+      (apply ~name (aget array# idx#) idx2# idxv#))))
 
 (def-aset
   ^{:doc "Sets the value at the index/indices. Works on arrays of int. Returns val."
@@ -3902,12 +3946,12 @@
    :added "1.0"
    :static true}
   [^java.util.Collection coll]
-    (let [ret (make-array (. Class (forName "[Ljava.lang.Object;")) (. coll (size)))]
-      (loop [i 0 xs (seq coll)]
-        (when xs
-          (aset ret i (to-array (first xs)))
-          (recur (inc i) (next xs))))
-      ret))
+  (let [ret (make-array (. Class (forName "[Ljava.lang.Object;")) (. coll (size)))]
+    (loop [i 0 xs (seq coll)]
+      (when xs
+        (aset ret i (to-array (first xs)))
+        (recur (inc i) (next xs))))
+    ret))
 
 (defn macroexpand-1
   "If form represents a macro form, returns its expansion,
@@ -3915,7 +3959,7 @@
   {:added "1.0"
    :static true}
   [form]
-    (. clojure.lang.Compiler (macroexpand1 form)))
+  (. clojure.lang.Compiler (macroexpand1 form)))
 
 (defn macroexpand
   "Repeatedly calls macroexpand-1 on form until it no longer
@@ -3924,17 +3968,17 @@
   {:added "1.0"
    :static true}
   [form]
-    (let [ex (macroexpand-1 form)]
-      (if (identical? ex form)
-        form
-        (macroexpand ex))))
+  (let [ex (macroexpand-1 form)]
+    (if (identical? ex form)
+      form
+      (macroexpand ex))))
 
 (defn create-struct
   "Returns a structure basis object."
   {:added "1.0"
    :static true}
   [& keys]
-    (. clojure.lang.PersistentStructMap (createSlotMap keys)))
+  (. clojure.lang.PersistentStructMap (createSlotMap keys)))
 
 (defmacro defstruct
   "Same as (def name (create-struct keys...))"
@@ -3951,7 +3995,7 @@
   {:added "1.0"
    :static true}
   [s & inits]
-    (. clojure.lang.PersistentStructMap (create s inits)))
+  (. clojure.lang.PersistentStructMap (create s inits)))
 
 (defn struct
   "Returns a new structmap instance with the keys of the
@@ -3960,7 +4004,7 @@
   {:added "1.0"
    :static true}
   [s & vals]
-    (. clojure.lang.PersistentStructMap (construct s vals)))
+  (. clojure.lang.PersistentStructMap (construct s vals)))
 
 (defn accessor
   "Returns a fn that, given an instance of a structmap with the basis,
@@ -3971,7 +4015,7 @@
   {:added "1.0"
    :static true}
   [s key]
-    (. clojure.lang.PersistentStructMap (getAccessor s key)))
+  (. clojure.lang.PersistentStructMap (getAccessor s key)))
 
 (defn load-reader
   "Sequentially read and evaluate the set of forms contained in the
@@ -4008,14 +4052,14 @@
       (persistent! (reduce1 conj! (transient #{}) coll)))))
 
 (defn ^{:private true
-   :static true}
+        :static true}
   filter-key [keyfn pred amap]
-    (loop [ret {} es (seq amap)]
-      (if es
-        (if (pred (keyfn (first es)))
-          (recur (assoc ret (key (first es)) (val (first es))) (next es))
-          (recur ret (next es)))
-        ret)))
+  (loop [ret {} es (seq amap)]
+    (if es
+      (if (pred (keyfn (first es)))
+        (recur (assoc ret (key (first es)) (val (first es))) (next es))
+        (recur ret (next es)))
+      ret)))
 
 (defn ns?
   "Type predicate. Returns true if o is a Namespace."
@@ -4054,12 +4098,12 @@
   "If passed a namespace, returns it. Else, when passed a symbol,
   returns the namespace named by it, throwing an exception if not
   found."
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
   ^clojure.lang.Namespace [x]
-  (if (ns? x) x
-    (or (find-ns x)
-        (throw (Exception. (str "No namespace: " x " found"))))))
+  (or (when (ns? x) x)
+      (find-ns x)
+      (throw (Exception. (str "No namespace: " x " found")))))
 
 (defn ns-name
   "Returns the name of the namespace, a symbol."
@@ -4082,19 +4126,17 @@
   [ns sym]
   (.unmap (the-ns ns) sym))
 
-;(defn export [syms]
-;  (doseq [sym syms]
-;   (.. *ns* (intern sym) (setExported true))))
-
 (defn ns-publics
   "Returns a map of the public intern mappings for the namespace."
   {:added "1.0"
    :static true}
   [ns]
   (let [ns (the-ns ns)]
-    (filter-key val (fn [^clojure.lang.Var v] (and (instance? clojure.lang.Var v)
-                                 (= ns (.ns v))
-                                 (.isPublic v)))
+    (filter-key val
+                (fn [v]
+                  (and (instance? clojure.lang.Var v)
+                       (= ns (.ns ^clojure.lang.Var v))
+                       (.isPublic ^clojure.lang.Var v)))
                 (ns-map ns))))
 
 (defn ns-imports
@@ -4110,8 +4152,10 @@
    :static true}
   [ns]
   (let [ns (the-ns ns)]
-    (filter-key val (fn [^clojure.lang.Var v] (and (instance? clojure.lang.Var v)
-                                 (= ns (.ns v))))
+    (filter-key val
+                (fn [v]
+                  (and (instance? clojure.lang.Var v)
+                       (= ns (.ns ^clojure.lang.Var v))))
                 (ns-map ns))))
 
 ;; FIXME: not really how I want to do this in the long run but correct for now.
@@ -4189,8 +4233,10 @@
    :static true}
   [ns]
   (let [ns (the-ns ns)]
-    (filter-key val (fn [^clojure.lang.Var v] (and (instance? clojure.lang.Var v)
-                                 (not= ns (.ns v))))
+    (filter-key val
+                (fn [v]
+                  (and (instance? clojure.lang.Var v)
+                       (not= ns (.ns ^clojure.lang.Var v))))
                 (ns-map ns))))
 
 (defn alias
@@ -4230,20 +4276,20 @@
   {:added "1.0"
    :static true}
   ([n]
-     (fn [rf]
-       (let [iv (volatile! -1)]
-         (fn
-           ([] (rf))
-           ([result] (rf result))
-           ([result input]
-              (let [i (vswap! iv inc)]
-                (if (zero? (rem i n))
-                  (rf result input)
-                  result)))))))
+   (fn [rf]
+     (let [iv (volatile! -1)]
+       (fn
+         ([] (rf))
+         ([result] (rf result))
+         ([result input]
+          (let [i (vswap! iv inc)]
+            (if (zero? (rem i n))
+              (rf result input)
+              result)))))))
   ([n coll]
-     (lazy-seq
-      (when-let [s (seq coll)]
-        (cons (first s) (take-nth n (drop n s)))))))
+   (lazy-seq
+    (when-let [s (seq coll)]
+      (cons (first s) (take-nth n (drop n s)))))))
 
 (defn interleave
   "Returns a lazy seq of the first item in each coll, then the second etc."
@@ -4252,16 +4298,16 @@
   ([] ())
   ([c1] (lazy-seq c1))
   ([c1 c2]
-     (lazy-seq
-      (let [s1 (seq c1) s2 (seq c2)]
-        (when (and s1 s2)
-          (cons (first s1) (cons (first s2) 
-                                 (interleave (rest s1) (rest s2))))))))
-  ([c1 c2 & colls] 
-     (lazy-seq 
-      (let [ss (map seq (conj colls c2 c1))]
-        (when (every? identity ss)
-          (concat (map first ss) (apply interleave (map rest ss))))))))
+   (lazy-seq
+    (let [s1 (seq c1) s2 (seq c2)]
+      (when (and s1 s2)
+        (cons (first s1) (cons (first s2)
+                               (interleave (rest s1) (rest s2))))))))
+  ([c1 c2 & colls]
+   (lazy-seq
+    (let [ss (map seq (conj colls c2 c1))]
+      (when (every? identity ss)
+        (concat (map first ss) (apply interleave (map rest ss))))))))
 
 (defn var-get
   "Gets the value in the var object"
@@ -4271,7 +4317,7 @@
 
 (defn var-set
   "Sets the value in the var object to val. The var must be
- thread-locally bound."
+  thread-locally bound."
   {:added "1.0"
    :static true}
   [^clojure.lang.Var x val] (. x (set val)))
@@ -4286,14 +4332,14 @@
   {:added "1.0"}
   [name-vals-vec & body]
   (assert-args
-     (vector? name-vals-vec) "a vector for its binding"
-     (even? (count name-vals-vec)) "an even number of forms in binding vector")
+   (vector? name-vals-vec) "a vector for its binding"
+   (even? (count name-vals-vec)) "an even number of forms in binding vector")
   `(let [~@(interleave (take-nth 2 name-vals-vec)
                        (repeat '(.. clojure.lang.Var create setDynamic)))]
      (. clojure.lang.Var (pushThreadBindings (hash-map ~@name-vals-vec)))
      (try
-      ~@body
-      (finally (. clojure.lang.Var (popThreadBindings))))))
+       ~@body
+       (finally (. clojure.lang.Var (popThreadBindings))))))
 
 (defn ns-resolve
   "Returns the var or Class to which a symbol will be resolved in the
@@ -4303,10 +4349,10 @@
   {:added "1.0"
    :static true}
   ([ns sym]
-    (ns-resolve ns nil sym))
+   (ns-resolve ns nil sym))
   ([ns env sym]
-    (when-not (contains? env sym)
-      (clojure.lang.Compiler/maybeResolveIn (the-ns ns) sym))))
+   (when-not (contains? env sym)
+     (clojure.lang.Compiler/maybeResolveIn (the-ns ns) sym))))
 
 (defn resolve
   "same as (ns-resolve *ns* symbol) or (ns-resolve *ns* &env symbol)"
@@ -4322,70 +4368,70 @@
    :static true}
   ([] (. clojure.lang.PersistentArrayMap EMPTY))
   ([& keyvals]
-     (clojure.lang.PersistentArrayMap/createAsIfByAssoc (to-array keyvals))))
+   (clojure.lang.PersistentArrayMap/createAsIfByAssoc (to-array keyvals))))
 
-;redefine let and loop  with destructuring
+;; redefine let and loop  with destructuring
 (defn destructure [bindings]
   (let [bents (partition 2 bindings)
         pb (fn pb [bvec b v]
-               (let [pvec
-                     (fn [bvec b val]
-                       (let [gvec (gensym "vec__")]
-                         (loop [ret (-> bvec (conj gvec) (conj val))
-                                n 0
-                                bs b
-                                seen-rest? false]
-                           (if (seq bs)
-                             (let [firstb (first bs)]
-                               (cond
-                                (= firstb '&) (recur (pb ret (second bs) (list `nthnext gvec n))
-                                                     n
-                                                     (nnext bs)
-                                                     true)
-                                (= firstb :as) (pb ret (second bs) gvec)
-                                :else (if seen-rest?
-                                        (throw (new Exception "Unsupported binding form, only :as can follow & parameter"))
-                                        (recur (pb ret firstb  (list `nth gvec n nil))
-                                               (inc n)
-                                               (next bs)
-                                               seen-rest?))))
-                             ret))))
-                     pmap
-                     (fn [bvec b v]
-                       (let [gmap (gensym "map__")
-                             gmapseq (with-meta gmap {:tag 'clojure.lang.ISeq})
-                             defaults (:or b)]
-                         (loop [ret (-> bvec (conj gmap) (conj v)
-                                        (conj gmap) (conj `(if (map? ~gmap) ~gmap (clojure.lang.PersistentHashMap/create (seq ~gmapseq))))
-                                        ((fn [ret]
-                                           (if (:as b)
-                                             (conj ret (:as b) gmap)
-                                             ret))))
-                                bes (reduce1
-                                     (fn [bes entry]
-                                       (reduce1 #(assoc %1 %2 ((val entry) %2))
-                                               (dissoc bes (key entry))
-                                               ((key entry) bes)))
-                                     (dissoc b :as :or)
-                                     {:keys #(if (keyword? %) % (keyword (str %))),
-                                      :strs str, :syms #(list `quote %)})]
-                           (if (seq bes)
-                             (let [bb (key (first bes))
-                                   bk (val (first bes))
-                                   bv (if (contains? defaults bb)
-                                        (list `get gmap bk (defaults bb))
-                                        (list `get gmap bk))]
-                               (recur (cond
-                                        (symbol? bb) (-> ret (conj (if (namespace bb) (symbol (name bb)) bb)) (conj bv))
-                                        (keyword? bb) (-> ret (conj (symbol (name bb)) bv))
-                                        :else (pb ret bb bv))
-                                      (next bes)))
-                             ret))))]
-                 (cond
-                   (symbol? b) (-> bvec (conj b) (conj v))
-                   (vector? b) (pvec bvec b v)
-                   (map? b) (pmap bvec b v)
-                   :else (throw (new Exception (str "Unsupported binding form: " b))))))
+             (let [pvec
+                   (fn [bvec b val]
+                     (let [gvec (gensym "vec__")]
+                       (loop [ret (-> bvec (conj gvec) (conj val))
+                              n 0
+                              bs b
+                              seen-rest? false]
+                         (if (seq bs)
+                           (let [firstb (first bs)]
+                             (cond
+                               (= firstb '&) (recur (pb ret (second bs) (list `nthnext gvec n))
+                                                    n
+                                                    (nnext bs)
+                                                    true)
+                               (= firstb :as) (pb ret (second bs) gvec)
+                               :else (if seen-rest?
+                                       (throw (new Exception "Unsupported binding form, only :as can follow & parameter"))
+                                       (recur (pb ret firstb  (list `nth gvec n nil))
+                                              (inc n)
+                                              (next bs)
+                                              seen-rest?))))
+                           ret))))
+                   pmap
+                   (fn [bvec b v]
+                     (let [gmap (gensym "map__")
+                           gmapseq (with-meta gmap {:tag 'clojure.lang.ISeq})
+                           defaults (:or b)]
+                       (loop [ret (-> bvec (conj gmap) (conj v)
+                                      (conj gmap) (conj `(if (map? ~gmap) ~gmap (clojure.lang.PersistentHashMap/create (seq ~gmapseq))))
+                                      ((fn [ret]
+                                         (if (:as b)
+                                           (conj ret (:as b) gmap)
+                                           ret))))
+                              bes (reduce1
+                                   (fn [bes entry]
+                                     (reduce1 #(assoc %1 %2 ((val entry) %2))
+                                              (dissoc bes (key entry))
+                                              ((key entry) bes)))
+                                   (dissoc b :as :or)
+                                   {:keys #(if (keyword? %) % (keyword (str %))),
+                                    :strs str, :syms #(list `quote %)})]
+                         (if (seq bes)
+                           (let [bb (key (first bes))
+                                 bk (val (first bes))
+                                 bv (if (contains? defaults bb)
+                                      (list `get gmap bk (defaults bb))
+                                      (list `get gmap bk))]
+                             (recur (cond
+                                      (symbol? bb) (-> ret (conj (if (namespace bb) (symbol (name bb)) bb)) (conj bv))
+                                      (keyword? bb) (-> ret (conj (symbol (name bb)) bv))
+                                      :else (pb ret bb bv))
+                                    (next bes)))
+                           ret))))]
+               (cond
+                 (symbol? b) (-> bvec (conj b) (conj v))
+                 (vector? b) (pvec bvec b v)
+                 (map? b) (pmap bvec b v)
+                 :else (throw (new Exception (str "Unsupported binding form: " b))))))
         process-entry (fn [bvec b] (pb bvec (first b) (second b)))]
     (if (every? symbol? (map first bents))
       bindings
@@ -4400,8 +4446,8 @@
   {:added "1.0", :special-form true, :forms '[(let [bindings*] exprs*)]}
   [bindings & body]
   (assert-args
-     (vector? bindings) "a vector for its binding"
-     (even? (count bindings)) "an even number of forms in binding vector")
+   (vector? bindings) "a vector for its binding"
+   (even? (count bindings)) "an even number of forms in binding vector")
   `(let* ~(destructure bindings) ~@body))
 
 (defn ^{:private true}
@@ -4422,7 +4468,7 @@
           (let ~lets
             ~@body))))))
 
-;redefine fn with destructuring and pre/post conditions
+;; redefine fn with destructuring and pre/post conditions
 (defmacro fn
   "params => positional-params* , or positional-params* & next-param
   positional-param => binding-form
@@ -4431,59 +4477,59 @@
 
   Defines a function"
   {:added "1.0", :special-form true,
-   :forms '[(fn name? [params* ] exprs*) (fn name? ([params* ] exprs*)+)]}
+   :forms '[(fn name? [params*] exprs*) (fn name? ([params*] exprs*) +)]}
   [& sigs]
-    (let [name (if (symbol? (first sigs)) (first sigs) nil)
-          sigs (if name (next sigs) sigs)
-          sigs (if (vector? (first sigs)) 
-                 (list sigs) 
-                 (if (seq? (first sigs))
-                   sigs
-                   ;; Assume single arity syntax
-                   (throw (IllegalArgumentException. 
-                            (if (seq sigs)
-                              (str "Parameter declaration " 
-                                   (first sigs)
-                                   " should be a vector")
-                              (str "Parameter declaration missing"))))))
-          psig (fn* [sig]
-                 ;; Ensure correct type before destructuring sig
-                 (when (not (seq? sig))
-                   (throw (IllegalArgumentException.
-                            (str "Invalid signature " sig
-                                 " should be a list"))))
-                 (let [[params & body] sig
-                       _ (when (not (vector? params))
-                           (throw (IllegalArgumentException. 
-                                    (if (seq? (first sigs))
-                                      (str "Parameter declaration " params
-                                           " should be a vector")
-                                      (str "Invalid signature " sig
-                                           " should be a list")))))
-                       conds (when (and (next body) (map? (first body))) 
-                                           (first body))
-                       body (if conds (next body) body)
-                       conds (or conds (meta params))
-                       pre (:pre conds)
-                       post (:post conds)                       
-                       body (if post
-                              `((let [~'% ~(if (< 1 (count body)) 
-                                            `(do ~@body) 
-                                            (first body))]
-                                 ~@(map (fn* [c] `(assert ~c)) post)
-                                 ~'%))
-                              body)
-                       body (if pre
-                              (concat (map (fn* [c] `(assert ~c)) pre) 
-                                      body)
-                              body)]
-                   (maybe-destructured params body)))
-          new-sigs (map psig sigs)]
-      (with-meta
-        (if name
-          (list* 'fn* name new-sigs)
-          (cons 'fn* new-sigs))
-        (meta &form))))
+  (let [name (if (symbol? (first sigs)) (first sigs) nil)
+        sigs (if name (next sigs) sigs)
+        sigs (if (vector? (first sigs))
+               (list sigs)
+               (if (seq? (first sigs))
+                 sigs
+                 ;; Assume single arity syntax
+                 (throw (IllegalArgumentException.
+                         (if (seq sigs)
+                           (str "Parameter declaration "
+                                (first sigs)
+                                " should be a vector")
+                           (str "Parameter declaration missing"))))))
+        psig (fn* [sig]
+               ;; Ensure correct type before destructuring sig
+               (when (not (seq? sig))
+                 (throw (IllegalArgumentException.
+                         (str "Invalid signature " sig
+                              " should be a list"))))
+               (let [[params & body] sig
+                     _ (when (not (vector? params))
+                         (throw (IllegalArgumentException.
+                                 (if (seq? (first sigs))
+                                   (str "Parameter declaration " params
+                                        " should be a vector")
+                                   (str "Invalid signature " sig
+                                        " should be a list")))))
+                     conds (when (and (next body) (map? (first body)))
+                             (first body))
+                     body (if conds (next body) body)
+                     conds (or conds (meta params))
+                     pre (:pre conds)
+                     post (:post conds)
+                     body (if post
+                            `((let [~'% ~(if (< 1 (count body))
+                                           `(do ~@body)
+                                           (first body))]
+                                ~@(map (fn* [c] `(assert ~c)) post)
+                                ~'%))
+                            body)
+                     body (if pre
+                            (concat (map (fn* [c] `(assert ~c)) pre)
+                                    body)
+                            body)]
+                 (maybe-destructured params body)))
+        new-sigs (map psig sigs)]
+    (with-meta
+      (if name
+        (list* 'fn* name new-sigs)
+        (cons 'fn* new-sigs))
+      (meta &form))))
 
 (defmacro loop
   "Evaluates the exprs in a lexical context in which the symbols in
@@ -4491,24 +4537,24 @@
   therein. Acts as a recur target."
   {:added "1.0", :special-form true, :forms '[(loop [bindings*] exprs*)]}
   [bindings & body]
-    (assert-args
-      (vector? bindings) "a vector for its binding"
-      (even? (count bindings)) "an even number of forms in binding vector")
-    (let [db (destructure bindings)]
-      (if (= db bindings)
-        `(loop* ~bindings ~@body)
-        (let [vs (take-nth 2 (drop 1 bindings))
-              bs (take-nth 2 bindings)
-              gs (map (fn [b] (if (symbol? b) b (gensym))) bs)
-              bfs (reduce1 (fn [ret [b v g]]
-                            (if (symbol? b)
-                              (conj ret g v)
-                              (conj ret g v b g)))
-                          [] (map vector bs vs gs))]
-          `(let ~bfs
-             (loop* ~(vec (interleave gs gs))
-               (let ~(vec (interleave bs gs))
-                 ~@body)))))))
+  (assert-args
+   (vector? bindings) "a vector for its binding"
+   (even? (count bindings)) "an even number of forms in binding vector")
+  (let [db (destructure bindings)]
+    (if (= db bindings)
+      `(loop* ~bindings ~@body)
+      (let [vs (take-nth 2 (drop 1 bindings))
+            bs (take-nth 2 bindings)
+            gs (map (fn [b] (if (symbol? b) b (gensym))) bs)
+            bfs (reduce1 (fn [ret [b v g]]
+                           (if (symbol? b)
+                             (conj ret g v)
+                             (conj ret g v b g)))
+                         [] (map vector bs vs gs))]
+        `(let ~bfs
+           (loop* ~(vec (interleave gs gs))
+                  (let ~(vec (interleave bs gs))
+                    ~@body)))))))
 
 (defmacro when-first
   "bindings => x xs
@@ -4517,17 +4563,17 @@
   {:added "1.0"}
   [bindings & body]
   (assert-args
-     (vector? bindings) "a vector for its binding"
-     (= 2 (count bindings)) "exactly 2 forms in binding vector")
+   (vector? bindings) "a vector for its binding"
+   (= 2 (count bindings)) "exactly 2 forms in binding vector")
   (let [[x xs] bindings]
     `(when-let [xs# (seq ~xs)]
        (let [~x (first xs#)]
-           ~@body))))
+         ~@body))))
 
 (defmacro lazy-cat
   "Expands to code which yields a lazy sequence of the concatenation
   of the supplied colls.  Each coll expr is not evaluated until it is
-  needed. 
+  needed.
 
   (lazy-cat xs ys zs) === (concat (lazy-seq xs) (lazy-seq ys) (lazy-seq zs))"
   {:added "1.0"}
@@ -4547,14 +4593,14 @@
   {:added "1.0"}
   [seq-exprs body-expr]
   (assert-args
-     (vector? seq-exprs) "a vector for its binding"
-     (even? (count seq-exprs)) "an even number of forms in binding vector")
+   (vector? seq-exprs) "a vector for its binding"
+   (even? (count seq-exprs)) "an even number of forms in binding vector")
   (let [to-groups (fn [seq-exprs]
                     (reduce1 (fn [groups [k v]]
-                              (if (keyword? k)
-                                (conj (pop groups) (conj (peek groups) [k v]))
-                                (conj groups [k v])))
-                            [] (partition 2 seq-exprs)))
+                               (if (keyword? k)
+                                 (conj (pop groups) (conj (peek groups) [k v]))
+                                 (conj groups [k v])))
+                             [] (partition 2 seq-exprs)))
         err (fn [& msg] (throw (IllegalArgumentException. ^String (apply str msg))))
         emit-bind (fn emit-bind [[[bind expr & mod-pairs]
                                   & [[_ next-expr] :as next-groups]]]
@@ -4569,20 +4615,20 @@
                                                     (recur (rest ~gxs)))
                                      (keyword? k) (err "Invalid 'for' keyword " k)
                                      next-groups
-                                      `(let [iterys# ~(emit-bind next-groups)
-                                             fs# (seq (iterys# ~next-expr))]
-                                         (if fs#
-                                           (concat fs# (~giter (rest ~gxs)))
-                                           (recur (rest ~gxs))))
+                                     `(let [iterys# ~(emit-bind next-groups)
+                                            fs# (seq (iterys# ~next-expr))]
+                                        (if fs#
+                                          (concat fs# (~giter (rest ~gxs)))
+                                          (recur (rest ~gxs))))
                                      :else `(cons ~body-expr
                                                   (~giter (rest ~gxs)))))]
                       (if next-groups
                         #_"not the inner-most loop"
                         `(fn ~giter [~gxs]
                            (lazy-seq
-                             (loop [~gxs ~gxs]
-                               (when-first [~bind ~gxs]
-                                 ~(do-mod mod-pairs)))))
+                            (loop [~gxs ~gxs]
+                              (when-first [~bind ~gxs]
+                                ~(do-mod mod-pairs)))))
                         #_"inner-most loop"
                         (let [gi (gensym "i__")
                               gb (gensym "b__")
@@ -4593,33 +4639,33 @@
                                           (= k :when) `(if ~v
                                                          ~(do-cmod etc)
                                                          (recur
-                                                           (unchecked-inc ~gi)))
+                                                          (unchecked-inc ~gi)))
                                           (keyword? k)
-                                            (err "Invalid 'for' keyword " k)
+                                          (err "Invalid 'for' keyword " k)
                                           :else
-                                            `(do (chunk-append ~gb ~body-expr)
-                                                 (recur (unchecked-inc ~gi)))))]
+                                          `(do (chunk-append ~gb ~body-expr)
+                                               (recur (unchecked-inc ~gi)))))]
                           `(fn ~giter [~gxs]
                              (lazy-seq
-                               (loop [~gxs ~gxs]
-                                 (when-let [~gxs (seq ~gxs)]
-                                   (if (chunked-seq? ~gxs)
-                                     (let [c# (chunk-first ~gxs)
-                                           size# (int (count c#))
-                                           ~gb (chunk-buffer size#)]
-                                       (if (loop [~gi (int 0)]
-                                             (if (< ~gi size#)
-                                               (let [~bind (.nth c# ~gi)]
-                                                 ~(do-cmod mod-pairs))
-                                               true))
-                                         (chunk-cons
-                                           (chunk ~gb)
-                                           (~giter (chunk-rest ~gxs)))
-                                         (chunk-cons (chunk ~gb) nil)))
-                                     (let [~bind (first ~gxs)]
-                                       ~(do-mod mod-pairs)))))))))))]
+                              (loop [~gxs ~gxs]
+                                (when-let [~gxs (seq ~gxs)]
+                                  (if (chunked-seq? ~gxs)
+                                    (let [c# (chunk-first ~gxs)
+                                          size# (int (count c#))
+                                          ~gb (chunk-buffer size#)]
+                                      (if (loop [~gi (int 0)]
+                                            (if (< ~gi size#)
+                                              (let [~bind (.nth c# ~gi)]
+                                                ~(do-cmod mod-pairs))
+                                              true))
+                                        (chunk-cons
+                                         (chunk ~gb)
+                                         (~giter (chunk-rest ~gxs)))
+                                        (chunk-cons (chunk ~gb) nil)))
+                                    (let [~bind (first ~gxs)]
+                                      ~(do-mod mod-pairs)))))))))))]
     `(let [iter# ~(emit-bind (to-groups seq-exprs))]
-        (iter# ~(second seq-exprs)))))
+       (iter# ~(second seq-exprs)))))
 
 (defmacro comment
   "Ignores body, yields nil"
@@ -4652,8 +4698,8 @@
    :added "1.0"
    :static true}
   [& xs]
-    (with-out-str
-     (apply pr xs)))
+  (with-out-str
+    (apply pr xs)))
 
 (defn prn-str
   "prn to a string, returning it"
@@ -4662,7 +4708,7 @@
    :static true}
   [& xs]
   (with-out-str
-   (apply prn xs)))
+    (apply prn xs)))
 
 (defn print-str
   "print to a string, returning it"
@@ -4670,8 +4716,8 @@
    :added "1.0"
    :static true}
   [& xs]
-    (with-out-str
-     (apply print xs)))
+  (with-out-str
+    (apply print xs)))
 
 (defn println-str
   "println to a string, returning it"
@@ -4679,8 +4725,8 @@
    :added "1.0"
    :static true}
   [& xs]
-    (with-out-str
-     (apply println xs)))
+  (with-out-str
+    (apply println xs)))
 
 (import clojure.lang.ExceptionInfo clojure.lang.IExceptionInfo)
 (defn ex-info
@@ -4688,9 +4734,9 @@
    that carries a map of additional data."
   {:added "1.4"}
   ([msg map]
-     (ExceptionInfo. msg map))
+   (ExceptionInfo. msg map))
   ([msg map cause]
-     (ExceptionInfo. msg map cause)))
+   (ExceptionInfo. msg map cause)))
 
 (defn ex-data
   "Returns exception data (a map) if ex is an IExceptionInfo.
@@ -4705,23 +4751,23 @@
   logical true."
   {:added "1.0"}
   ([x]
-     (when *assert*
-       `(when-not ~x
-          (throw (new AssertionError (str "Assert failed: " (pr-str '~x)))))))
+   (when *assert*
+     `(when-not ~x
+        (throw (new AssertionError (str "Assert failed: " (pr-str '~x)))))))
   ([x message]
-     (when *assert*
-       `(when-not ~x
-          (throw (new AssertionError (str "Assert failed: " ~message "\n" (pr-str '~x))))))))
+   (when *assert*
+     `(when-not ~x
+        (throw (new AssertionError (str "Assert failed: " ~message "\n" (pr-str '~x))))))))
 
 (defn test
   "test [v] finds fn at key :test in var metadata and calls it,
   presuming failure will throw exception"
   {:added "1.0"}
   [v]
-    (let [f (:test (meta v))]
-      (if f
-        (do (f) :ok)
-        :no-test)))
+  (let [f (:test (meta v))]
+    (if f
+      (do (f) :ok)
+      :no-test)))
 
 (defn re-pattern
   "Returns an instance of java.util.regex.Pattern, for use, e.g. in
@@ -4740,7 +4786,7 @@
    :added "1.0"
    :static true}
   [^java.util.regex.Pattern re s]
-    (. re (matcher s)))
+  (. re (matcher s)))
 
 (defn re-groups
   "Returns the groups from the most recent match/find. If there are no
@@ -4750,13 +4796,13 @@
   {:added "1.0"
    :static true}
   [^java.util.regex.Matcher m]
-    (let [gc  (. m (groupCount))]
-      (if (zero? gc)
-        (. m (group))
-        (loop [ret [] c 0]
-          (if (<= c gc)
-            (recur (conj ret (. m (group c))) (inc c))
-            ret)))))
+  (let [gc  (. m (groupCount))]
+    (if (zero? gc)
+      (. m (group))
+      (loop [ret [] c 0]
+        (if (<= c gc)
+          (recur (conj ret (. m (group c))) (inc c))
+          ret)))))
 
 (defn re-seq
   "Returns a lazy sequence of successive matches of pattern in string,
@@ -4777,10 +4823,9 @@
   {:added "1.0"
    :static true}
   [^java.util.regex.Pattern re s]
-    (let [m (re-matcher re s)]
-      (when (. m (matches))
-        (re-groups m))))
-
+  (let [m (re-matcher re s)]
+    (when (. m (matches))
+      (re-groups m))))
 
 (defn re-find
   "Returns the next regex match, if any, of string to pattern, using
@@ -4813,7 +4858,7 @@
   "same as defn, yielding non-public def"
   {:added "1.0"}
   [name & decls]
-    (list* `defn (with-meta name (assoc (meta name) :private true)) decls))
+  (list* `defn (with-meta name (assoc (meta name) :private true)) decls))
 
 (defn tree-seq
   "Returns a lazy sequence of the nodes in a tree, via a depth-first walk.
@@ -4824,40 +4869,40 @@
   tree."
   {:added "1.0"
    :static true}
-   [branch? children root]
-   (let [walk (fn walk [node]
-                (lazy-seq
-                 (cons node
-                  (when (branch? node)
-                    (mapcat walk (children node))))))]
-     (walk root)))
+  [branch? children root]
+  (let [walk (fn walk [node]
+               (lazy-seq
+                (cons node
+                      (when (branch? node)
+                        (mapcat walk (children node))))))]
+    (walk root)))
 
 (defn file-seq
   "A tree seq on java.io.Files"
   {:added "1.0"
    :static true}
   [dir]
-    (tree-seq
-     (fn [^java.io.File f] (. f (isDirectory)))
-     (fn [^java.io.File d] (seq (. d (listFiles))))
-     dir))
+  (tree-seq
+   (fn [^java.io.File f] (. f (isDirectory)))
+   (fn [^java.io.File d] (seq (. d (listFiles))))
+   dir))
 
 (defn xml-seq
   "A tree seq on the xml elements as per xml/parse"
   {:added "1.0"
    :static true}
   [root]
-    (tree-seq
-     (complement string?)
-     (comp seq :content)
-     root))
+  (tree-seq
+   (complement string?)
+   (comp seq :content)
+   root))
 
 (defn special-symbol?
   "Returns true if s names a special form"
   {:added "1.0"
    :static true}
   [s]
-    (contains? (. clojure.lang.Compiler specials) s))
+  (contains? (. clojure.lang.Compiler specials) s))
 
 (defn var?
   "Returns true if v is of type clojure.lang.Var"
@@ -4910,15 +4955,13 @@
   ([coll]
    (let [step (fn step [xs seen]
                 (lazy-seq
-                  ((fn [[f :as xs] seen]
-                     (when-let [s (seq xs)]
-                       (if (contains? seen f)
-                         (recur (rest s) seen)
-                         (cons f (step (rest s) (conj seen f))))))
-                   xs seen)))]
+                 ((fn [[f :as xs] seen]
+                    (when-let [s (seq xs)]
+                      (if (contains? seen f)
+                        (recur (rest s) seen)
+                        (cons f (step (rest s) (conj seen f))))))
+                  xs seen)))]
      (step coll #{}))))
-
-
 
 (defn replace
   "Given a map of replacement pairs and a vector/collection, returns a
@@ -4928,15 +4971,15 @@
   {:added "1.0"
    :static true}
   ([smap]
-     (map #(if-let [e (find smap %)] (val e) %)))
+   (map #(if-let [e (find smap %)] (val e) %)))
   ([smap coll]
-     (if (vector? coll)
-       (reduce1 (fn [v i]
-                  (if-let [e (find smap (nth v i))]
-                    (assoc v i (val e))
-                    v))
-                coll (range (count coll)))
-       (map #(if-let [e (find smap %)] (val e) %) coll))))
+   (if (vector? coll)
+     (reduce1 (fn [v i]
+                (if-let [e (find smap (nth v i))]
+                  (assoc v i (val e))
+                  v))
+              coll (range (count coll)))
+     (map #(if-let [e (find smap %)] (val e) %) coll))))
 
 (defmacro dosync
   "Runs the exprs (in an implicit do) in a transaction that encompasses
@@ -4958,12 +5001,12 @@
   HALF_EVEN, UP, DOWN and UNNECESSARY; it defaults to HALF_UP."
   {:added "1.0"}
   [precision & exprs]
-    (let [[body rm] (if (= (first exprs) :rounding)
-                      [(next (next exprs))
-                       `((. java.math.RoundingMode ~(second exprs)))]
-                      [exprs nil])]
-      `(binding [*math-context* (java.math.MathContext. ~precision ~@rm)]
-         ~@body)))
+  (let [[body rm] (if (= (first exprs) :rounding)
+                    [(next (next exprs))
+                     `((. java.math.RoundingMode ~(second exprs)))]
+                    [exprs nil])]
+    `(binding [*math-context* (java.math.MathContext. ~precision ~@rm)]
+       ~@body)))
 
 (defn mk-bound-fn
   {:private true}
@@ -5015,7 +5058,7 @@
   ([n f] (take n (repeatedly f))))
 
 (defn add-classpath
-  "DEPRECATED 
+  "DEPRECATED
 
   Adds the url (String or URL object) to the classpath per
   URLClassLoader.addURL"
@@ -5032,7 +5075,6 @@
   {:added "1.0"
    :static true}
   [x] (. clojure.lang.Util (hasheq x)))
-
 
 (defn mix-collection-hash
   "Mix final collection hash for ordered or unordered collections.
@@ -5110,8 +5152,8 @@
 
 (defmacro amap
   "Maps an expression across an array a, using an index named idx, and
-  return value named ret, initialized to a clone of a, then setting 
-  each element of ret to the evaluation of expr, returning the new 
+  return value named ret, initialized to a clone of a, then setting
+  each element of ret to the evaluation of expr, returning the new
   array ret."
   {:added "1.0"}
   [a idx ret expr]
@@ -5126,7 +5168,7 @@
 
 (defmacro areduce
   "Reduces an expression across an array a, using an index named idx,
-  and return value named ret, initialized to init, setting ret to the 
+  and return value named ret, initialized to init, setting ret to the
   evaluation of expr at each step, returning ret."
   {:added "1.0"}
   [a idx ret init expr]
@@ -5261,8 +5303,8 @@
   ([s] (seque 100 s))
   ([n-or-q s]
    (let [^BlockingQueue q (if (instance? BlockingQueue n-or-q)
-                             n-or-q
-                             (LinkedBlockingQueue. (int n-or-q)))
+                            n-or-q
+                            (LinkedBlockingQueue. (int n-or-q)))
          NIL (Object.) ;nil sentinel since LBQ doesn't support nils
          agt (agent (lazy-seq s)) ; never start with nil; that signifies we've already put eos
          log-error (fn [q e]
@@ -5306,10 +5348,10 @@
        (.isAssignableFrom java.lang.annotation.Annotation c)))
 
 (defn- is-runtime-annotation? [^Class c]
-  (boolean 
+  (boolean
    (and (is-annotation? c)
-        (when-let [^java.lang.annotation.Retention r 
-                   (.getAnnotation c java.lang.annotation.Retention)] 
+        (when-let [^java.lang.annotation.Retention r
+                   (.getAnnotation c java.lang.annotation.Retention)]
           (= (.value r) java.lang.annotation.RetentionPolicy/RUNTIME)))))
 
 (defn- descriptor [^Class c] (clojure.asm.Type/getDescriptor c))
@@ -5317,26 +5359,26 @@
 (declare ^:private process-annotation)
 (defn- add-annotation [^clojure.asm.AnnotationVisitor av name v]
   (cond
-   (vector? v) (let [avec (.visitArray av name)]
-                 (doseq [vval v]
-                   (add-annotation avec "value" vval))
-                 (.visitEnd avec))
-   (symbol? v) (let [ev (eval v)]
-                 (cond 
-                  (instance? java.lang.Enum ev)
-                  (.visitEnum av name (descriptor (class ev)) (str ev))
-                  (class? ev) (.visit av name (clojure.asm.Type/getType ev))
-                  :else (throw (IllegalArgumentException. 
-                                (str "Unsupported annotation value: " v " of class " (class ev))))))
-   (seq? v) (let [[nested nv] v
-                  c (resolve nested)
-                  nav (.visitAnnotation av name (descriptor c))]
-              (process-annotation nav nv)
-              (.visitEnd nav))
-   :else (.visit av name v)))
+    (vector? v) (let [avec (.visitArray av name)]
+                  (doseq [vval v]
+                    (add-annotation avec "value" vval))
+                  (.visitEnd avec))
+    (symbol? v) (let [ev (eval v)]
+                  (cond
+                    (instance? java.lang.Enum ev)
+                    (.visitEnum av name (descriptor (class ev)) (str ev))
+                    (class? ev) (.visit av name (clojure.asm.Type/getType ev))
+                    :else (throw (IllegalArgumentException.
+                                  (str "Unsupported annotation value: " v " of class " (class ev))))))
+    (seq? v) (let [[nested nv] v
+                   c (resolve nested)
+                   nav (.visitAnnotation av name (descriptor c))]
+               (process-annotation nav nv)
+               (.visitEnd nav))
+    :else (.visit av name v)))
 
 (defn- process-annotation [av v]
-  (if (map? v) 
+  (if (map? v)
     (doseq [[k v] v]
       (add-annotation av (name k) v))
     (add-annotation av "value" v)))
@@ -5344,18 +5386,18 @@
 (defn- add-annotations
   ([visitor m] (add-annotations visitor m nil))
   ([visitor m i]
-     (doseq [[k v] m]
-       (when (symbol? k)
-         (when-let [c (resolve k)]
-           (when (is-annotation? c)
+   (doseq [[k v] m]
+     (when (symbol? k)
+       (when-let [c (resolve k)]
+         (when (is-annotation? c)
                                         ;this is known duck/reflective as no common base of ASM Visitors
-             (let [av (if i
-                        (.visitParameterAnnotation visitor i (descriptor c) 
-                                                   (is-runtime-annotation? c))
-                        (.visitAnnotation visitor (descriptor c) 
-                                          (is-runtime-annotation? c)))]
-               (process-annotation av v)
-               (.visitEnd av))))))))
+           (let [av (if i
+                      (.visitParameterAnnotation visitor i (descriptor c)
+                                                 (is-runtime-annotation? c))
+                      (.visitAnnotation visitor (descriptor c)
+                                        (is-runtime-annotation? c)))]
+             (process-annotation av v)
+             (.visitEnd av))))))))
 
 (defn alter-var-root
   "Atomically alters the root binding of var v by applying f to its
@@ -5387,7 +5429,7 @@
   [] {:parents {} :descendants {} :ancestors {}})
 
 (def ^{:private true}
-     global-hierarchy (make-hierarchy))
+  global-hierarchy (make-hierarchy))
 
 (defn not-empty
   "If coll is empty, returns nil, else coll"
@@ -5462,8 +5504,8 @@
               (if (class? tag)
                 (let [superclasses (set (supers tag))]
                   (reduce1 into1 superclasses
-                    (cons ta
-                          (map #(get (:ancestors h) %) superclasses))))
+                           (cons ta
+                                 (map #(get (:ancestors h) %) superclasses))))
                 ta)))))
 
 (defn descendants
@@ -5500,9 +5542,9 @@
          ta (:ancestors h)
          tf (fn [m source sources target targets]
               (reduce1 (fn [ret k]
-                        (assoc ret k
-                               (reduce1 conj (get targets k #{}) (cons target (targets target)))))
-                      m (cons source (sources source))))]
+                         (assoc ret k
+                                (reduce1 conj (get targets k #{}) (cons target (targets target)))))
+                       m (cons source (sources source))))]
      (or
       (when-not (contains? (tp tag) parent)
         (when (contains? (ta tag) parent)
@@ -5523,19 +5565,18 @@
   {:added "1.0"}
   ([tag parent] (alter-var-root #'global-hierarchy underive tag parent) nil)
   ([h tag parent]
-    (let [parentMap (:parents h)
-	  childsParents (if (parentMap tag)
-			  (disj (parentMap tag) parent) #{})
-	  newParents (if (not-empty childsParents)
-		       (assoc parentMap tag childsParents)
-		       (dissoc parentMap tag))
-	  deriv-seq (flatten (map #(cons (key %) (interpose (key %) (val %)))
-				       (seq newParents)))]
-      (if (contains? (parentMap tag) parent)
-	(reduce1 #(apply derive %1 %2) (make-hierarchy)
-		(partition 2 deriv-seq))
-	h))))
-
+   (let [parentMap (:parents h)
+         childsParents (if (parentMap tag)
+                         (disj (parentMap tag) parent) #{})
+         newParents (if (not-empty childsParents)
+                      (assoc parentMap tag childsParents)
+                      (dissoc parentMap tag))
+         deriv-seq (flatten (map #(cons (key %) (interpose (key %) (val %)))
+                                 (seq newParents)))]
+     (if (contains? (parentMap tag) parent)
+       (reduce1 #(apply derive %1 %2) (make-hierarchy)
+                (partition 2 deriv-seq))
+       h))))
 
 (defn distinct?
   "Returns true if no two of the arguments are ="
@@ -5559,19 +5600,19 @@
   the rows in the java.sql.ResultSet rs"
   {:added "1.0"}
   [^java.sql.ResultSet rs]
-    (let [rsmeta (. rs (getMetaData))
-          idxs (range 1 (inc (. rsmeta (getColumnCount))))
-          keys (map (comp keyword #(.toLowerCase ^String %))
-                    (map (fn [i] (. rsmeta (getColumnLabel i))) idxs))
-          check-keys
-                (or (apply distinct? keys)
-                    (throw (Exception. "ResultSet must have unique column labels")))
-          row-struct (apply create-struct keys)
-          row-values (fn [] (map (fn [^Integer i] (. rs (getObject i))) idxs))
-          rows (fn thisfn []
-                 (when (. rs (next))
-                   (cons (apply struct row-struct (row-values)) (lazy-seq (thisfn)))))]
-      (rows)))
+  (let [rsmeta (. rs (getMetaData))
+        idxs (range 1 (inc (. rsmeta (getColumnCount))))
+        keys (map (comp keyword #(.toLowerCase ^String %))
+                  (map (fn [i] (. rsmeta (getColumnLabel i))) idxs))
+        check-keys
+        (or (apply distinct? keys)
+            (throw (Exception. "ResultSet must have unique column labels")))
+        row-struct (apply create-struct keys)
+        row-values (fn [] (map (fn [^Integer i] (. rs (getObject i))) idxs))
+        rows (fn thisfn []
+               (when (. rs (next))
+                 (cons (apply struct row-struct (row-values)) (lazy-seq (thisfn)))))]
+    (rows)))
 
 (defn iterator-seq
   "Returns a seq on a java.util.Iterator. Note that most collections
@@ -5608,12 +5649,12 @@
 (declare gen-class)
 
 (defmacro with-loading-context [& body]
-  `((fn loading# [] 
-        (. clojure.lang.Var (pushThreadBindings {clojure.lang.Compiler/LOADER  
-                                                 (.getClassLoader (.getClass ^Object loading#))}))
-        (try
-         ~@body
-         (finally
+  `((fn loading# []
+      (. clojure.lang.Var (pushThreadBindings {clojure.lang.Compiler/LOADER
+                                               (.getClassLoader (.getClass ^Object loading#))}))
+      (try
+        ~@body
+        (finally
           (. clojure.lang.Var (popThreadBindings)))))))
 
 (defmacro ns
@@ -5643,7 +5684,7 @@
   (let [process-reference
         (fn [[kname & args]]
           `(~(symbol "clojure.core" (clojure.core/name kname))
-             ~@(map #(list 'quote %) args)))
+            ~@(map #(list 'quote %) args)))
         docstring  (when (string? (first references)) (first references))
         references (if docstring (next references) references)
         name (if docstring
@@ -5656,23 +5697,22 @@
                name)
         gen-class-clause (first (filter #(= :gen-class (first %)) references))
         gen-class-call
-          (when gen-class-clause
-            (list* `gen-class :name (.replace (str name) \- \_) :impl-ns name :main true (next gen-class-clause)))
+        (when gen-class-clause
+          (list* `gen-class :name (.replace (str name) \- \_) :impl-ns name :main true (next gen-class-clause)))
         references (remove #(= :gen-class (first %)) references)
-        ;ns-effect (clojure.core/in-ns name)
         name-metadata (meta name)]
     `(do
        (clojure.core/in-ns '~name)
        ~@(when name-metadata
            `((.resetMeta (clojure.lang.Namespace/find '~name) ~name-metadata)))
        (with-loading-context
-        ~@(when gen-class-call (list gen-class-call))
-        ~@(when (and (not= name 'clojure.core) (not-any? #(= :refer-clojure (first %)) references))
-            `((clojure.core/refer '~'clojure.core)))
-        ~@(map process-reference references))
-        (if (.equals '~name 'clojure.core) 
-          nil
-          (do (dosync (commute @#'*loaded-libs* conj '~name)) nil)))))
+         ~@(when gen-class-call (list gen-class-call))
+         ~@(when (and (not= name 'clojure.core) (not-any? #(= :refer-clojure (first %)) references))
+             `((clojure.core/refer '~'clojure.core)))
+         ~@(map process-reference references))
+       (if (.equals '~name 'clojure.core)
+         nil
+         (do (dosync (commute @#'*loaded-libs* conj '~name)) nil)))))
 
 (defmacro refer-clojure
   "Same as (refer 'clojure.core <filters>)"
@@ -5700,17 +5740,17 @@
 
 (defonce ^:dynamic
   ^{:private true
-     :doc "A ref to a sorted set of symbols representing loaded libs"}
+    :doc "A ref to a sorted set of symbols representing loaded libs"}
   *loaded-libs* (ref (sorted-set)))
 
 (defonce ^:dynamic
   ^{:private true
-     :doc "A stack of paths currently being loaded by this thread"}
+    :doc "A stack of paths currently being loaded by this thread"}
   *pending-paths* ())
 
 (defonce ^:dynamic
   ^{:private true :doc
-     "True while a verbose load is pending"}
+    "True while a verbose load is pending"}
   *loading-verbosely* false)
 
 (defn- throw-if
@@ -5835,13 +5875,13 @@
   (let [flags (filter keyword? args)
         opts (interleave flags (repeat true))
         args (filter (complement keyword?) args)]
-    ; check for unsupported options
+;; check for unsupported options
     (let [supported #{:as :reload :reload-all :require :use :verbose :refer}
           unsupported (seq (remove supported flags))]
       (throw-if unsupported
                 (apply str "Unsupported option(s) supplied: "
-                     (interpose \, unsupported))))
-    ; check a load target was specified
+                       (interpose \, unsupported))))
+;; check a load target was specified
     (throw-if (not (seq args)) "Nothing specified to load")
     (doseq [arg args]
       (if (libspec? arg)
@@ -5955,8 +5995,8 @@
   [& paths]
   (doseq [^String path paths]
     (let [^String path (if (.startsWith path "/")
-                          path
-                          (str (root-directory (name *ns*)) \/ path))]
+                         path
+                         (str (root-directory (name *ns*)) \/ path))]
       (when *loading-verbosely*
         (printf "(clojure.core/load \"%s\")\n" path)
         (flush))
@@ -5986,17 +6026,17 @@
   {:added "1.2"
    :static true}
   ([m ks]
-     (reduce1 get m ks))
+   (reduce1 get m ks))
   ([m ks not-found]
-     (loop [sentinel (Object.)
-            m m
-            ks (seq ks)]
-       (if ks
-         (let [m (get m (first ks) sentinel)]
-           (if (identical? sentinel m)
-             not-found
-             (recur sentinel m (next ks))))
-         m))))
+   (loop [sentinel (Object.)
+          m m
+          ks (seq ks)]
+     (if ks
+       (let [m (get m (first ks) sentinel)]
+         (if (identical? sentinel m)
+           not-found
+           (recur sentinel m (next ks))))
+       m))))
 
 (defn assoc-in
   "Associates a value in a nested associative structure, where ks is a
@@ -6072,56 +6112,55 @@
    :static true}
   [x] (instance? clojure.lang.Fn x))
 
-
 (defn associative?
- "Returns true if coll implements Associative"
- {:added "1.0"
-  :static true}
+  "Returns true if coll implements Associative"
+  {:added "1.0"
+   :static true}
   [coll] (instance? clojure.lang.Associative coll))
 
 (defn sequential?
- "Returns true if coll implements Sequential"
- {:added "1.0"
-  :static true}
+  "Returns true if coll implements Sequential"
+  {:added "1.0"
+   :static true}
   [coll] (instance? clojure.lang.Sequential coll))
 
 (defn sorted?
- "Returns true if coll implements Sorted"
- {:added "1.0"
+  "Returns true if coll implements Sorted"
+  {:added "1.0"
    :static true}
   [coll] (instance? clojure.lang.Sorted coll))
 
 (defn counted?
- "Returns true if coll implements count in constant time"
- {:added "1.0"
+  "Returns true if coll implements count in constant time"
+  {:added "1.0"
    :static true}
   [coll] (instance? clojure.lang.Counted coll))
 
 (defn reversible?
- "Returns true if coll implements Reversible"
- {:added "1.0"
+  "Returns true if coll implements Reversible"
+  {:added "1.0"
    :static true}
   [coll] (instance? clojure.lang.Reversible coll))
 
 (def ^:dynamic
- ^{:doc "bound in a repl thread to the most recent value printed"
-   :added "1.0"}
- *1)
+  ^{:doc "bound in a repl thread to the most recent value printed"
+    :added "1.0"}
+  *1)
 
 (def ^:dynamic
- ^{:doc "bound in a repl thread to the second most recent value printed"
-   :added "1.0"}
- *2)
+  ^{:doc "bound in a repl thread to the second most recent value printed"
+    :added "1.0"}
+  *2)
 
 (def ^:dynamic
- ^{:doc "bound in a repl thread to the third most recent value printed"
-   :added "1.0"}
- *3)
+  ^{:doc "bound in a repl thread to the third most recent value printed"
+    :added "1.0"}
+  *3)
 
 (def ^:dynamic
- ^{:doc "bound in a repl thread to the most recent exception caught by the repl"
-   :added "1.0"}
- *e)
+  ^{:doc "bound in a repl thread to the most recent exception caught by the repl"
+    :added "1.0"}
+  *e)
 
 (defn trampoline
   "trampoline can be used to convert algorithms requiring mutual
@@ -6134,12 +6173,12 @@
   {:added "1.0"
    :static true}
   ([f]
-     (let [ret (f)]
-       (if (fn? ret)
-         (recur ret)
-         ret)))
+   (let [ret (f)]
+     (if (fn? ret)
+       (recur ret)
+       ret)))
   ([f & args]
-     (trampoline #(apply f args))))
+   (trampoline #(apply f args))))
 
 (defn intern
   "Finds or creates a var named by the symbol name in the namespace
@@ -6149,13 +6188,13 @@
   {:added "1.0"
    :static true}
   ([ns ^clojure.lang.Symbol name]
-     (let [v (clojure.lang.Var/intern (the-ns ns) name)]
-       (when (meta name) (.setMeta v (meta name)))
-       v))
+   (let [v (clojure.lang.Var/intern (the-ns ns) name)]
+     (when (meta name) (.setMeta v (meta name)))
+     v))
   ([ns name val]
-     (let [v (clojure.lang.Var/intern (the-ns ns) name val)]
-       (when (meta name) (.setMeta v (meta name)))
-       v)))
+   (let [v (clojure.lang.Var/intern (the-ns ns) name val)]
+     (when (meta name) (.setMeta v (meta name)))
+     v)))
 
 (defmacro while
   "Repeatedly executes body while test expression is true. Presumes
@@ -6209,17 +6248,17 @@
         gexpr (gensym "expr__")
         emit (fn emit [pred expr args]
                (let [[[a b c :as clause] more]
-                       (split-at (if (= :>> (second args)) 3 2) args)
-                       n (count clause)]
+                     (split-at (if (= :>> (second args)) 3 2) args)
+                     n (count clause)]
                  (cond
-                  (= 0 n) `(throw (IllegalArgumentException. (str "No matching clause: " ~expr)))
-                  (= 1 n) a
-                  (= 2 n) `(if (~pred ~a ~expr)
-                             ~b
-                             ~(emit pred expr more))
-                  :else `(if-let [p# (~pred ~a ~expr)]
-                           (~c p#)
-                           ~(emit pred expr more)))))]
+                   (= 0 n) `(throw (IllegalArgumentException. (str "No matching clause: " ~expr)))
+                   (= 1 n) a
+                   (= 2 n) `(if (~pred ~a ~expr)
+                              ~b
+                              ~(emit pred expr more))
+                   :else `(if-let [p# (~pred ~a ~expr)]
+                            (~c p#)
+                            ~(emit pred expr more)))))]
     `(let [~gpred ~pred
            ~gexpr ~expr]
        ~(emit gpred gexpr clauses))))
@@ -6351,7 +6390,7 @@
   {:added "1.0"})
 
 (add-doc-and-meta *read-eval*
- "Defaults to true (or value specified by system property, see below)
+  "Defaults to true (or value specified by system property, see below)
   ***This setting implies that the full power of the reader is in play,
   including syntax that can cause code to execute. It should never be
   used with untrusted sources. See also: clojure.edn/read.***
@@ -6388,8 +6427,7 @@
    :static true}
   [^java.util.concurrent.Future f] (.isDone f))
 
-
-(defmacro letfn 
+(defmacro letfn
   "fnspec ==> (fname [params*] exprs) or (fname ([params*] exprs)+)
 
   Takes a vector of function specs and a body, and generates a set of
@@ -6397,8 +6435,8 @@
   in all of the definitions of the functions, as well as the body."
   {:added "1.0", :forms '[(letfn [fnspecs*] exprs*)],
    :special-form true, :url nil}
-  [fnspecs & body] 
-  `(letfn* ~(vec (interleave (map first fnspecs) 
+  [fnspecs & body]
+  `(letfn* ~(vec (interleave (map first fnspecs)
                              (map #(cons `fn %) fnspecs)))
            ~@body))
 
@@ -6427,7 +6465,6 @@
      ([a b c] (f (if (nil? a) x a) (if (nil? b) y b) (if (nil? c) z c)))
      ([a b c & ds] (apply f (if (nil? a) x a) (if (nil? b) y b) (if (nil? c) z c) ds)))))
 
-
 ;;;;;;; case ;;;;;;;;;;;;;
 (defn- shift-mask [shift mask x]
   (-> x (bit-shift-right shift) (bit-and mask)))
@@ -6439,11 +6476,11 @@
   "takes a collection of hashes and returns [shift mask] or nil if none found"
   [hashes]
   (first
-    (filter (fn [[s m]]
-              (apply distinct? (map #(shift-mask s m %) hashes)))
-            (for [mask (map #(dec (bit-shift-left 1 %)) (range 1 (inc max-mask-bits)))
-                  shift (range 0 31)]
-              [shift mask]))))
+   (filter (fn [[s m]]
+             (apply distinct? (map #(shift-mask s m %) hashes)))
+           (for [mask (map #(dec (bit-shift-left 1 %)) (range 1 (inc max-mask-bits)))
+                 shift (range 0 31)]
+             [shift mask]))))
 
 (defn- case-map
   "Transforms a sequence of test constants and a corresponding sequence of then
@@ -6451,10 +6488,10 @@
   entries are {(case-f test) [(test-f test) then]}."
   [case-f test-f tests thens]
   (into1 (sorted-map)
-    (zipmap (map case-f tests)
-            (map vector
-              (map test-f tests)
-              thens))))
+         (zipmap (map case-f tests)
+                 (map vector
+                      (map test-f tests)
+                      thens))))
 
 (defn- fits-table?
   "Returns true if the collection of ints can fit within the
@@ -6469,13 +6506,13 @@
   is either :sparse or :compact."
   [tests thens]
   (if (fits-table? tests)
-    ; compact case ints, no shift-mask
+;; compact case ints, no shift-mask
     [0 0 (case-map int int tests thens) :compact]
     (let [[shift mask] (or (maybe-min-hash (map int tests)) [0 0])]
       (if (zero? mask)
-        ; sparse case ints, no shift-mask
+;; sparse case ints, no shift-mask
         [0 0 (case-map int int tests thens) :sparse]
-        ; compact case ints, with shift-mask
+;; compact case ints, with shift-mask
         [shift mask (case-map #(shift-mask shift mask (int %)) int tests thens) :compact]))))
 
 (defn- merge-hash-collisions
@@ -6495,23 +6532,23 @@
   (let [buckets (loop [m {} ks tests vs thens]
                   (if (and ks vs)
                     (recur
-                      (update m (clojure.lang.Util/hash (first ks)) (fnil conj []) [(first ks) (first vs)])
-                      (next ks) (next vs))
+                     (update m (clojure.lang.Util/hash (first ks)) (fnil conj []) [(first ks) (first vs)])
+                     (next ks) (next vs))
                     m))
         assoc-multi (fn [m h bucket]
                       (let [testexprs (apply concat bucket)
                             expr `(condp = ~expr-sym ~@testexprs ~default)]
                         (assoc m h expr)))
         hmap (reduce1
-               (fn [m [h bucket]]
-                 (if (== 1 (count bucket))
-                   (assoc m (ffirst bucket) (second (first bucket)))
-                   (assoc-multi m h bucket)))
-               {} buckets)
+              (fn [m [h bucket]]
+                (if (== 1 (count bucket))
+                  (assoc m (ffirst bucket) (second (first bucket)))
+                  (assoc-multi m h bucket)))
+              {} buckets)
         skip-check (->> buckets
-                     (filter #(< 1 (count (second %))))
-                     (map first)
-                     (into1 #{}))]
+                        (filter #(< 1 (count (second %))))
+                        (map first)
+                        (into1 #{}))]
     [(keys hmap) (vals hmap) skip-check]))
 
 (defn- prep-hashes
@@ -6526,15 +6563,15 @@
         hashes (into1 #{} (map hashcode tests))]
     (if (== (count tests) (count hashes))
       (if (fits-table? hashes)
-        ; compact case ints, no shift-mask
+;; compact case ints, no shift-mask
         [0 0 (case-map hashcode identity tests thens) :compact]
         (let [[shift mask] (or (maybe-min-hash hashes) [0 0])]
           (if (zero? mask)
-            ; sparse case ints, no shift-mask
+;; sparse case ints, no shift-mask
             [0 0 (case-map hashcode identity tests thens) :sparse]
-            ; compact case ints, with shift-mask
+;; compact case ints, with shift-mask
             [shift mask (case-map #(shift-mask shift mask (hashcode %)) identity tests thens) :compact])))
-      ; resolve hash collisions and try again
+;; resolve hash collisions and try again
       (let [[tests thens skip-check] (merge-hash-collisions expr-sym default tests thens)
             [shift mask case-map switch-type] (prep-hashes expr-sym default tests thens)
             skip-check (if (zero? mask)
@@ -6542,8 +6579,7 @@
                          (into1 #{} (map #(shift-mask shift mask %) skip-check)))]
         [shift mask case-map switch-type skip-check]))))
 
-
-(defmacro case 
+(defmacro case
   "Takes an expression, and a set of clauses.
 
   Each clause can take the form of either:
@@ -6570,7 +6606,7 @@
 
   [e & clauses]
   (let [ge (with-meta (gensym) {:tag Object})
-        default (if (odd? (count clauses)) 
+        default (if (odd? (count clauses))
                   (last clauses)
                   `(throw (IllegalArgumentException. (str "No matching clause: " ~ge))))]
     (if (> 2 (count clauses))
@@ -6581,11 +6617,11 @@
                            (throw (IllegalArgumentException. (str "Duplicate case test constant: " test)))
                            (assoc m test expr)))
             pairs (reduce1
-                       (fn [m [test expr]]
-                         (if (seq? test)
-                           (reduce1 #(assoc-test %1 %2 expr) m test)
-                           (assoc-test m test expr)))
-                       {} pairs)
+                   (fn [m [test expr]]
+                     (if (seq? test)
+                       (reduce1 #(assoc-test %1 %2 expr) m test)
+                       (assoc-test m test expr)))
+                   {} pairs)
             tests (keys pairs)
             thens (vals pairs)
             mode (cond
@@ -6604,7 +6640,6 @@
           :identity
           (let [[shift mask imap switch-type skip-check] (prep-hashes ge default tests thens)]
             `(let [~ge ~e] (case* ~ge ~shift ~mask ~default ~imap ~switch-type :hash-identity ~skip-check))))))))
-
 
 ;; redefine reduce with internal-reduce
 
@@ -6631,30 +6666,30 @@
   items, returns val and f is not called."
   {:added "1.0"}
   ([f coll]
-     (if (instance? clojure.lang.IReduce coll)
-       (.reduce ^clojure.lang.IReduce coll f)
-       (clojure.core.protocols/coll-reduce coll f)))
+   (if (instance? clojure.lang.IReduce coll)
+     (.reduce ^clojure.lang.IReduce coll f)
+     (clojure.core.protocols/coll-reduce coll f)))
   ([f val coll]
-     (if (instance? clojure.lang.IReduceInit coll)
-       (.reduce ^clojure.lang.IReduceInit coll f val)
-       (clojure.core.protocols/coll-reduce coll f val))))
+   (if (instance? clojure.lang.IReduceInit coll)
+     (.reduce ^clojure.lang.IReduceInit coll f val)
+     (clojure.core.protocols/coll-reduce coll f val))))
 
 (extend-protocol clojure.core.protocols/IKVReduce
- nil
- (kv-reduce
-  [_ f init]
-  init)
+  nil
+  (kv-reduce
+    [_ f init]
+    init)
 
  ;;slow path default
- clojure.lang.IPersistentMap
- (kv-reduce 
-  [amap f init]
-  (reduce (fn [ret [k v]] (f ret k v)) init amap))
+  clojure.lang.IPersistentMap
+  (kv-reduce
+    [amap f init]
+    (reduce (fn [ret [k v]] (f ret k v)) init amap))
 
- clojure.lang.IKVReduce
- (kv-reduce 
-  [amap f init]
-  (.kvreduce amap f init)))
+  clojure.lang.IKVReduce
+  (kv-reduce
+    [amap f init]
+    (.kvreduce amap f init)))
 
 (defn reduce-kv
   "Reduces an associative collection. f should be a function of 3
@@ -6662,10 +6697,10 @@
   and the first value in coll, then applying f to that result and the
   2nd key and value, etc. If coll contains no entries, returns init
   and f is not called. Note that reduce-kv is supported on vectors,
-  where the keys will be the ordinals."  
+  where the keys will be the ordinals."
   {:added "1.4"}
   ([f init coll]
-     (clojure.core.protocols/kv-reduce coll f init)))
+   (clojure.core.protocols/kv-reduce coll f init)))
 
 (defn completing
   "Takes a reducing function f of 2 args and returns a fn suitable for
@@ -6674,10 +6709,10 @@
   {:added "1.7"}
   ([f] (completing f identity))
   ([f cf]
-     (fn
-       ([] (f))
-       ([x] (cf x))
-       ([x y] (f x y)))))
+   (fn
+     ([] (f))
+     ([x] (cf x))
+     ([x y] (f x y)))))
 
 (defn transduce
   "reduce with a transformation of f (xf). If init is not
@@ -6690,11 +6725,11 @@
   certain transforms may inject or skip items."  {:added "1.7"}
   ([xform f coll] (transduce xform f (f) coll))
   ([xform f init coll]
-     (let [f (xform f)
-           ret (if (instance? clojure.lang.IReduceInit coll)
-                 (.reduce ^clojure.lang.IReduceInit coll f init)
-                 (clojure.core.protocols/coll-reduce coll f init))]
-       (f ret))))
+   (let [f (xform f)
+         ret (if (instance? clojure.lang.IReduceInit coll)
+               (.reduce ^clojure.lang.IReduceInit coll f init)
+               (clojure.core.protocols/coll-reduce coll f init))]
+     (f ret))))
 
 (defn into
   "Returns a new coll consisting of to-coll with all of the items of
@@ -6702,13 +6737,13 @@
   {:added "1.0"
    :static true}
   ([to from]
-     (if (instance? clojure.lang.IEditableCollection to)
-       (with-meta (persistent! (reduce conj! (transient to) from)) (meta to))
-       (reduce conj to from)))
+   (if (instance? clojure.lang.IEditableCollection to)
+     (with-meta (persistent! (reduce conj! (transient to) from)) (meta to))
+     (reduce conj to from)))
   ([to xform from]
-     (if (instance? clojure.lang.IEditableCollection to)
-       (with-meta (persistent! (transduce xform conj! (transient to) from)) (meta to))
-       (transduce xform conj to from))))
+   (if (instance? clojure.lang.IEditableCollection to)
+     (with-meta (persistent! (transduce xform conj! (transient to) from)) (meta to))
+     (transduce xform conj to from))))
 
 (defn mapv
   "Returns a vector consisting of the result of applying f to the
@@ -6719,14 +6754,14 @@
   {:added "1.4"
    :static true}
   ([f coll]
-     (-> (reduce (fn [v o] (conj! v (f o))) (transient []) coll)
-         persistent!))
+   (-> (reduce (fn [v o] (conj! v (f o))) (transient []) coll)
+       persistent!))
   ([f c1 c2]
-     (into [] (map f c1 c2)))
+   (into [] (map f c1 c2)))
   ([f c1 c2 c3]
-     (into [] (map f c1 c2 c3)))
+   (into [] (map f c1 c2 c3)))
   ([f c1 c2 c3 & colls]
-     (into [] (apply map f c1 c2 c3 colls))))
+   (into [] (apply map f c1 c2 c3 colls))))
 
 (defn filterv
   "Returns a vector of the items in coll for which
@@ -6754,11 +6789,11 @@
   See clojure.java.io/reader for a complete list of supported arguments."
   {:added "1.0"}
   ([f & opts]
-     (let [opts (normalize-slurp-opts opts)
-           sw (java.io.StringWriter.)]
-       (with-open [^java.io.Reader r (apply jio/reader f opts)]
-         (jio/copy r sw)
-         (.toString sw)))))
+   (let [opts (normalize-slurp-opts opts)
+         sw (java.io.StringWriter.)]
+     (with-open [^java.io.Reader r (apply jio/reader f opts)]
+       (jio/copy r sw)
+       (.toString sw)))))
 
 (defn spit
   "Opposite of slurp.  Opens f with writer, writes content, then
@@ -6769,7 +6804,7 @@
     (.write w (str content))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; futures (needs proxy);;;;;;;;;;;;;;;;;;
-(defn future-call 
+(defn future-call
   "Takes a function of no args and yields a future object that will
   invoke the function in another thread, and will cache the result and
   return it on all subsequent calls to deref/@. If the computation has
@@ -6780,22 +6815,22 @@
   [f]
   (let [f (binding-conveyor-fn f)
         fut (.submit clojure.lang.Agent/soloExecutor ^Callable f)]
-    (reify 
-     clojure.lang.IDeref 
-     (deref [_] (deref-future fut))
-     clojure.lang.IBlockingDeref
-     (deref
-      [_ timeout-ms timeout-val]
-      (deref-future fut timeout-ms timeout-val))
-     clojure.lang.IPending
-     (isRealized [_] (.isDone fut))
-     java.util.concurrent.Future
+    (reify
+      clojure.lang.IDeref
+      (deref [_] (deref-future fut))
+      clojure.lang.IBlockingDeref
+      (deref
+        [_ timeout-ms timeout-val]
+        (deref-future fut timeout-ms timeout-val))
+      clojure.lang.IPending
+      (isRealized [_] (.isDone fut))
+      java.util.concurrent.Future
       (get [_] (.get fut))
       (get [_ timeout unit] (.get fut timeout unit))
       (isCancelled [_] (.isCancelled fut))
       (isDone [_] (.isDone fut))
       (cancel [_ interrupt?] (.cancel fut interrupt?)))))
-  
+
 (defmacro future
   "Takes a body of expressions and yields a future object that will
   invoke the body in another thread, and will cache the result and
@@ -6804,7 +6839,6 @@
   deref with timeout is used. See also - realized?."
   {:added "1.1"}
   [& body] `(future-call (^{:once true} fn* [] ~@body)))
-
 
 (defn future-cancel
   "Cancels the future, if possible."
@@ -6853,11 +6887,10 @@
 (defmacro pvalues
   "Returns a lazy sequence of the values of the exprs, which are
   evaluated in parallel"
-  {:added "1.0"
+  {:added  "1.0"
    :static true}
   [& exprs]
   `(pcalls ~@(map #(list `fn [] %) exprs)))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; clojure version number ;;;;;;;;;;;;;;;;;;;;;;
 
@@ -6893,7 +6926,7 @@
 (defn- parse-version [v]
   {:pre [(string? v)]}
   (let [[_ major minor incremental qualifier]
-        ,,(re-matches #"^(\d+)\.(\d+)\.(\d+)(-.*)?$" v)]
+        (re-matches #"^(\d+)\.(\d+)\.(\d+)(-.*)?$" v)]
     {:major        (Integer/valueOf ^String major)
      :minor        (Integer/valueOf ^String minor)
      :incremental  (Integer/valueOf ^String incremental)
@@ -6954,25 +6987,25 @@
   []
   (let [d (java.util.concurrent.CountDownLatch. 1)
         v (atom d)]
-    (reify 
-     clojure.lang.IDeref
-       (deref [_] (.await d) @v)
-     clojure.lang.IBlockingDeref
-       (deref
+    (reify
+      clojure.lang.IDeref
+      (deref [_] (.await d) @v)
+      clojure.lang.IBlockingDeref
+      (deref
         [_ timeout-ms timeout-val]
         (if (.await d timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)
           @v
-          timeout-val))  
-     clojure.lang.IPending
+          timeout-val))
+      clojure.lang.IPending
       (isRealized [this]
-       (zero? (.getCount d)))
-     clojure.lang.IFn
-     (invoke
-      [this x]
-      (when (and (pos? (.getCount d))
-                 (compare-and-set! v d x))
-        (.countDown d)
-        this)))))
+        (zero? (.getCount d)))
+      clojure.lang.IFn
+      (invoke
+        [this x]
+        (when (and (pos? (.getCount d))
+                   (compare-and-set! v d x))
+          (.countDown d)
+          this)))))
 
 (defn deliver
   "Delivers the supplied value to the promise, releasing any pending
@@ -6980,8 +7013,6 @@
   {:added "1.1"
    :static true}
   [promise val] (promise val))
-
-
 
 (defn flatten
   "Takes any nested combination of sequential things (lists, vectors,
@@ -6993,13 +7024,13 @@
   (filter (complement sequential?)
           (rest (tree-seq sequential? seq x))))
 
-(defn group-by 
+(defn group-by
   "Returns a map of the elements of coll keyed by the result of
   f on each element. The value at each key will be a vector of the
   corresponding elements, in the order they appeared in coll."
   {:added "1.2"
    :static true}
-  [f coll]  
+  [f coll]
   (persistent!
    (reduce
     (fn [ret x]
@@ -7014,41 +7045,41 @@
   {:added "1.2"
    :static true}
   ([f]
-  (fn [rf]
-    (let [a (java.util.ArrayList.)
-          pv (volatile! ::none)]
-      (fn
-        ([] (rf))
-        ([result]
-           (let [result (if (.isEmpty a)
-                          result
-                          (let [v (vec (.toArray a))]
+   (fn [rf]
+     (let [a (java.util.ArrayList.)
+           pv (volatile! ::none)]
+       (fn
+         ([] (rf))
+         ([result]
+          (let [result (if (.isEmpty a)
+                         result
+                         (let [v (vec (.toArray a))]
                             ;;clear first!
-                            (.clear a)
-                            (unreduced (rf result v))))]
-             (rf result)))
-        ([result input]
-           (let [pval @pv
-                 val (f input)]
-             (vreset! pv val)
-             (if (or (identical? pval ::none)
-                     (= val pval))
-               (do
-                 (.add a input)
-                 result)
-               (let [v (vec (.toArray a))]
-                 (.clear a)
-                 (let [ret (rf result v)]
-                   (when-not (reduced? ret)
-                     (.add a input))
-                   ret)))))))))
+                           (.clear a)
+                           (unreduced (rf result v))))]
+            (rf result)))
+         ([result input]
+          (let [pval @pv
+                val (f input)]
+            (vreset! pv val)
+            (if (or (identical? pval ::none)
+                    (= val pval))
+              (do
+                (.add a input)
+                result)
+              (let [v (vec (.toArray a))]
+                (.clear a)
+                (let [ret (rf result v)]
+                  (when-not (reduced? ret)
+                    (.add a input))
+                  ret)))))))))
   ([f coll]
-     (lazy-seq
-      (when-let [s (seq coll)]
-        (let [fst (first s)
-              fv (f fst)
-              run (cons fst (take-while #(= fv (f %)) (next s)))]
-          (cons run (partition-by f (seq (drop (count run) s)))))))))
+   (lazy-seq
+    (when-let [s (seq coll)]
+      (let [fst (first s)
+            fv (f fst)
+            run (cons fst (take-while #(= fv (f %)) (next s)))]
+        (cons run (partition-by f (seq (drop (count run) s)))))))))
 
 (defn frequencies
   "Returns a map from distinct items in coll to the number of times
@@ -7066,17 +7097,17 @@
   per reduce) of coll by f, starting with init."
   {:added "1.2"}
   ([f coll]
-     (lazy-seq
-      (if-let [s (seq coll)]
-        (reductions f (first s) (rest s))
-        (list (f)))))
+   (lazy-seq
+    (if-let [s (seq coll)]
+      (reductions f (first s) (rest s))
+      (list (f)))))
   ([f init coll]
-     (if (reduced? init)
-       (list @init)
-       (cons init
-             (lazy-seq
-              (when-let [s (seq coll)]
-                (reductions f (f init (first s)) (rest s))))))))
+   (if (reduced? init)
+     (list @init)
+     (cons init
+           (lazy-seq
+            (when-let [s (seq coll)]
+              (reductions f (f init (first s)) (rest s))))))))
 
 (defn rand-nth
   "Return a random element of the (sequential) collection. Will have
@@ -7099,27 +7130,27 @@
        (fn
          ([] (rf))
          ([result]
-            (let [result (if (.isEmpty a)
-                           result
-                           (let [v (vec (.toArray a))]
+          (let [result (if (.isEmpty a)
+                         result
+                         (let [v (vec (.toArray a))]
                              ;;clear first!
-                             (.clear a)
-                             (unreduced (rf result v))))]
-              (rf result)))
+                           (.clear a)
+                           (unreduced (rf result v))))]
+            (rf result)))
          ([result input]
-            (.add a input)
-            (if (= n (.size a))
-              (let [v (vec (.toArray a))]
-                (.clear a)
-                (rf result v))
-              result))))))
+          (.add a input)
+          (if (= n (.size a))
+            (let [v (vec (.toArray a))]
+              (.clear a)
+              (rf result v))
+            result))))))
   ([n coll]
-     (partition-all n n coll))
+   (partition-all n n coll))
   ([n step coll]
-     (lazy-seq
-      (when-let [s (seq coll)]
-        (let [seg (doall (take n s))]
-          (cons seg (partition-all n step (nthrest s step))))))))
+   (lazy-seq
+    (when-let [s (seq coll)]
+      (let [seg (doall (take n s))]
+        (cons seg (partition-all n step (nthrest s step))))))))
 
 (defn shuffle
   "Return a random permutation of coll"
@@ -7148,16 +7179,16 @@
           (rf result (f (vswap! i inc) input)))))))
   ([f coll]
    (letfn [(mapi [idx coll]
-                 (lazy-seq
-                   (when-let [s (seq coll)]
-                     (if (chunked-seq? s)
-                       (let [c (chunk-first s)
-                             size (int (count c))
-                             b (chunk-buffer size)]
-                         (dotimes [i size]
-                           (chunk-append b (f (+ idx i) (.nth c i))))
-                         (chunk-cons (chunk b) (mapi (+ idx size) (chunk-rest s))))
-                       (cons (f idx (first s)) (mapi (inc idx) (rest s)))))))]
+             (lazy-seq
+              (when-let [s (seq coll)]
+                (if (chunked-seq? s)
+                  (let [c (chunk-first s)
+                        size (int (count c))
+                        b (chunk-buffer size)]
+                    (dotimes [i size]
+                      (chunk-append b (f (+ idx i) (.nth c i))))
+                    (chunk-cons (chunk b) (mapi (+ idx size) (chunk-rest s))))
+                  (cons (f idx (first s)) (mapi (inc idx) (rest s)))))))]
      (mapi 0 coll))))
 
 (defn keep
@@ -7172,10 +7203,10 @@
        ([] (rf))
        ([result] (rf result))
        ([result input]
-          (let [v (f input)]
-            (if (nil? v)
-              result
-              (rf result v)))))))
+        (let [v (f input)]
+          (if (nil? v)
+            result
+            (rf result v)))))))
   ([f coll]
    (lazy-seq
     (when-let [s (seq coll)]
@@ -7207,29 +7238,29 @@
          ([] (rf))
          ([result] (rf result))
          ([result input]
-            (let [i (vswap! iv inc)
-                  v (f i input)]
-              (if (nil? v)
-                result
-                (rf result v))))))))
+          (let [i (vswap! iv inc)
+                v (f i input)]
+            (if (nil? v)
+              result
+              (rf result v))))))))
   ([f coll]
-     (letfn [(keepi [idx coll]
-               (lazy-seq
-                (when-let [s (seq coll)]
-                  (if (chunked-seq? s)
-                    (let [c (chunk-first s)
-                          size (count c)
-                          b (chunk-buffer size)]
-                      (dotimes [i size]
-                        (let [x (f (+ idx i) (.nth c i))]
-                          (when-not (nil? x)
-                            (chunk-append b x))))
-                      (chunk-cons (chunk b) (keepi (+ idx size) (chunk-rest s))))
-                    (let [x (f idx (first s))]
-                      (if (nil? x)
-                        (keepi (inc idx) (rest s))
-                        (cons x (keepi (inc idx) (rest s)))))))))]
-       (keepi 0 coll))))
+   (letfn [(keepi [idx coll]
+             (lazy-seq
+              (when-let [s (seq coll)]
+                (if (chunked-seq? s)
+                  (let [c (chunk-first s)
+                        size (count c)
+                        b (chunk-buffer size)]
+                    (dotimes [i size]
+                      (let [x (f (+ idx i) (.nth c i))]
+                        (when-not (nil? x)
+                          (chunk-append b x))))
+                    (chunk-cons (chunk b) (keepi (+ idx size) (chunk-rest s))))
+                  (let [x (f idx (first s))]
+                    (if (nil? x)
+                      (keepi (inc idx) (rest s))
+                      (cons x (keepi (inc idx) (rest s)))))))))]
+     (keepi 0 coll))))
 
 (defn every-pred
   "Takes a set of predicates and returns a function f that returns true if all of its
@@ -7238,38 +7269,38 @@
   argument that triggers a logical false result against the original predicates."
   {:added "1.3"}
   ([p]
-     (fn ep1
-       ([] true)
-       ([x] (boolean (p x)))
-       ([x y] (boolean (and (p x) (p y))))
-       ([x y z] (boolean (and (p x) (p y) (p z))))
-       ([x y z & args] (boolean (and (ep1 x y z)
-                                     (every? p args))))))
+   (fn ep1
+     ([] true)
+     ([x] (boolean (p x)))
+     ([x y] (boolean (and (p x) (p y))))
+     ([x y z] (boolean (and (p x) (p y) (p z))))
+     ([x y z & args] (boolean (and (ep1 x y z)
+                                   (every? p args))))))
   ([p1 p2]
-     (fn ep2
-       ([] true)
-       ([x] (boolean (and (p1 x) (p2 x))))
-       ([x y] (boolean (and (p1 x) (p1 y) (p2 x) (p2 y))))
-       ([x y z] (boolean (and (p1 x) (p1 y) (p1 z) (p2 x) (p2 y) (p2 z))))
-       ([x y z & args] (boolean (and (ep2 x y z)
-                                     (every? #(and (p1 %) (p2 %)) args))))))
+   (fn ep2
+     ([] true)
+     ([x] (boolean (and (p1 x) (p2 x))))
+     ([x y] (boolean (and (p1 x) (p1 y) (p2 x) (p2 y))))
+     ([x y z] (boolean (and (p1 x) (p1 y) (p1 z) (p2 x) (p2 y) (p2 z))))
+     ([x y z & args] (boolean (and (ep2 x y z)
+                                   (every? #(and (p1 %) (p2 %)) args))))))
   ([p1 p2 p3]
-     (fn ep3
-       ([] true)
-       ([x] (boolean (and (p1 x) (p2 x) (p3 x))))
-       ([x y] (boolean (and (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y))))
-       ([x y z] (boolean (and (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y) (p1 z) (p2 z) (p3 z))))
-       ([x y z & args] (boolean (and (ep3 x y z)
-                                     (every? #(and (p1 %) (p2 %) (p3 %)) args))))))
+   (fn ep3
+     ([] true)
+     ([x] (boolean (and (p1 x) (p2 x) (p3 x))))
+     ([x y] (boolean (and (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y))))
+     ([x y z] (boolean (and (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y) (p1 z) (p2 z) (p3 z))))
+     ([x y z & args] (boolean (and (ep3 x y z)
+                                   (every? #(and (p1 %) (p2 %) (p3 %)) args))))))
   ([p1 p2 p3 & ps]
-     (let [ps (list* p1 p2 p3 ps)]
-       (fn epn
-         ([] true)
-         ([x] (every? #(% x) ps))
-         ([x y] (every? #(and (% x) (% y)) ps))
-         ([x y z] (every? #(and (% x) (% y) (% z)) ps))
-         ([x y z & args] (boolean (and (epn x y z)
-                                       (every? #(every? % args) ps))))))))
+   (let [ps (list* p1 p2 p3 ps)]
+     (fn epn
+       ([] true)
+       ([x] (every? #(% x) ps))
+       ([x y] (every? #(and (% x) (% y)) ps))
+       ([x y z] (every? #(and (% x) (% y) (% z)) ps))
+       ([x y z & args] (boolean (and (epn x y z)
+                                     (every? #(every? % args) ps))))))))
 
 (defn some-fn
   "Takes a set of predicates and returns a function f that returns the first logical true value
@@ -7278,59 +7309,59 @@
   argument that triggers a logical true result against the original predicates."
   {:added "1.3"}
   ([p]
-     (fn sp1
-       ([] nil)
-       ([x] (p x))
-       ([x y] (or (p x) (p y)))
-       ([x y z] (or (p x) (p y) (p z)))
-       ([x y z & args] (or (sp1 x y z)
-                           (some p args)))))
+   (fn sp1
+     ([] nil)
+     ([x] (p x))
+     ([x y] (or (p x) (p y)))
+     ([x y z] (or (p x) (p y) (p z)))
+     ([x y z & args] (or (sp1 x y z)
+                         (some p args)))))
   ([p1 p2]
-     (fn sp2
-       ([] nil)
-       ([x] (or (p1 x) (p2 x)))
-       ([x y] (or (p1 x) (p1 y) (p2 x) (p2 y)))
-       ([x y z] (or (p1 x) (p1 y) (p1 z) (p2 x) (p2 y) (p2 z)))
-       ([x y z & args] (or (sp2 x y z)
-                           (some #(or (p1 %) (p2 %)) args)))))
+   (fn sp2
+     ([] nil)
+     ([x] (or (p1 x) (p2 x)))
+     ([x y] (or (p1 x) (p1 y) (p2 x) (p2 y)))
+     ([x y z] (or (p1 x) (p1 y) (p1 z) (p2 x) (p2 y) (p2 z)))
+     ([x y z & args] (or (sp2 x y z)
+                         (some #(or (p1 %) (p2 %)) args)))))
   ([p1 p2 p3]
-     (fn sp3
-       ([] nil)
-       ([x] (or (p1 x) (p2 x) (p3 x)))
-       ([x y] (or (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y)))
-       ([x y z] (or (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y) (p1 z) (p2 z) (p3 z)))
-       ([x y z & args] (or (sp3 x y z)
-                           (some #(or (p1 %) (p2 %) (p3 %)) args)))))
+   (fn sp3
+     ([] nil)
+     ([x] (or (p1 x) (p2 x) (p3 x)))
+     ([x y] (or (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y)))
+     ([x y z] (or (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y) (p1 z) (p2 z) (p3 z)))
+     ([x y z & args] (or (sp3 x y z)
+                         (some #(or (p1 %) (p2 %) (p3 %)) args)))))
   ([p1 p2 p3 & ps]
-     (let [ps (list* p1 p2 p3 ps)]
-       (fn spn
-         ([] nil)
-         ([x] (some #(% x) ps))
-         ([x y] (some #(or (% x) (% y)) ps))
-         ([x y z] (some #(or (% x) (% y) (% z)) ps))
-         ([x y z & args] (or (spn x y z)
-                             (some #(some % args) ps)))))))
+   (let [ps (list* p1 p2 p3 ps)]
+     (fn spn
+       ([] nil)
+       ([x] (some #(% x) ps))
+       ([x y] (some #(or (% x) (% y)) ps))
+       ([x y z] (some #(or (% x) (% y) (% z)) ps))
+       ([x y z & args] (or (spn x y z)
+                           (some #(some % args) ps)))))))
 
 (defn- ^{:dynamic true} assert-valid-fdecl
   "A good fdecl looks like (([a] ...) ([a b] ...)) near the end of defn."
   [fdecl]
   (when (empty? fdecl) (throw (IllegalArgumentException.
-                                "Parameter declaration missing")))
-  (let [argdecls (map 
-                   #(if (seq? %)
-                      (first %)
-                      (throw (IllegalArgumentException. 
-                        (if (seq? (first fdecl))
-                          (str "Invalid signature \""
-                               %
-                               "\" should be a list")
-                          (str "Parameter declaration \""
-                               %
-                               "\" should be a vector")))))
-                   fdecl)
+                               "Parameter declaration missing")))
+  (let [argdecls (map
+                  #(if (seq? %)
+                     (first %)
+                     (throw (IllegalArgumentException.
+                             (if (seq? (first fdecl))
+                               (str "Invalid signature \""
+                                    %
+                                    "\" should be a list")
+                               (str "Parameter declaration \""
+                                    %
+                                    "\" should be a vector")))))
+                  fdecl)
         bad-args (seq (remove #(vector? %) argdecls))]
     (when bad-args
-      (throw (IllegalArgumentException. (str "Parameter declaration \"" (first bad-args) 
+      (throw (IllegalArgumentException. (str "Parameter declaration \"" (first bad-args)
                                              "\" should be a vector"))))))
 
 (defn with-redefs-fn
@@ -7366,7 +7397,7 @@
   [bindings & body]
   `(with-redefs-fn ~(zipmap (map #(list `var %) (take-nth 2 bindings))
                             (take-nth 2 (next bindings)))
-                    (fn [] ~@body)))
+     (fn [] ~@body)))
 
 (defn realized?
   "Returns true if a value has been produced for a promise, delay, future or lazy sequence."
@@ -7459,12 +7490,12 @@
   collection, into the reduction."
   {:added "1.7"}
   [rf]
-  (let [rrf (preserving-reduced rf)]  
+  (let [rrf (preserving-reduced rf)]
     (fn
       ([] (rf))
       ([result] (rf result))
       ([result input]
-         (reduce rrf result input)))))
+       (reduce rrf result input)))))
 
 (defn dedupe
   "Returns a lazy sequence removing consecutive duplicates in coll.
@@ -7477,11 +7508,11 @@
          ([] (rf))
          ([result] (rf result))
          ([result input]
-            (let [prior @pv]
-              (vreset! pv input)
-              (if (= prior input)
-                result
-                (rf result input))))))))
+          (let [prior @pv]
+            (vreset! pv input)
+            (if (= prior input)
+              result
+              (rf result input))))))))
   ([coll] (sequence (dedupe) coll)))
 
 (defn random-sample
@@ -7489,21 +7520,21 @@
   1.0).  Returns a transducer when no collection is provided."
   {:added "1.7"}
   ([prob]
-     (filter (fn [_] (< (rand) prob))))
+   (filter (fn [_] (< (rand) prob))))
   ([prob coll]
-     (filter (fn [_] (< (rand) prob)) coll)))
+   (filter (fn [_] (< (rand) prob)) coll)))
 
 (deftype Eduction [xform coll]
-   Iterable
-   (iterator [_]
-     (clojure.lang.TransformerIterator/create xform (clojure.lang.RT/iter coll)))
+  Iterable
+  (iterator [_]
+    (clojure.lang.TransformerIterator/create xform (clojure.lang.RT/iter coll)))
 
-   clojure.lang.IReduceInit
-   (reduce [_ f init]
+  clojure.lang.IReduceInit
+  (reduce [_ f init]
      ;; NB (completing f) isolates completion of inner rf from outer rf
-     (transduce xform (completing f) init coll))
+    (transduce xform (completing f) init coll))
 
-   clojure.lang.Sequential)
+  clojure.lang.Sequential)
 
 (defn eduction
   "Returns a reducible/iterable application of the transducers
@@ -7528,7 +7559,6 @@
   [proc coll]
   (reduce #(proc %2) nil coll)
   nil)
-
 
 (defn tagged-literal?
   "Return true if the value is the data representation of a tagged literal"
@@ -7555,9 +7585,6 @@
   {:added "1.7"}
   [form ^Boolean splicing?]
   (clojure.lang.ReaderConditional/create form splicing?))
-
-
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; data readers ;;;;;;;;;;;;;;;;;;
 
@@ -7596,7 +7623,7 @@
   data_readers.clj or by rebinding this Var."
   {})
 
-(def ^{:added "1.5" :dynamic true} *default-data-reader-fn* 
+(def ^{:added "1.5" :dynamic true} *default-data-reader-fn*
   "When no data reader is found for a tag and *default-data-reader-fn*
   is non-nil, it will be called with two arguments,
   the tag and the value.  If *default-data-reader-fn* is nil (the
@@ -7606,8 +7633,8 @@
 (defn- data-reader-urls []
   (let [cl (.. Thread currentThread getContextClassLoader)]
     (concat
-      (enumeration-seq (.getResources cl "data_readers.clj"))
-      (enumeration-seq (.getResources cl "data_readers.cljc")))))
+     (enumeration-seq (.getResources cl "data_readers.clj"))
+     (enumeration-seq (.getResources cl "data_readers.cljc")))))
 
 (defn- data-reader-var [sym]
   (intern (create-ns (symbol (namespace sym)))
@@ -7649,7 +7676,7 @@
                             mappings (data-reader-urls)))))
 
 (try
- (load-data-readers)
- (catch Throwable t
-   (.printStackTrace t)
-   (throw t)))
+  (load-data-readers)
+  (catch Throwable t
+    (.printStackTrace t)
+    (throw t)))

--- a/src/clj/clojure/core/protocols.clj
+++ b/src/clj/clojure/core/protocols.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.core.protocols)
 
@@ -23,12 +23,12 @@
 
 (defn- seq-reduce
   ([coll f]
-     (if-let [s (seq coll)]
-       (internal-reduce (next s) f (first s))
-       (f)))
+   (if-let [s (seq coll)]
+     (internal-reduce (next s) f (first s))
+     (f)))
   ([coll f val]
-     (let [s (seq coll)]
-       (internal-reduce s f val))))
+   (let [s (seq coll)]
+     (internal-reduce s f val))))
 
 (defn- iter-reduce
   ([^java.lang.Iterable coll f]
@@ -75,13 +75,13 @@
 (extend-protocol CollReduce
   nil
   (coll-reduce
-   ([coll f] (f))
-   ([coll f val] val))
+    ([coll f] (f))
+    ([coll f val] val))
 
   Object
   (coll-reduce
-   ([coll f] (seq-reduce coll f))
-   ([coll f val] (seq-reduce coll f val)))
+    ([coll f] (seq-reduce coll f))
+    ([coll f val] (seq-reduce coll f val)))
 
   clojure.lang.IReduceInit
   (coll-reduce
@@ -91,25 +91,25 @@
   ;;aseqs are iterable, masking internal-reducers
   clojure.lang.ASeq
   (coll-reduce
-   ([coll f] (seq-reduce coll f))
-   ([coll f val] (seq-reduce coll f val)))
+    ([coll f] (seq-reduce coll f))
+    ([coll f val] (seq-reduce coll f val)))
 
   ;;for range
   clojure.lang.LazySeq
   (coll-reduce
-   ([coll f] (seq-reduce coll f))
-   ([coll f val] (seq-reduce coll f val)))
+    ([coll f] (seq-reduce coll f))
+    ([coll f val] (seq-reduce coll f val)))
 
   ;;vector's chunked seq is faster than its iter
   clojure.lang.PersistentVector
   (coll-reduce
-   ([coll f] (seq-reduce coll f))
-   ([coll f val] (seq-reduce coll f val)))
-  
+    ([coll f] (seq-reduce coll f))
+    ([coll f val] (seq-reduce coll f val)))
+
   Iterable
   (coll-reduce
-   ([coll f] (iter-reduce coll f))
-   ([coll f val] (iter-reduce coll f val)))
+    ([coll f] (iter-reduce coll f))
+    ([coll f val] (iter-reduce coll f val)))
 
   clojure.lang.APersistentMap$KeySeq
   (coll-reduce
@@ -124,52 +124,52 @@
 (extend-protocol InternalReduce
   nil
   (internal-reduce
-   [s f val]
-   val)
-  
+    [s f val]
+    val)
+
   ;; handles vectors and ranges
   clojure.lang.IChunkedSeq
   (internal-reduce
-   [s f val]
-   (if-let [s (seq s)]
-     (if (chunked-seq? s)
-       (let [ret (.reduce (chunk-first s) f val)]
-         (if (reduced? ret)
-           @ret
-           (recur (chunk-next s)
-                  f
-                  ret)))
-       (interface-or-naive-reduce s f val))
-     val))
- 
+    [s f val]
+    (if-let [s (seq s)]
+      (if (chunked-seq? s)
+        (let [ret (.reduce (chunk-first s) f val)]
+          (if (reduced? ret)
+            @ret
+            (recur (chunk-next s)
+                   f
+                   ret)))
+        (interface-or-naive-reduce s f val))
+      val))
+
   clojure.lang.StringSeq
   (internal-reduce
-   [str-seq f val]
-   (let [s (.s str-seq)]
-     (loop [i (.i str-seq)
-            val val]
-       (if (< i (.length s))
-         (let [ret (f val (.charAt s i))]
-                (if (reduced? ret)
-                  @ret
-                  (recur (inc i) ret)))
-         val))))
-  
+    [str-seq f val]
+    (let [s (.s str-seq)]
+      (loop [i (.i str-seq)
+             val val]
+        (if (< i (.length s))
+          (let [ret (f val (.charAt s i))]
+            (if (reduced? ret)
+              @ret
+              (recur (inc i) ret)))
+          val))))
+
   java.lang.Object
   (internal-reduce
-   [s f val]
-   (loop [cls (class s)
-          s s
-          f f
-          val val]
-     (if-let [s (seq s)]
-       (if (identical? (class s) cls)
-         (let [ret (f val (first s))]
-                (if (reduced? ret)
-                  @ret
-                  (recur cls (next s) f ret)))
-         (interface-or-naive-reduce s f val))
-       val))))
+    [s f val]
+    (loop [cls (class s)
+           s s
+           f f
+           val val]
+      (if-let [s (seq s)]
+        (if (identical? (class s) cls)
+          (let [ret (f val (first s))]
+            (if (reduced? ret)
+              @ret
+              (recur cls (next s) f ret)))
+          (interface-or-naive-reduce s f val))
+        val))))
 
 (defprotocol IKVReduce
   "Protocol for concrete associative types that can reduce themselves

--- a/src/clj/clojure/core/reducers.clj
+++ b/src/clj/clojure/core/reducers.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc
       "A library for reduction and parallel folding. Alpha and subject
@@ -12,7 +12,7 @@
       Java 6 + jsr166y.jar for fork/join support. See Clojure's pom.xml for the
       dependency info."
       :author "Rich Hickey"}
-  clojure.core.reducers
+ clojure.core.reducers
   (:refer-clojure :exclude [reduce map mapcat filter remove take take-while drop flatten cat])
   (:require [clojure.walk :as walk]))
 
@@ -74,9 +74,9 @@
      Maps are reduced with reduce-kv"
   ([f coll] (reduce f (f) coll))
   ([f init coll]
-     (if (instance? java.util.Map coll)
-       (clojure.core.protocols/kv-reduce coll f init)
-       (clojure.core.protocols/coll-reduce coll f init))))
+   (if (instance? java.util.Map coll)
+     (clojure.core.protocols/kv-reduce coll f init)
+     (clojure.core.protocols/coll-reduce coll f init))))
 
 (defprotocol CollFold
   (coll-fold [coll n combinef reducef]))
@@ -95,7 +95,7 @@
   ([reducef coll] (fold reducef reducef coll))
   ([combinef reducef coll] (fold 512 combinef reducef coll))
   ([n combinef reducef coll]
-     (coll-fold coll n combinef reducef)))
+   (coll-fold coll n combinef reducef)))
 
 (defn reducer
   "Given a reducible collection, and a transformation function xf,
@@ -104,12 +104,12 @@
   reducing fn."
   {:added "1.5"}
   ([coll xf]
-     (reify
-      clojure.core.protocols/CollReduce
-      (coll-reduce [this f1]
-                   (clojure.core.protocols/coll-reduce this f1 (f1)))
-      (coll-reduce [_ f1 init]
-                   (clojure.core.protocols/coll-reduce coll (xf f1) init)))))
+   (reify
+     clojure.core.protocols/CollReduce
+     (coll-reduce [this f1]
+       (clojure.core.protocols/coll-reduce this f1 (f1)))
+     (coll-reduce [_ f1 init]
+       (clojure.core.protocols/coll-reduce coll (xf f1) init)))))
 
 (defn folder
   "Given a foldable collection, and a transformation function xf,
@@ -118,16 +118,16 @@
   reducing fn."
   {:added "1.5"}
   ([coll xf]
-     (reify
-      clojure.core.protocols/CollReduce
-      (coll-reduce [_ f1]
-                   (clojure.core.protocols/coll-reduce coll (xf f1) (f1)))
-      (coll-reduce [_ f1 init]
-                   (clojure.core.protocols/coll-reduce coll (xf f1) init))
+   (reify
+     clojure.core.protocols/CollReduce
+     (coll-reduce [_ f1]
+       (clojure.core.protocols/coll-reduce coll (xf f1) (f1)))
+     (coll-reduce [_ f1 init]
+       (clojure.core.protocols/coll-reduce coll (xf f1) init))
 
-      CollFold
-      (coll-fold [_ n combinef reducef]
-                 (coll-fold coll n combinef (xf reducef))))))
+     CollFold
+     (coll-fold [_ n combinef reducef]
+       (coll-fold coll n combinef (xf reducef))))))
 
 (defn- do-curried
   [name doc meta args body]
@@ -163,10 +163,10 @@
   {:added "1.5"}
   [f coll]
   (folder coll
-   (fn [f1]
-     (rfn [f1 k]
-          ([ret k v]
-             (f1 ret (f k v)))))))
+          (fn [f1]
+            (rfn [f1 k]
+              ([ret k v]
+               (f1 ret (f k v)))))))
 
 (defcurried mapcat
   "Applies f to every value in the reduction of coll, concatenating the result
@@ -174,15 +174,15 @@
   {:added "1.5"}
   [f coll]
   (folder coll
-   (fn [f1]
-     (let [f1 (fn
-                ([ret v]
-                  (let [x (f1 ret v)] (if (reduced? x) (reduced x) x)))
+          (fn [f1]
+            (let [f1 (fn
+                       ([ret v]
+                        (let [x (f1 ret v)] (if (reduced? x) (reduced x) x)))
+                       ([ret k v]
+                        (let [x (f1 ret k v)] (if (reduced? x) (reduced x) x))))]
+              (rfn [f1 k]
                 ([ret k v]
-                  (let [x (f1 ret k v)] (if (reduced? x) (reduced x) x))))]
-       (rfn [f1 k]
-            ([ret k v]
-               (reduce f1 ret (f k v))))))))
+                 (reduce f1 ret (f k v))))))))
 
 (defcurried filter
   "Retains values in the reduction of coll for which (pred val)
@@ -190,12 +190,12 @@
   {:added "1.5"}
   [pred coll]
   (folder coll
-   (fn [f1]
-     (rfn [f1 k]
-          ([ret k v]
-             (if (pred k v)
-               (f1 ret k v)
-               ret))))))
+          (fn [f1]
+            (rfn [f1 k]
+              ([ret k v]
+               (if (pred k v)
+                 (f1 ret k v)
+                 ret))))))
 
 (defcurried remove
   "Removes values in the reduction of coll for which (pred val)
@@ -211,53 +211,53 @@
   {:added "1.5"}
   [coll]
   (folder coll
-   (fn [f1]
-     (fn
-       ([] (f1))
-       ([ret v]
-          (if (sequential? v)
-            (clojure.core.protocols/coll-reduce (flatten v) f1 ret)
-            (f1 ret v)))))))
+          (fn [f1]
+            (fn
+              ([] (f1))
+              ([ret v]
+               (if (sequential? v)
+                 (clojure.core.protocols/coll-reduce (flatten v) f1 ret)
+                 (f1 ret v)))))))
 
 (defcurried take-while
   "Ends the reduction of coll when (pred val) returns logical false."
   {:added "1.5"}
   [pred coll]
   (reducer coll
-   (fn [f1]
-     (rfn [f1 k]
-          ([ret k v]
-             (if (pred k v)
-               (f1 ret k v)
-               (reduced ret)))))))
+           (fn [f1]
+             (rfn [f1 k]
+               ([ret k v]
+                (if (pred k v)
+                  (f1 ret k v)
+                  (reduced ret)))))))
 
 (defcurried take
   "Ends the reduction of coll after consuming n values."
   {:added "1.5"}
   [n coll]
   (reducer coll
-   (fn [f1]
-     (let [cnt (atom n)]
-       (rfn [f1 k]
-         ([ret k v]
-            (swap! cnt dec)
-            (if (neg? @cnt)
-              (reduced ret)
-              (f1 ret k v))))))))
+           (fn [f1]
+             (let [cnt (atom n)]
+               (rfn [f1 k]
+                 ([ret k v]
+                  (swap! cnt dec)
+                  (if (neg? @cnt)
+                    (reduced ret)
+                    (f1 ret k v))))))))
 
 (defcurried drop
   "Elides the first n values from the reduction of coll."
   {:added "1.5"}
   [n coll]
   (reducer coll
-   (fn [f1]
-     (let [cnt (atom n)]
-       (rfn [f1 k]
-         ([ret k v]
-            (swap! cnt dec)
-            (if (neg? @cnt)
-              (f1 ret k v)
-              ret)))))))
+           (fn [f1]
+             (let [cnt (atom n)]
+               (rfn [f1 k]
+                 ([ret k v]
+                  (swap! cnt dec)
+                  (if (neg? @cnt)
+                    (f1 ret k v)
+                    ret)))))))
 
 ;;do not construct this directly, use cat
 (deftype Cat [cnt left right]
@@ -270,20 +270,20 @@
   clojure.core.protocols/CollReduce
   (coll-reduce [this f1] (clojure.core.protocols/coll-reduce this f1 (f1)))
   (coll-reduce
-   [_  f1 init]
-   (clojure.core.protocols/coll-reduce
-    right f1
-    (clojure.core.protocols/coll-reduce left f1 init)))
+    [_  f1 init]
+    (clojure.core.protocols/coll-reduce
+     right f1
+     (clojure.core.protocols/coll-reduce left f1 init)))
 
   CollFold
   (coll-fold
-   [_ n combinef reducef]
-   (fjinvoke
-    (fn []
-      (let [rt (fjfork (fjtask #(coll-fold right n combinef reducef)))]
-        (combinef
-         (coll-fold left n combinef reducef)
-         (fjjoin rt)))))))
+    [_ n combinef reducef]
+    (fjinvoke
+     (fn []
+       (let [rt (fjfork (fjtask #(coll-fold right n combinef reducef)))]
+         (combinef
+          (coll-fold left n combinef reducef)
+          (fjjoin rt)))))))
 
 (defn cat
   "A high-performance combining fn that yields the catenation of the
@@ -295,15 +295,15 @@
   {:added "1.5"}
   ([] (java.util.ArrayList.))
   ([ctor]
-     (fn
-       ([] (ctor))
-       ([left right] (cat left right))))
+   (fn
+     ([] (ctor))
+     ([left right] (cat left right))))
   ([left right]
-     (cond
-      (zero? (count left)) right
-      (zero? (count right)) left
-      :else
-      (Cat. (+ (count left) (count right)) left right))))
+   (cond
+     (zero? (count left)) right
+     (zero? (count right)) left
+     :else
+     (Cat. (+ (count left) (count right)) left right))))
 
 (defn append!
   ".adds x to acc and returns acc"
@@ -331,37 +331,37 @@
 (defn- foldvec
   [v n combinef reducef]
   (cond
-   (empty? v) (combinef)
-   (<= (count v) n) (reduce reducef (combinef) v)
-   :else
-   (let [split (quot (count v) 2)
-         v1 (subvec v 0 split)
-         v2 (subvec v split (count v))
-         fc (fn [child] #(foldvec child n combinef reducef))]
-     (fjinvoke
-      #(let [f1 (fc v1)
-             t2 (fjtask (fc v2))]
-         (fjfork t2)
-         (combinef (f1) (fjjoin t2)))))))
+    (empty? v) (combinef)
+    (<= (count v) n) (reduce reducef (combinef) v)
+    :else
+    (let [split (quot (count v) 2)
+          v1 (subvec v 0 split)
+          v2 (subvec v split (count v))
+          fc (fn [child] #(foldvec child n combinef reducef))]
+      (fjinvoke
+       #(let [f1 (fc v1)
+              t2 (fjtask (fc v2))]
+          (fjfork t2)
+          (combinef (f1) (fjjoin t2)))))))
 
 (extend-protocol CollFold
- nil
- (coll-fold
-  [coll n combinef reducef]
-  (combinef))
+  nil
+  (coll-fold
+    [coll n combinef reducef]
+    (combinef))
 
- Object
- (coll-fold
-  [coll n combinef reducef]
+  Object
+  (coll-fold
+    [coll n combinef reducef]
   ;;can't fold, single reduce
-  (reduce reducef (combinef) coll))
+    (reduce reducef (combinef) coll))
 
- clojure.lang.IPersistentVector
- (coll-fold
-  [v n combinef reducef]
-  (foldvec v n combinef reducef))
+  clojure.lang.IPersistentVector
+  (coll-fold
+    [v n combinef reducef]
+    (foldvec v n combinef reducef))
 
- clojure.lang.PersistentHashMap
- (coll-fold
-  [m n combinef reducef]
-  (.fold m n combinef reducef fjinvoke fjtask fjfork fjjoin)))
+  clojure.lang.PersistentHashMap
+  (coll-fold
+    [m n combinef reducef]
+    (.fold m n combinef reducef fjinvoke fjtask fjfork fjjoin)))

--- a/src/clj/clojure/core/server.clj
+++ b/src/clj/clojure/core/server.clj
@@ -1,14 +1,14 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "Socket server support"
       :author "Alex Miller"}
-  clojure.core.server
+ clojure.core.server
   (:require [clojure.string :as str]
             [clojure.edn :as edn]
             [clojure.main :as m])
@@ -35,8 +35,8 @@
 (defmacro ^:private thread
   [^String name daemon & body]
   `(doto (Thread. (fn [] ~@body) ~name)
-    (.setDaemon ~daemon)
-    (.start)))
+     (.setDaemon ~daemon)
+     (.start)))
 
 (defn- required
   "Throw if opts does not contain prop."
@@ -95,8 +95,8 @@
          :or {bind-err true
               server-daemon true
               client-daemon true}} opts
-         address (InetAddress/getByName address)  ;; nil returns loopback
-         socket (ServerSocket. port 0 address)]
+        address (InetAddress/getByName address)  ;; nil returns loopback
+        socket (ServerSocket. port 0 address)]
     (with-lock lock
       (alter-var-root #'servers assoc name {:name name, :socket socket, :sessions {}}))
     (thread
@@ -144,12 +144,12 @@
   "Parse clojure.server.* from properties to produce a map of server configs."
   [props]
   (reduce
-    (fn [acc [^String k ^String v]]
-      (let [[k1 k2 k3] (str/split k #"\.")]
-        (if (and (= k1 "clojure") (= k2 "server"))
-          (conj acc (merge {:name k3} (edn/read-string v)))
-          acc)))
-    [] props))
+   (fn [acc [^String k ^String v]]
+     (let [[k1 k2 k3] (str/split k #"\.")]
+       (if (and (= k1 "clojure") (= k2 "server"))
+         (conj acc (merge {:name k3} (edn/read-string v)))
+         acc)))
+   [] props))
 
 (defn start-servers
   "Start all servers specified in the system properties."
@@ -167,7 +167,7 @@
   "Enhanced :read hook for repl supporting :repl/quit."
   [request-prompt request-exit]
   (or ({:line-start request-prompt :stream-end request-exit}
-        (m/skip-whitespace *in*))
+       (m/skip-whitespace *in*))
       (let [input (read {:read-cond :allow} *in*)]
         (m/skip-if-eol *in*)
         (case input
@@ -178,5 +178,5 @@
   "REPL with predefined hooks for attachable socket server."
   []
   (m/repl
-    :init repl-init
-    :read repl-read))
+   :init repl-init
+   :read repl-read))

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (in-ns 'clojure.core)
 
@@ -31,7 +31,7 @@
         psig (fn [[name [& args]]]
                (vector name (vec (map tag args)) (tag name) (map meta args)))
         cname (with-meta (symbol (str (namespace-munge *ns*) "." name)) (meta name))]
-    `(let [] 
+    `(let []
        (gen-interface :name ~cname :methods ~(vec (map psig sigs)))
        (import ~cname))))
 
@@ -53,7 +53,7 @@
 (defn- parse-opts+specs [opts+specs]
   (let [[opts specs] (parse-opts opts+specs)
         impls (parse-impls specs)
-        interfaces (-> (map #(if (var? (resolve %)) 
+        interfaces (-> (map #(if (var? (resolve %))
                                (:on (deref (resolve %)))
                                %)
                             (keys impls))
@@ -67,11 +67,11 @@
       (throw (IllegalArgumentException. (apply print-str "Unsupported option(s) -" bad-opts))))
     [interfaces methods opts]))
 
-(defmacro reify 
+(defmacro reify
   "reify is a macro with the following structure:
 
  (reify options* specs*)
-  
+
   Currently there are no options.
 
   Each spec consists of the protocol or interface name followed by zero
@@ -102,28 +102,28 @@
 
   recur works to method heads The method bodies of reify are lexical
   closures, and can refer to the surrounding local scope:
-  
-  (str (let [f \"foo\"] 
-       (reify Object 
+
+  (str (let [f \"foo\"]
+       (reify Object
          (toString [this] f))))
   == \"foo\"
 
-  (seq (let [f \"foo\"] 
-       (reify clojure.lang.Seqable 
+  (seq (let [f \"foo\"]
+       (reify clojure.lang.Seqable
          (seq [this] (seq f)))))
   == (\\f \\o \\o))
-  
+
   reify always implements clojure.lang.IObj and transfers meta
   data of the form to the created object.
-  
+
   (meta ^{:k :v} (reify Object (toString [this] \"foo\")))
   == {:k :v}"
-  {:added "1.2"} 
+  {:added "1.2"}
   [& opts+specs]
   (let [[interfaces methods] (parse-opts+specs opts+specs)]
     (with-meta `(reify* ~interfaces ~@methods) (meta &form))))
 
-(defn hash-combine [x y] 
+(defn hash-combine [x y]
   (clojure.lang.Util/hashCombine x (clojure.lang.Util/hash y)))
 
 (defn munge [s]
@@ -132,20 +132,20 @@
 (defn- imap-cons
   [^IPersistentMap this o]
   (cond
-   (map-entry? o)
-     (let [^java.util.Map$Entry pair o]
-       (.assoc this (.getKey pair) (.getValue pair)))
-   (instance? clojure.lang.IPersistentVector o)
-     (let [^clojure.lang.IPersistentVector vec o]
-       (.assoc this (.nth vec 0) (.nth vec 1)))
-   :else (loop [this this
-                o o]
-      (if (seq o)
-        (let [^java.util.Map$Entry pair (first o)]
-          (recur (.assoc this (.getKey pair) (.getValue pair)) (rest o)))
-        this))))
+    (map-entry? o)
+    (let [^java.util.Map$Entry pair o]
+      (.assoc this (.getKey pair) (.getValue pair)))
+    (instance? clojure.lang.IPersistentVector o)
+    (let [^clojure.lang.IPersistentVector vec o]
+      (.assoc this (.nth vec 0) (.nth vec 1)))
+    :else (loop [this this
+                 o o]
+            (if (seq o)
+              (let [^java.util.Map$Entry pair (first o)]
+                (recur (.assoc this (.getKey pair) (.getValue pair)) (rest o)))
+              this))))
 
-(defn- emit-defrecord 
+(defn- emit-defrecord
   "Do not use this directly - use defrecord"
   {:added "1.2"}
   [tagname cname fields interfaces methods opts]
@@ -161,92 +161,91 @@
     (when (some #{:volatile-mutable :unsynchronized-mutable} (mapcat (comp keys meta) hinted-fields))
       (throw (IllegalArgumentException. ":volatile-mutable or :unsynchronized-mutable not supported for record fields")))
     (let [gs (gensym)]
-    (letfn 
-     [(irecord [[i m]]
-        [(conj i 'clojure.lang.IRecord)
-         m])
-      (eqhash [[i m]] 
-        [(conj i 'clojure.lang.IHashEq)
-         (conj m
-               `(hasheq [this#] (bit-xor ~type-hash (clojure.lang.APersistentMap/mapHasheq this#)))
-               `(hashCode [this#] (clojure.lang.APersistentMap/mapHash this#))
-               `(equals [this# ~gs] (clojure.lang.APersistentMap/mapEquals this# ~gs)))])
-      (iobj [[i m]] 
-            [(conj i 'clojure.lang.IObj)
-             (conj m `(meta [this#] ~'__meta)
-                   `(withMeta [this# ~gs] (new ~tagname ~@(replace {'__meta gs} fields))))])
-      (ilookup [[i m]] 
-         [(conj i 'clojure.lang.ILookup 'clojure.lang.IKeywordLookup)
-          (conj m `(valAt [this# k#] (.valAt this# k# nil))
-                `(valAt [this# k# else#] 
-                   (case k# ~@(mapcat (fn [fld] [(keyword fld) fld]) 
-                                       base-fields)
-                         (get ~'__extmap k# else#)))
-                `(getLookupThunk [this# k#]
-                   (let [~'gclass (class this#)]              
-                     (case k#
-                           ~@(let [hinted-target (with-meta 'gtarget {:tag tagname})] 
-                               (mapcat 
-                                (fn [fld]
-                                  [(keyword fld)
-                                   `(reify clojure.lang.ILookupThunk
-                                           (get [~'thunk ~'gtarget]
-                                                (if (identical? (class ~'gtarget) ~'gclass)
-                                                  (. ~hinted-target ~(symbol (str "-" fld)))
-                                                  ~'thunk)))])
-                                base-fields))
-                           nil))))])
-      (imap [[i m]] 
-            [(conj i 'clojure.lang.IPersistentMap)
-             (conj m 
-                   `(count [this#] (+ ~(count base-fields) (count ~'__extmap)))
-                   `(empty [this#] (throw (UnsupportedOperationException. (str "Can't create empty: " ~(str classname)))))
-                   `(cons [this# e#] ((var imap-cons) this# e#))
-                   `(equiv [this# ~gs] 
-                        (boolean 
-                         (or (identical? this# ~gs)
-                             (when (identical? (class this#) (class ~gs))
-                               (let [~gs ~(with-meta gs {:tag tagname})]
-                                 (and  ~@(map (fn [fld] `(= ~fld (. ~gs ~(symbol (str "-" fld))))) base-fields)
-                                       (= ~'__extmap (. ~gs ~'__extmap))))))))
-                   `(containsKey [this# k#] (not (identical? this# (.valAt this# k# this#))))
-                   `(entryAt [this# k#] (let [v# (.valAt this# k# this#)]
+      (letfn
+       [(irecord [[i m]]
+          [(conj i 'clojure.lang.IRecord)
+           m])
+        (eqhash [[i m]]
+                [(conj i 'clojure.lang.IHashEq)
+                 (conj m
+                       `(hasheq [this#] (bit-xor ~type-hash (clojure.lang.APersistentMap/mapHasheq this#)))
+                       `(hashCode [this#] (clojure.lang.APersistentMap/mapHash this#))
+                       `(equals [this# ~gs] (clojure.lang.APersistentMap/mapEquals this# ~gs)))])
+        (iobj [[i m]]
+              [(conj i 'clojure.lang.IObj)
+               (conj m `(meta [this#] ~'__meta)
+                     `(withMeta [this# ~gs] (new ~tagname ~@(replace {'__meta gs} fields))))])
+        (ilookup [[i m]]
+                 [(conj i 'clojure.lang.ILookup 'clojure.lang.IKeywordLookup)
+                  (conj m `(valAt [this# k#] (.valAt this# k# nil))
+                        `(valAt [this# k# else#]
+                                (case k# ~@(mapcat (fn [fld] [(keyword fld) fld])
+                                                   base-fields)
+                                      (get ~'__extmap k# else#)))
+                        `(getLookupThunk [this# k#]
+                                         (let [~'gclass (class this#)]
+                                           (case k#
+                                             ~@(let [hinted-target (with-meta 'gtarget {:tag tagname})]
+                                                 (mapcat
+                                                  (fn [fld]
+                                                    [(keyword fld)
+                                                     `(reify clojure.lang.ILookupThunk
+                                                        (get [~'thunk ~'gtarget]
+                                                          (if (identical? (class ~'gtarget) ~'gclass)
+                                                            (. ~hinted-target ~(symbol (str "-" fld)))
+                                                            ~'thunk)))])
+                                                  base-fields))
+                                             nil))))])
+        (imap [[i m]]
+              [(conj i 'clojure.lang.IPersistentMap)
+               (conj m
+                     `(count [this#] (+ ~(count base-fields) (count ~'__extmap)))
+                     `(empty [this#] (throw (UnsupportedOperationException. (str "Can't create empty: " ~(str classname)))))
+                     `(cons [this# e#] ((var imap-cons) this# e#))
+                     `(equiv [this# ~gs]
+                             (boolean
+                              (or (identical? this# ~gs)
+                                  (when (identical? (class this#) (class ~gs))
+                                    (let [~gs ~(with-meta gs {:tag tagname})]
+                                      (and  ~@(map (fn [fld] `(= ~fld (. ~gs ~(symbol (str "-" fld))))) base-fields)
+                                            (= ~'__extmap (. ~gs ~'__extmap))))))))
+                     `(containsKey [this# k#] (not (identical? this# (.valAt this# k# this#))))
+                     `(entryAt [this# k#] (let [v# (.valAt this# k# this#)]
                                             (when-not (identical? this# v#)
                                               (clojure.lang.MapEntry/create k# v#))))
-                   `(seq [this#] (seq (concat [~@(map #(list `clojure.lang.MapEntry/create (keyword %) %) base-fields)]
-                                              ~'__extmap)))
-                   `(iterator [~gs]
-                        (clojure.lang.RecordIterator. ~gs [~@(map keyword base-fields)] (RT/iter ~'__extmap)))
-                   `(assoc [this# k# ~gs]
-                     (condp identical? k#
-                       ~@(mapcat (fn [fld]
-                                   [(keyword fld) (list* `new tagname (replace {fld gs} fields))])
-                                 base-fields)
-                       (new ~tagname ~@(remove #{'__extmap} fields) (assoc ~'__extmap k# ~gs))))
-                   `(without [this# k#] (if (contains? #{~@(map keyword base-fields)} k#)
+                     `(seq [this#] (seq (concat [~@(map #(list `clojure.lang.MapEntry/create (keyword %) %) base-fields)]
+                                                ~'__extmap)))
+                     `(iterator [~gs]
+                                (clojure.lang.RecordIterator. ~gs [~@(map keyword base-fields)] (RT/iter ~'__extmap)))
+                     `(assoc [this# k# ~gs]
+                             (condp identical? k#
+                               ~@(mapcat (fn [fld]
+                                           [(keyword fld) (list* `new tagname (replace {fld gs} fields))])
+                                         base-fields)
+                               (new ~tagname ~@(remove #{'__extmap} fields) (assoc ~'__extmap k# ~gs))))
+                     `(without [this# k#] (if (contains? #{~@(map keyword base-fields)} k#)
                                             (dissoc (with-meta (into {} this#) ~'__meta) k#)
-                                            (new ~tagname ~@(remove #{'__extmap} fields) 
+                                            (new ~tagname ~@(remove #{'__extmap} fields)
                                                  (not-empty (dissoc ~'__extmap k#))))))])
-      (ijavamap [[i m]]
-                [(conj i 'java.util.Map 'java.io.Serializable)
-                 (conj m
-                       `(size [this#] (.count this#))
-                       `(isEmpty [this#] (= 0 (.count this#)))
-                       `(containsValue [this# v#] (boolean (some #{v#} (vals this#))))
-                       `(get [this# k#] (.valAt this# k#))
-                       `(put [this# k# v#] (throw (UnsupportedOperationException.)))
-                       `(remove [this# k#] (throw (UnsupportedOperationException.)))
-                       `(putAll [this# m#] (throw (UnsupportedOperationException.)))
-                       `(clear [this#] (throw (UnsupportedOperationException.)))
-                       `(keySet [this#] (set (keys this#)))
-                       `(values [this#] (vals this#))
-                       `(entrySet [this#] (set this#)))])
-      ]
-     (let [[i m] (-> [interfaces methods] irecord eqhash iobj ilookup imap ijavamap)]
-       `(deftype* ~(symbol (name *ns*) (name tagname)) ~classname ~(conj hinted-fields '__meta '__extmap)
-          :implements ~(vec i) 
-          ~@(mapcat identity opts)
-          ~@m))))))
+        (ijavamap [[i m]]
+                  [(conj i 'java.util.Map 'java.io.Serializable)
+                   (conj m
+                         `(size [this#] (.count this#))
+                         `(isEmpty [this#] (= 0 (.count this#)))
+                         `(containsValue [this# v#] (boolean (some #{v#} (vals this#))))
+                         `(get [this# k#] (.valAt this# k#))
+                         `(put [this# k# v#] (throw (UnsupportedOperationException.)))
+                         `(remove [this# k#] (throw (UnsupportedOperationException.)))
+                         `(putAll [this# m#] (throw (UnsupportedOperationException.)))
+                         `(clear [this#] (throw (UnsupportedOperationException.)))
+                         `(keySet [this#] (set (keys this#)))
+                         `(values [this#] (vals this#))
+                         `(entrySet [this#] (set this#)))])]
+        (let [[i m] (-> [interfaces methods] irecord eqhash iobj ilookup imap ijavamap)]
+          `(deftype* ~(symbol (name *ns*) (name tagname)) ~classname ~(conj hinted-fields '__meta '__extmap)
+             :implements ~(vec i)
+             ~@(mapcat identity opts)
+             ~@m))))))
 
 (defn- build-positional-factory
   "Used to build a positional factory for a given type/record.  Because of the
@@ -400,7 +399,7 @@
   (let [classname (with-meta (symbol (str (namespace-munge *ns*) "." cname)) (meta cname))
         interfaces (conj interfaces 'clojure.lang.IType)]
     `(deftype* ~(symbol (name *ns*) (name tagname)) ~classname ~fields
-       :implements ~interfaces 
+       :implements ~interfaces
        ~@(mapcat identity opts)
        ~@methods)))
 
@@ -423,7 +422,7 @@
   Dynamically generates compiled bytecode for class with the given
   name, in a package with the same name as the current namespace, the
   given fields, and, optionally, methods for protocols and/or
-  interfaces. 
+  interfaces.
 
   The class will have the (by default, immutable) fields named by
   fields, which can have type hints. Protocols/interfaces and methods
@@ -513,9 +512,9 @@
 
 (defn- pref
   ([] nil)
-  ([a] a) 
+  ([a] a)
   ([^Class a ^Class b]
-     (if (.isAssignableFrom a b) b a)))
+   (if (.isAssignableFrom a b) b a)))
 
 (defn find-protocol-impl [protocol x]
   (if (instance? (:on-interface protocol) x)
@@ -538,20 +537,20 @@
 (defn- implements? [protocol atype]
   (and atype (.isAssignableFrom ^Class (:on-interface protocol) atype)))
 
-(defn extends? 
+(defn extends?
   "Returns true if atype extends protocol"
   {:added "1.2"}
   [protocol atype]
-  (boolean (or (implements? protocol atype) 
+  (boolean (or (implements? protocol atype)
                (get (:impls protocol) atype))))
 
-(defn extenders 
+(defn extenders
   "Returns a collection of the types explicitly extending protocol"
   {:added "1.2"}
   [protocol]
   (keys (:impls protocol)))
 
-(defn satisfies? 
+(defn satisfies?
   "Returns true if x satisfies the protocol"
   {:added "1.2"}
   [protocol x]
@@ -560,11 +559,11 @@
 (defn -cache-protocol-fn [^clojure.lang.AFunction pf x ^Class c ^clojure.lang.IFn interf]
   (let [cache  (.__methodImplCache pf)
         f (if (.isInstance c x)
-            interf 
+            interf
             (find-protocol-method (.protocol cache) (.methodk cache) x))]
     (when-not f
-      (throw (IllegalArgumentException. (str "No implementation of method: " (.methodk cache) 
-                                             " of protocol: " (:var (.protocol cache)) 
+      (throw (IllegalArgumentException. (str "No implementation of method: " (.methodk cache)
+                                             " of protocol: " (:var (.protocol cache))
                                              " found for class: " (if (nil? x) "nil" (.getName (class x)))))))
     (set! (.__methodImplCache pf) (expand-method-impl-cache cache (class x) f))
     f))
@@ -576,25 +575,25 @@
     `(fn [cache#]
        (let [~ginterf
              (fn
-               ~@(map 
+               ~@(map
                   (fn [args]
                     (let [gargs (map #(gensym (str "gf__" % "__")) args)
                           target (first gargs)]
                       `([~@gargs]
-                          (. ~(with-meta target {:tag on-interface}) (~(or on-method method) ~@(rest gargs))))))
+                        (. ~(with-meta target {:tag on-interface}) (~(or on-method method) ~@(rest gargs))))))
                   arglists))
              ^clojure.lang.AFunction f#
              (fn ~gthis
-               ~@(map 
+               ~@(map
                   (fn [args]
                     (let [gargs (map #(gensym (str "gf__" % "__")) args)
                           target (first gargs)]
                       `([~@gargs]
-                          (let [cache# (.__methodImplCache ~gthis)
-                                f# (.fnFor cache# (clojure.lang.Util/classOf ~target))]
-                            (if f# 
-                              (f# ~@gargs)
-                              ((-cache-protocol-fn ~gthis ~target ~on-interface ~ginterf) ~@gargs))))))
+                        (let [cache# (.__methodImplCache ~gthis)
+                              f# (.fnFor cache# (clojure.lang.Util/classOf ~target))]
+                          (if f#
+                            (f# ~@gargs)
+                            ((-cache-protocol-fn ~gthis ~target ~on-interface ~ginterf) ~@gargs))))))
                   arglists))]
          (set! (.__methodImplCache f#) cache#)
          f#))))
@@ -619,7 +618,7 @@
   (let [iname (symbol (str (munge (namespace-munge *ns*)) "." (munge name)))
         [opts sigs]
         (loop [opts {:on (list 'quote iname) :on-interface iname} sigs opts+sigs]
-          (condp #(%1 %2) (first sigs) 
+          (condp #(%1 %2) (first sigs)
             string? (recur (assoc opts :doc (first sigs)) (next sigs))
             keyword? (recur (assoc opts (first sigs) (second sigs)) (nnext sigs))
             [opts sigs]))
@@ -644,37 +643,37 @@
                         {} sigs))
         meths (mapcat (fn [sig]
                         (let [m (munge (:name sig))]
-                          (map #(vector m (vec (repeat (dec (count %))'Object)) 'Object) 
+                          (map #(vector m (vec (repeat (dec (count %)) 'Object)) 'Object)
                                (:arglists sig))))
                       (vals sigs))]
-  `(do
-     (defonce ~name {})
-     (gen-interface :name ~iname :methods ~meths)
-     (alter-meta! (var ~name) assoc :doc ~(:doc opts))
-     ~(when sigs
-        `(#'assert-same-protocol (var ~name) '~(map :name (vals sigs))))
-     (alter-var-root (var ~name) merge 
-                     (assoc ~opts 
-                       :sigs '~sigs 
-                       :var (var ~name)
-                       :method-map 
-                         ~(and (:on opts)
-                               (apply hash-map 
-                                      (mapcat 
-                                       (fn [s] 
-                                         [(keyword (:name s)) (keyword (or (:on s) (:name s)))])
-                                       (vals sigs))))
-                       :method-builders 
-                        ~(apply hash-map 
-                                (mapcat 
-                                 (fn [s]
-                                   [`(intern *ns* (with-meta '~(:name s) (merge '~s {:protocol (var ~name)})))
-                                    (emit-method-builder (:on-interface opts) (:name s) (:on s) (:arglists s))])
-                                 (vals sigs)))))
-     (-reset-methods ~name)
-     '~name)))
+    `(do
+       (defonce ~name {})
+       (gen-interface :name ~iname :methods ~meths)
+       (alter-meta! (var ~name) assoc :doc ~(:doc opts))
+       ~(when sigs
+          `(#'assert-same-protocol (var ~name) '~(map :name (vals sigs))))
+       (alter-var-root (var ~name) merge
+                       (assoc ~opts
+                              :sigs '~sigs
+                              :var (var ~name)
+                              :method-map
+                              ~(and (:on opts)
+                                    (apply hash-map
+                                           (mapcat
+                                            (fn [s]
+                                              [(keyword (:name s)) (keyword (or (:on s) (:name s)))])
+                                            (vals sigs))))
+                              :method-builders
+                              ~(apply hash-map
+                                      (mapcat
+                                       (fn [s]
+                                         [`(intern *ns* (with-meta '~(:name s) (merge '~s {:protocol (var ~name)})))
+                                          (emit-method-builder (:on-interface opts) (:name s) (:on s) (:arglists s))])
+                                       (vals sigs)))))
+       (-reset-methods ~name)
+       '~name)))
 
-(defmacro defprotocol 
+(defmacro defprotocol
   "A protocol is a named set of named methods and their signatures:
   (defprotocol AProtocolName
 
@@ -690,9 +689,9 @@
   polymorphic functions and a protocol object. All are
   namespace-qualified by the ns enclosing the definition The resulting
   functions dispatch on the type of their first argument, which is
-  required and corresponds to the implicit target object ('this' in 
-  Java parlance). defprotocol is dynamic, has no special compile-time 
-  effect, and defines no new types or classes. Implementations of 
+  required and corresponds to the implicit target object ('this' in
+  Java parlance). defprotocol is dynamic, has no special compile-time
+  effect, and defines no new types or classes. Implementations of
   the protocol methods can be provided using extend.
 
   defprotocol will automatically generate a corresponding interface,
@@ -704,31 +703,31 @@
   Note that you should not use this interface with deftype or
   reify, as they support the protocol directly:
 
-  (defprotocol P 
-    (foo [this]) 
+  (defprotocol P
+    (foo [this])
     (bar-me [this] [this y]))
 
-  (deftype Foo [a b c] 
+  (deftype Foo [a b c]
    P
     (foo [this] a)
     (bar-me [this] b)
     (bar-me [this y] (+ c y)))
-  
+
   (bar-me (Foo. 1 2 3) 42)
   => 45
 
-  (foo 
+  (foo
     (let [x 42]
-      (reify P 
+      (reify P
         (foo [this] 17)
         (bar-me [this] x)
         (bar-me [this y] x))))
   => 17"
-  {:added "1.2"} 
+  {:added "1.2"}
   [name & opts+sigs]
   (emit-protocol name opts+sigs))
 
-(defn extend 
+(defn extend
   "Implementations of protocol methods can be provided using the extend construct:
 
   (extend AType
@@ -736,14 +735,14 @@
      {:foo an-existing-fn
       :bar (fn [a b] ...)
       :baz (fn ([a]...) ([a b] ...)...)}
-    BProtocol 
-      {...} 
+    BProtocol
+      {...}
     ...)
- 
+
   extend takes a type/class (or interface, see below), and one or more
   protocol + method map pairs. It will extend the polymorphism of the
   protocol's methods to call the supplied methods when an AType is
-  provided as the first argument. 
+  provided as the first argument.
 
   Method maps are maps of the keyword-ized method names to ordinary
   fns. This facilitates easy reuse of existing fns and fn maps, for
@@ -763,15 +762,15 @@
 
   See also:
   extends?, satisfies?, extenders"
-  {:added "1.2"} 
+  {:added "1.2"}
   [atype & proto+mmaps]
   (doseq [[proto mmap] (partition 2 proto+mmaps)]
     (when-not (protocol? proto)
       (throw (IllegalArgumentException.
               (str proto " is not a protocol"))))
     (when (implements? proto atype)
-      (throw (IllegalArgumentException. 
-              (str atype " already directly implements " (:on-interface proto) " for protocol:"  
+      (throw (IllegalArgumentException.
+              (str atype " already directly implements " (:on-interface proto) " for protocol:"
                    (:var proto)))))
     (-reset-methods (alter-var-root (:var proto) assoc-in [:impls atype] mmap))))
 
@@ -781,9 +780,9 @@
 
 (defn- emit-hinted-impl [c [p fs]]
   (let [hint (fn [specs]
-               (let [specs (if (vector? (first specs)) 
-                                        (list specs) 
-                                        specs)]
+               (let [specs (if (vector? (first specs))
+                             (list specs)
+                             specs)]
                  (map (fn [[[target & args] & body]]
                         (cons (apply vector (vary-meta target assoc :tag c) args)
                               body))
@@ -794,15 +793,15 @@
 (defn- emit-extend-type [c specs]
   (let [impls (parse-impls specs)]
     `(extend ~c
-             ~@(mapcat (partial emit-hinted-impl c) impls))))
+       ~@(mapcat (partial emit-hinted-impl c) impls))))
 
-(defmacro extend-type 
+(defmacro extend-type
   "A macro that expands into an extend call. Useful when you are
   supplying the definitions explicitly inline, extend-type
   automatically creates the maps required by extend.  Propagates the
   class as a type hint on the first argument of all fns.
 
-  (extend-type MyType 
+  (extend-type MyType
     Countable
       (cnt [c] ...)
     Foo
@@ -817,7 +816,7 @@
    Foo
      {:baz (fn ([x] ...) ([x y & zs] ...))
       :bar (fn [x y] ...)})"
-  {:added "1.2"} 
+  {:added "1.2"}
   [t & specs]
   (emit-extend-type t specs))
 
@@ -828,7 +827,7 @@
                 `(extend-type ~t ~p ~@fs))
               impls))))
 
-(defmacro extend-protocol 
+(defmacro extend-protocol
   "Useful when you want to provide several implementations of the same
   protocol all at once. Takes a single protocol and the implementation
   of that protocol for one or more types. Expands into calls to
@@ -851,17 +850,17 @@
   expands into:
 
   (do
-   (clojure.core/extend-type AType Protocol 
-     (foo [x] ...) 
+   (clojure.core/extend-type AType Protocol
+     (foo [x] ...)
      (bar [x y] ...))
-   (clojure.core/extend-type BType Protocol 
-     (foo [x] ...) 
+   (clojure.core/extend-type BType Protocol
+     (foo [x] ...)
      (bar [x y] ...))
-   (clojure.core/extend-type AClass Protocol 
-     (foo [x] ...) 
+   (clojure.core/extend-type AClass Protocol
+     (foo [x] ...)
      (bar [x y] ...))
-   (clojure.core/extend-type nil Protocol 
-     (foo [x] ...) 
+   (clojure.core/extend-type nil Protocol
+     (foo [x] ...)
      (bar [x y] ...)))"
   {:added "1.2"}
 

--- a/src/clj/clojure/core_print.clj
+++ b/src/clj/clojure/core_print.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (in-ns 'clojure.core)
 
@@ -14,18 +14,18 @@
 
 (set! *warn-on-reflection* true)
 (def ^:dynamic
- ^{:doc "*print-length* controls how many items of each collection the
+  ^{:doc "*print-length* controls how many items of each collection the
   printer will print. If it is bound to logical false, there is no
   limit. Otherwise, it must be bound to an integer indicating the maximum
   number of items of each collection to print. If a collection contains
   more items, the printer will print items up to the limit followed by
   '...' to represent the remaining items. The root binding is nil
   indicating no limit."
-   :added "1.0"}
- *print-length* nil)
+    :added "1.0"}
+  *print-length* nil)
 
 (def ^:dynamic
- ^{:doc "*print-level* controls how many levels deep the printer will
+  ^{:doc "*print-level* controls how many levels deep the printer will
   print nested objects. If it is bound to logical false, there is no
   limit. Otherwise, it must be bound to an integer indicating the maximum
   level to print. Each argument to print is at level 0; if an argument is a
@@ -33,8 +33,8 @@
   collection and is at a level greater than or equal to the value bound to
   *print-level*, the printer prints '#' to represent it. The root binding
   is nil indicating no limit."
-   :added "1.0"}
- *print-level* nil)
+    :added "1.0"}
+  *print-level* nil)
 
 (def ^:dynamic *verbose-defrecords* false)
 
@@ -69,8 +69,8 @@
                    (and *print-meta* *print-readably*)))
       (.write w "^")
       (if (and (= (count m) 1) (:tag m))
-          (pr-on (:tag m) w)
-          (pr-on m w))
+        (pr-on (:tag m) w)
+        (pr-on m w))
       (.write w " "))))
 
 (defn print-simple [o, ^Writer w]
@@ -124,7 +124,7 @@
 (defmethod print-dup Number [o, ^Writer w]
   (print-ctor o
               (fn [o w]
-                  (print-dup (str o) w))
+                (print-dup (str o) w))
               w))
 
 (defmethod print-dup clojure.lang.Fn [o, ^Writer w]
@@ -161,10 +161,8 @@
 (prefer-method print-method clojure.lang.ISeq java.util.Collection)
 (prefer-method print-dup clojure.lang.ISeq java.util.Collection)
 
-
-
 (defmethod print-dup java.util.Collection [o, ^Writer w]
- (print-ctor o #(print-sequential "[" print-dup " " "]" %1 %2) w))
+  (print-ctor o #(print-sequential "[" print-dup " " "]" %1 %2) w))
 
 (defmethod print-dup clojure.lang.IPersistentCollection [o, ^Writer w]
   (print-meta o w)
@@ -176,26 +174,26 @@
 
 (prefer-method print-dup clojure.lang.IPersistentCollection java.util.Collection)
 
-(def ^{:tag String 
+(def ^{:tag String
        :doc "Returns escape string for char or nil if none"
        :added "1.0"}
   char-escape-string
-    {\newline "\\n"
-     \tab  "\\t"
-     \return "\\r"
-     \" "\\\""
-     \\  "\\\\"
-     \formfeed "\\f"
-     \backspace "\\b"})
+  {\newline "\\n"
+   \tab  "\\t"
+   \return "\\r"
+   \" "\\\""
+   \\  "\\\\"
+   \formfeed "\\f"
+   \backspace "\\b"})
 
 (defmethod print-method String [^String s, ^Writer w]
   (if (or *print-dup* *print-readably*)
     (do (.append w \")
-      (dotimes [n (count s)]
-        (let [c (.charAt s n)
-              e (char-escape-string c)]
-          (if e (.write w e) (.append w c))))
-      (.append w \"))
+        (dotimes [n (count s)]
+          (let [c (.charAt s n)
+                e (char-escape-string c)]
+            (if e (.write w e) (.append w c))))
+        (.append w \"))
     (.write w s))
   nil)
 
@@ -206,7 +204,7 @@
   (print-sequential "[" pr-on " " "]" v w))
 
 (defn- print-map [m print-one w]
-  (print-sequential 
+  (print-sequential
    "{"
    (fn [e  ^Writer w]
      (do (print-one (key e) w) (.append w \space) (print-one (val e) w)))
@@ -292,14 +290,14 @@
 
 (def ^{:tag String
        :doc "Returns name string for char or nil if none"
-       :added "1.0"} 
- char-name-string
-   {\newline "newline"
-    \tab "tab"
-    \space "space"
-    \backspace "backspace"
-    \formfeed "formfeed"
-    \return "return"})
+       :added "1.0"}
+  char-name-string
+  {\newline "newline"
+   \tab "tab"
+   \space "space"
+   \backspace "backspace"
+   \formfeed "formfeed"
+   \return "return"})
 
 (defmethod print-method java.lang.Character [^Character c, ^Writer w]
   (if (or *print-dup* *print-readably*)
@@ -365,8 +363,8 @@
                    (.append w \\)
                    (.append w c2)
                    (if qmode
-                      (recur r2 (not= c2 \E))
-                      (recur r2 (= c2 \Q))))
+                     (recur r2 (not= c2 \E))
+                     (recur r2 (= c2 \Q))))
         (= c \") (do
                    (if qmode
                      (.write w "\\E\\\"\\Q")
@@ -394,16 +392,16 @@
                  [true e])))]
     {:status
      (cond
-      (or ex
-          (and (instance? clojure.lang.Agent o)
-               (agent-error o)))
-      :failed
+       (or ex
+           (and (instance? clojure.lang.Agent o)
+                (agent-error o)))
+       :failed
 
-      pending
-      :pending
+       pending
+       :pending
 
-      :else
-      :ready)
+       :else
+       :ready)
 
      :val val}))
 
@@ -442,15 +440,15 @@
   (.write w "#error {\n :cause ")
   (let [{:keys [cause data via trace]} (Throwable->map o)
         print-via #(do (.write w "{:type ")
-		               (print-method (:type %) w)
-					   (.write w "\n   :message ")
-					   (print-method (:message %) w)
-             (when-let [data (:data %)]
-               (.write w "\n   :data ")
-               (print-method data w))
-					   (.write w "\n   :at ")
-					   (print-method (:at %) w)
-					   (.write w "}"))]
+                       (print-method (:type %) w)
+                       (.write w "\n   :message ")
+                       (print-method (:message %) w)
+                       (when-let [data (:data %)]
+                         (.write w "\n   :data ")
+                         (print-method data w))
+                       (.write w "\n   :at ")
+                       (print-method (:at %) w)
+                       (.write w "}"))]
     (print-method cause w)
     (when data
       (.write w "\n :data ")
@@ -458,10 +456,10 @@
     (when via
       (.write w "\n :via\n [")
       (when-let [fv (first via)]
-	    (print-via fv)
+        (print-via fv)
         (doseq [v (rest via)]
           (.write w "\n  ")
-		  (print-via v)))
+          (print-via v)))
       (.write w "]"))
     (when trace
       (.write w "\n :trace\n [")

--- a/src/clj/clojure/data.clj
+++ b/src/clj/clojure/data.clj
@@ -1,15 +1,15 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-(ns 
-  ^{:author "Stuart Halloway",
-    :doc "Non-core data functions."}
-  clojure.data
+(ns
+ ^{:author "Stuart Halloway",
+   :doc "Non-core data functions."}
+ clojure.data
   (:require [clojure.set :as set]))
 
 (declare diff)
@@ -43,8 +43,7 @@
                       (and (nil? va) (nil? vb))))]
     [(when (and in-a (or (not (nil? a*)) (not same))) {k a*})
      (when (and in-b (or (not (nil? b*)) (not same))) {k b*})
-     (when same {k ab})
-     ]))
+     (when same {k ab})]))
 
 (defn- diff-associative
   "Diff associative things a and b, comparing only keys in ks."
@@ -73,25 +72,25 @@
   (^{:added "1.3"} diff-similar [a b] "Implementation detail. Subject to change."))
 
 (extend nil
-        Diff
-        {:diff-similar atom-diff})
+  Diff
+  {:diff-similar atom-diff})
 
 (extend Object
-        Diff
-        {:diff-similar (fn [a b] ((if (.. a getClass isArray) diff-sequential atom-diff) a b))}
-        EqualityPartition
-        {:equality-partition (fn [x] (if (.. x getClass isArray) :sequential :atom))})
+  Diff
+  {:diff-similar (fn [a b] ((if (.. a getClass isArray) diff-sequential atom-diff) a b))}
+  EqualityPartition
+  {:equality-partition (fn [x] (if (.. x getClass isArray) :sequential :atom))})
 
 (extend-protocol EqualityPartition
   nil
   (equality-partition [x] :atom)
-  
+
   java.util.Set
   (equality-partition [x] :set)
 
   java.util.List
   (equality-partition [x] :sequential)
-  
+
   java.util.Map
   (equality-partition [x] :map))
 
@@ -102,17 +101,17 @@
 (extend-protocol Diff
   java.util.Set
   (diff-similar
-   [a b]
-   (let [aval (as-set-value a)
-         bval (as-set-value b)]
-     [(not-empty (set/difference aval bval))
-      (not-empty (set/difference bval aval))
-      (not-empty (set/intersection aval bval))]))
-  
+    [a b]
+    (let [aval (as-set-value a)
+          bval (as-set-value b)]
+      [(not-empty (set/difference aval bval))
+       (not-empty (set/difference bval aval))
+       (not-empty (set/intersection aval bval))]))
+
   java.util.List
   (diff-similar [a b]
     (diff-sequential a b))
-  
+
   java.util.Map
   (diff-similar [a b]
     (diff-associative a b (set/union (keys a) (keys b)))))
@@ -136,4 +135,4 @@
     (if (= (equality-partition a) (equality-partition b))
       (diff-similar a b)
       (atom-diff a b))))
-  
+

--- a/src/clj/clojure/edn.clj
+++ b/src/clj/clojure/edn.clj
@@ -1,14 +1,14 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "edn reading."
       :author "Rich Hickey"}
-  clojure.edn
+ clojure.edn
   (:refer-clojure :exclude [read read-string]))
 
 (defn read
@@ -25,14 +25,14 @@
               When not supplied, only the default-data-readers will be used.
   :default - A function of two args, that will, if present and no reader is found for a tag,
              be called with the tag and the value."
-  
+
   {:added "1.5"}
   ([]
    (read *in*))
   ([stream]
    (read {} stream))
   ([opts stream]
-     (clojure.lang.EdnReader/read stream opts)))
+   (clojure.lang.EdnReader/read stream opts)))
 
 (defn read-string
   "Reads one object from the string s. Returns nil when s is nil or empty.

--- a/src/clj/clojure/genclass.clj
+++ b/src/clj/clojure/genclass.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (in-ns 'clojure.core)
 
@@ -25,8 +25,8 @@
             (loop [mm mm
                    considered considered
                    meths (seq (concat
-                                (seq (. c (getDeclaredMethods)))
-                                (seq (. c (getMethods)))))]
+                               (seq (. c (getDeclaredMethods)))
+                               (seq (. c (getMethods)))))]
               (if meths
                 (let [^java.lang.reflect.Method meth (first meths)
                       mods (. meth (getModifiers))
@@ -62,12 +62,12 @@
     (apply vector (. ctor (getParameterTypes)))))
 
 (defn- escape-class-name [^Class c]
-  (.. (.getSimpleName c) 
+  (.. (.getSimpleName c)
       (replace "[]" "<>")))
 
 (defn- overload-name [mname pclasses]
   (if (seq pclasses)
-    (apply str mname (interleave (repeat \-) 
+    (apply str mname (interleave (repeat \-)
                                  (map escape-class-name pclasses)))
     (str mname "-void")))
 
@@ -83,33 +83,33 @@
 ;(distinct (map first(keys (mapcat non-private-methods [Object IPersistentMap]))))
 
 (def ^{:private true} prim->class
-     {'int Integer/TYPE
-      'ints (Class/forName "[I")
-      'long Long/TYPE
-      'longs (Class/forName "[J")
-      'float Float/TYPE
-      'floats (Class/forName "[F")
-      'double Double/TYPE
-      'doubles (Class/forName "[D")
-      'void Void/TYPE
-      'short Short/TYPE
-      'shorts (Class/forName "[S")
-      'boolean Boolean/TYPE
-      'booleans (Class/forName "[Z")
-      'byte Byte/TYPE
-      'bytes (Class/forName "[B")
-      'char Character/TYPE
-      'chars (Class/forName "[C")})
+  {'int Integer/TYPE
+   'ints (Class/forName "[I")
+   'long Long/TYPE
+   'longs (Class/forName "[J")
+   'float Float/TYPE
+   'floats (Class/forName "[F")
+   'double Double/TYPE
+   'doubles (Class/forName "[D")
+   'void Void/TYPE
+   'short Short/TYPE
+   'shorts (Class/forName "[S")
+   'boolean Boolean/TYPE
+   'booleans (Class/forName "[Z")
+   'byte Byte/TYPE
+   'bytes (Class/forName "[B")
+   'char Character/TYPE
+   'chars (Class/forName "[C")})
 
-(defn- ^Class the-class [x] 
-  (cond 
-   (class? x) x
-   (contains? prim->class x) (prim->class x)
-   :else (let [strx (str x)]
-           (clojure.lang.RT/classForName 
-            (if (some #{\. \[} strx)
-              strx
-              (str "java.lang." strx))))))
+(defn- ^Class the-class [x]
+  (cond
+    (class? x) x
+    (contains? prim->class x) (prim->class x)
+    :else (let [strx (str x)]
+            (clojure.lang.RT/classForName
+             (if (some #{\. \[} strx)
+               strx
+               (str "java.lang." strx))))))
 
 ;; someday this can be made codepoint aware
 (defn- valid-java-method-name
@@ -124,9 +124,9 @@
 (defn- generate-class [options-map]
   (validate-generate-class-options options-map)
   (let [default-options {:prefix "-" :load-impl-ns true :impl-ns (name *ns*)}
-        {:keys [name extends implements constructors methods main factory state init exposes 
-                exposes-methods prefix load-impl-ns impl-ns post-init]} 
-          (merge default-options options-map)
+        {:keys [name extends implements constructors methods main factory state init exposes
+                exposes-methods prefix load-impl-ns impl-ns post-init]}
+        (merge default-options options-map)
         name-meta (meta name)
         name (str name)
         super (if extends (the-class extends) Object)
@@ -162,11 +162,11 @@
         iseq-type (totype clojure.lang.ISeq)
         ex-type  (totype java.lang.UnsupportedOperationException)
         util-type (totype clojure.lang.Util)
-        all-sigs (distinct (concat (map #(let[[m p] (key %)] {m [p]}) (mapcat non-private-methods supers))
+        all-sigs (distinct (concat (map #(let [[m p] (key %)] {m [p]}) (mapcat non-private-methods supers))
                                    (map (fn [[m p]] {(str m) [p]}) methods)))
         sigs-by-name (apply merge-with concat {} all-sigs)
         overloads (into1 {} (filter (fn [[m s]] (next s)) sigs-by-name))
-        var-fields (concat (when init [init-name]) 
+        var-fields (concat (when init [init-name])
                            (when post-init [post-init-name])
                            (when main [main-name])
                            ;(when exposes-methods (map str (vals exposes-methods)))
@@ -200,7 +200,7 @@
                 rtype ^Type (totype rclass)
                 m (new Method mname rtype ptypes)
                 is-overload (seq (overloads mname))
-                gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (if as-static (. Opcodes ACC_STATIC) 0)) 
+                gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (if as-static (. Opcodes ACC_STATIC) 0))
                          m nil nil cv)
                 found-label (. gen (newLabel))
                 else-label (. gen (newLabel))
@@ -231,53 +231,52 @@
                   (. gen (loadArg i))
                   (. clojure.lang.Compiler$HostExpr (emitBoxReturn nil gen (nth pclasses i))))
                                         ;call fn
-                (. gen (invokeInterface ifn-type (new Method "invoke" obj-type 
+                (. gen (invokeInterface ifn-type (new Method "invoke" obj-type
                                                       (to-types (repeat (+ (count ptypes)
-                                                                              (if as-static 0 1)) 
-                                                                           Object)))))
-                                        ;(into-array (cons obj-type 
-                                        ;                 (repeat (count ptypes) obj-type))))))
+                                                                           (if as-static 0 1))
+                                                                        Object)))))
+                                        ;(into-array (cons obj-type
+;; (repeat (count ptypes) obj-type))))))
                                         ;unbox return
                 (. gen (unbox rtype))
                 (when (= (. rtype (getSort)) (. Type VOID))
                   (. gen (pop)))
                 (. gen (goTo end-label))
-                
+
                                         ;else call supplied alternative generator
                 (. gen (mark else-label))
                 (. gen (pop))
-                
+
                 (else-gen gen m)
-            
+
                 (. gen (mark end-label))))
             (. gen (returnValue))
-            (. gen (endMethod))))
-        ]
+            (. gen (endMethod))))]
                                         ;start class definition
     (. cv (visit (. Opcodes V1_5) (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_SUPER))
                  cname nil (iname super)
                  (when-let [ifc (seq interfaces)]
                    (into-array (map iname ifc)))))
 
-                                        ; class annotations
+;; class annotations
     (add-annotations cv name-meta)
-    
+
                                         ;static fields for vars
     (doseq [v var-fields]
       (. cv (visitField (+ (. Opcodes ACC_PRIVATE) (. Opcodes ACC_FINAL) (. Opcodes ACC_STATIC))
-                        (var-name v) 
+                        (var-name v)
                         (. var-type getDescriptor)
                         nil nil)))
-    
+
                                         ;instance field for state
     (when state
       (. cv (visitField (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_FINAL))
-                        state-name 
+                        state-name
                         (. obj-type getDescriptor)
                         nil nil)))
-    
+
                                         ;static init to set up var fields and load init
-    (let [gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_STATIC)) 
+    (let [gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_STATIC))
                    (. Method getMethod "void <clinit> ()")
                    nil nil cv)]
       (. gen (visitCode))
@@ -286,18 +285,18 @@
         (. gen push (str prefix v))
         (. gen (invokeStatic var-type (. Method (getMethod "clojure.lang.Var internPrivate(String,String)"))))
         (. gen putStatic ctype (var-name v) var-type))
-      
+
       (when load-impl-ns
         (. gen push (str "/" impl-cname))
         (. gen push ctype)
         (. gen (invokeStatic util-type (. Method (getMethod "Object loadWithClass(String,Class)"))))
-;        (. gen push (str (.replace impl-pkg-name \- \_) "__init"))
-;        (. gen (invokeStatic class-type (. Method (getMethod "Class forName(String)"))))
+;;         (. gen push (str (.replace impl-pkg-name \- \_) "__init"))
+;;         (. gen (invokeStatic class-type (. Method (getMethod "Class forName(String)"))))
         (. gen pop))
 
       (. gen (returnValue))
       (. gen (endMethod)))
-    
+
                                         ;ctors
     (doseq [[pclasses super-pclasses] ctor-sig-map]
       (let [constructor-annotations (meta pclasses)
@@ -316,7 +315,7 @@
             nth-method (. Method (getMethod "Object nth(Object,int)"))
             local (. gen newLocal obj-type)]
         (. gen (visitCode))
-        
+
         (if init
           (do
             (emit-get-var gen init-name)
@@ -328,14 +327,14 @@
               (. gen (loadArg i))
               (. clojure.lang.Compiler$HostExpr (emitBoxReturn nil gen (nth pclasses i))))
                                         ;call init fn
-            (. gen (invokeInterface ifn-type (new Method "invoke" obj-type 
+            (. gen (invokeInterface ifn-type (new Method "invoke" obj-type
                                                   (arg-types (count ptypes)))))
                                         ;expecting [[super-ctor-args] state] returned
             (. gen dup)
             (. gen push (int 0))
             (. gen (invokeStatic rt-type nth-method))
             (. gen storeLocal local)
-            
+
             (. gen (loadThis))
             (. gen dupX1)
             (dotimes [i (count super-pclasses)]
@@ -344,14 +343,14 @@
               (. gen (invokeStatic rt-type nth-method))
               (. clojure.lang.Compiler$HostExpr (emitUnboxArg nil gen (nth super-pclasses i))))
             (. gen (invokeConstructor super-type super-m))
-            
+
             (if state
               (do
                 (. gen push (int 1))
                 (. gen (invokeStatic rt-type nth-method))
                 (. gen (putField ctype state-name obj-type)))
               (. gen pop))
-            
+
             (. gen goTo end-label)
                                         ;no init found
             (. gen mark no-init-label)
@@ -375,7 +374,7 @@
             (. gen (loadArg i))
             (. clojure.lang.Compiler$HostExpr (emitBoxReturn nil gen (nth pclasses i))))
                                        ;call init fn
-          (. gen (invokeInterface ifn-type (new Method "invoke" obj-type 
+          (. gen (invokeInterface ifn-type (new Method "invoke" obj-type
                                                 (arg-types (inc (count ptypes))))))
           (. gen pop)
           (. gen goTo end-post-init-label)
@@ -389,65 +388,65 @@
                                         ;factory
         (when factory
           (let [fm (new Method factory-name ctype ptypes)
-                gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_STATIC)) 
+                gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_STATIC))
                          fm nil nil cv)]
             (. gen (visitCode))
             (. gen newInstance ctype)
             (. gen dup)
             (. gen (loadArgs))
-            (. gen (invokeConstructor ctype m))            
+            (. gen (invokeConstructor ctype m))
             (. gen (returnValue))
             (. gen (endMethod))))))
-    
+
                                         ;add methods matching supers', if no fn -> call super
     (let [mm (non-private-methods super)]
       (doseq [^java.lang.reflect.Method meth (vals mm)]
-             (emit-forwarding-method (.getName meth) (.getParameterTypes meth) (.getReturnType meth) false
-                                     (fn [^GeneratorAdapter gen ^Method m]
-                                       (. gen (loadThis))
+        (emit-forwarding-method (.getName meth) (.getParameterTypes meth) (.getReturnType meth) false
+                                (fn [^GeneratorAdapter gen ^Method m]
+                                  (. gen (loadThis))
                                         ;push args
-                                       (. gen (loadArgs))
+                                  (. gen (loadArgs))
                                         ;call super
-                                       (. gen (visitMethodInsn (. Opcodes INVOKESPECIAL) 
-                                                               (. super-type (getInternalName))
-                                                               (. m (getName))
-                                                               (. m (getDescriptor)))))))
+                                  (. gen (visitMethodInsn (. Opcodes INVOKESPECIAL)
+                                                          (. super-type (getInternalName))
+                                                          (. m (getName))
+                                                          (. m (getDescriptor)))))))
                                         ;add methods matching interfaces', if no fn -> throw
       (reduce1 (fn [mm ^java.lang.reflect.Method meth]
-                (if (contains? mm (method-sig meth))
-                  mm
-                  (do
-                    (emit-forwarding-method (.getName meth) (.getParameterTypes meth) (.getReturnType meth) false
-                                            emit-unsupported)
-                    (assoc mm (method-sig meth) meth))))
-              mm (mapcat #(.getMethods ^Class %) interfaces))
+                 (if (contains? mm (method-sig meth))
+                   mm
+                   (do
+                     (emit-forwarding-method (.getName meth) (.getParameterTypes meth) (.getReturnType meth) false
+                                             emit-unsupported)
+                     (assoc mm (method-sig meth) meth))))
+               mm (mapcat #(.getMethods ^Class %) interfaces))
                                         ;extra methods
-       (doseq [[mname pclasses rclass :as msig] methods]
-         (emit-forwarding-method mname pclasses rclass (:static (meta msig))
-                                 emit-unsupported))
+      (doseq [[mname pclasses rclass :as msig] methods]
+        (emit-forwarding-method mname pclasses rclass (:static (meta msig))
+                                emit-unsupported))
                                         ;expose specified overridden superclass methods
-       (doseq [[local-mname ^java.lang.reflect.Method m] (reduce1 (fn [ms [[name _ _] m]]
-                              (if (contains? exposes-methods (symbol name))
-                                (conj ms [((symbol name) exposes-methods) m])
-                                ms)) [] (concat (seq mm)
-                                                (seq (protected-final-methods super))))]
-         (let [ptypes (to-types (.getParameterTypes m))
-               rtype (totype (.getReturnType m))
-               exposer-m (new Method (str local-mname) rtype ptypes)
-               target-m (new Method (.getName m) rtype ptypes)
-               gen (new GeneratorAdapter (. Opcodes ACC_PUBLIC) exposer-m nil nil cv)]
-           (. gen (loadThis))
-           (. gen (loadArgs))
-           (. gen (visitMethodInsn (. Opcodes INVOKESPECIAL) 
-                                   (. super-type (getInternalName))
-                                   (. target-m (getName))
-                                   (. target-m (getDescriptor))))
-           (. gen (returnValue))
-           (. gen (endMethod)))))
+      (doseq [[local-mname ^java.lang.reflect.Method m] (reduce1 (fn [ms [[name _ _] m]]
+                                                                   (if (contains? exposes-methods (symbol name))
+                                                                     (conj ms [((symbol name) exposes-methods) m])
+                                                                     ms)) [] (concat (seq mm)
+                                                                                     (seq (protected-final-methods super))))]
+        (let [ptypes (to-types (.getParameterTypes m))
+              rtype (totype (.getReturnType m))
+              exposer-m (new Method (str local-mname) rtype ptypes)
+              target-m (new Method (.getName m) rtype ptypes)
+              gen (new GeneratorAdapter (. Opcodes ACC_PUBLIC) exposer-m nil nil cv)]
+          (. gen (loadThis))
+          (. gen (loadArgs))
+          (. gen (visitMethodInsn (. Opcodes INVOKESPECIAL)
+                                  (. super-type (getInternalName))
+                                  (. target-m (getName))
+                                  (. target-m (getDescriptor))))
+          (. gen (returnValue))
+          (. gen (endMethod)))))
                                         ;main
     (when main
       (let [m (. Method getMethod "void main (String[])")
-            gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_STATIC)) 
+            gen (new GeneratorAdapter (+ (. Opcodes ACC_PUBLIC) (. Opcodes ACC_STATIC))
                      m nil nil cv)
             no-main-label (. gen newLabel)
             end-label (. gen newLabel)]
@@ -459,7 +458,7 @@
         (.checkCast gen ifn-type)
         (. gen loadArgs)
         (. gen (invokeStatic rt-type (. Method (getMethod "clojure.lang.ISeq seq(Object)"))))
-        (. gen (invokeInterface ifn-type (new Method "applyTo" obj-type 
+        (. gen (invokeInterface ifn-type (new Method "applyTo" obj-type
                                               (into-array [iseq-type]))))
         (. gen pop)
         (. gen goTo end-label)
@@ -504,7 +503,7 @@
     (. cv (visitEnd))
     [cname (. cv (toByteArray))]))
 
-(defmacro gen-class 
+(defmacro gen-class
   "When compiling, generates compiled bytecode for a class with the
   given package-qualified :name (which, as all names in these
   parameters, can be a string or symbol), and writes the .class file
@@ -513,7 +512,7 @@
   implementation will be dynamically sought by the generated class in
   functions in an implementing Clojure namespace. Given a generated
   class org.mydomain.MyClass with a method named mymethod, gen-class
-  will generate an implementation that looks for a function named by 
+  will generate an implementation that looks for a function named by
   (str prefix mymethod) (default prefix: \"-\") in a
   Clojure namespace specified by :impl-ns
   (defaults to the current namespace). All inherited methods,
@@ -549,7 +548,7 @@
   :init name
 
   If supplied, names a function that will be called with the arguments
-  to the constructor. Must return [ [superclass-constructor-args] state] 
+  to the constructor. Must return [ [superclass-constructor-args] state]
   If not supplied, the constructor args are passed directly to
   the superclass constructor and the state will be nil
 
@@ -560,7 +559,7 @@
   parameter may be used to explicitly specify constructors, each entry
   providing a mapping from a constructor signature to a superclass
   constructor signature. When you supply this, you must supply an :init
-  specifier. 
+  specifier.
 
   :post-init name
 
@@ -590,7 +589,7 @@
   If supplied, a (set of) public static factory function(s) will be
   created with the given name, and the same signature(s) as the
   constructor(s).
-  
+
   :state name
 
   If supplied, a public final instance field with the given name will be
@@ -610,7 +609,7 @@
   :exposes-methods {super-method-name exposed-name, ...}
 
   It is sometimes necessary to call the superclass' implementation of an
-  overridden method.  Those methods may be exposed and referred in 
+  overridden method.  Those methods may be exposed and referred in
   the new method implementation by a local name.
 
   :prefix string
@@ -620,7 +619,7 @@
 
   :impl-ns name
 
-  Default: the name of the current ns. Implementations of methods will be 
+  Default: the name of the current ns. Implementations of methods will be
   looked up in this namespace.
 
   :load-impl-ns boolean
@@ -630,12 +629,12 @@
   true when implementing-ns is the default, false if you intend to
   load the code via some other method."
   {:added "1.0"}
-  
+
   [& options]
-    (when *compile-files*
-      (let [options-map (into1 {} (map vec (partition 2 options)))
-            [cname bytecode] (generate-class options-map)]
-        (clojure.lang.Compiler/writeClassFile cname bytecode))))
+  (when *compile-files*
+    (let [options-map (into1 {} (map vec (partition 2 options)))
+          [cname bytecode] (generate-class options-map)]
+      (clojure.lang.Compiler/writeClassFile cname bytecode))))
 
 ;;;;;;;;;;;;;;;;;;;; gen-interface ;;;;;;;;;;;;;;;;;;;;;;
 ;; based on original contribution by Chris Houser
@@ -649,20 +648,20 @@
   (if (or (instance? Class c) (prim->class c))
     (Type/getType (the-class c))
     (let [strx (str c)]
-      (Type/getObjectType 
+      (Type/getObjectType
        (.replace (if (some #{\. \[} strx)
                    strx
-                   (str "java.lang." strx)) 
+                   (str "java.lang." strx))
                  "." "/")))))
 
 (defn- generate-interface
   [{:keys [name extends methods]}]
   (when (some #(-> % first clojure.core/name (.contains "-")) methods)
     (throw
-      (IllegalArgumentException. "Interface methods must not contain '-'")))
+     (IllegalArgumentException. "Interface methods must not contain '-'")))
   (let [iname (.replace (str name) "." "/")
         cv (ClassWriter. ClassWriter/COMPUTE_MAXS)]
-    (. cv visit Opcodes/V1_5 (+ Opcodes/ACC_PUBLIC 
+    (. cv visit Opcodes/V1_5 (+ Opcodes/ACC_PUBLIC
                                 Opcodes/ACC_ABSTRACT
                                 Opcodes/ACC_INTERFACE)
        iname nil "java/lang/Object"
@@ -673,7 +672,7 @@
     (doseq [[mname pclasses rclass pmetas] methods]
       (let [mv (. cv visitMethod (+ Opcodes/ACC_PUBLIC Opcodes/ACC_ABSTRACT)
                   (str mname)
-                  (Type/getMethodDescriptor (asm-type rclass) 
+                  (Type/getMethodDescriptor (asm-type rclass)
                                             (if pclasses
                                               (into-array Type (map asm-type pclasses))
                                               (make-array Type 0)))
@@ -690,12 +689,12 @@
   the given package-qualified :name (which, as all names in these
   parameters, can be a string or symbol), and writes the .class file
   to the *compile-path* directory.  When not compiling, does nothing.
- 
+
   In all subsequent sections taking types, the primitive types can be
   referred to by their Java names (int, float etc), and classes in the
   java.lang package can be used without a package qualifier. All other
   classes must be fully qualified.
- 
+
   Options should be a set of key/value pairs, all except for :name are
   optional:
 
@@ -715,27 +714,25 @@
   {:added "1.0"}
 
   [& options]
-    (let [options-map (apply hash-map options)
-          [cname bytecode] (generate-interface options-map)]
-      (when *compile-files*
-        (clojure.lang.Compiler/writeClassFile cname bytecode))
-      (.defineClass ^DynamicClassLoader (deref clojure.lang.Compiler/LOADER)
-                    (str (:name options-map)) bytecode options)))
+  (let [options-map (apply hash-map options)
+        [cname bytecode] (generate-interface options-map)]
+    (when *compile-files*
+      (clojure.lang.Compiler/writeClassFile cname bytecode))
+    (.defineClass ^DynamicClassLoader (deref clojure.lang.Compiler/LOADER)
+                  (str (:name options-map)) bytecode options)))
 
 (comment
 
-(defn gen-and-load-class 
-  "Generates and immediately loads the bytecode for the specified
+  (defn gen-and-load-class
+    "Generates and immediately loads the bytecode for the specified
   class. Note that a class generated this way can be loaded only once
   - the JVM supports only one class with a given name per
   classloader. Subsequent to generation you can import it into any
   desired namespaces just like any other class. See gen-class for a
   description of the options."
-  {:added "1.0"}
+    {:added "1.0"}
 
-  [& options]
-  (let [options-map (apply hash-map options)
-        [cname bytecode] (generate-class options-map)]
-    (.. (clojure.lang.RT/getRootClassLoader) (defineClass cname bytecode options))))
-
-)
+    [& options]
+    (let [options-map (apply hash-map options)
+          [cname bytecode] (generate-class options-map)]
+      (.. (clojure.lang.RT/getRootClassLoader) (defineClass cname bytecode options)))))

--- a/src/clj/clojure/gvec.clj
+++ b/src/clj/clojure/gvec.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;; a generic vector implementation for vectors of primitives
 
@@ -34,10 +34,10 @@
   (aset [arr ^int i val]))
 
 (deftype ArrayChunk [^clojure.core.ArrayManager am arr ^int off ^int end]
-  
+
   clojure.lang.Indexed
   (nth [_ i] (.aget am arr (+ off i)))
-  
+
   (count [_] (- end off))
 
   clojure.lang.IChunk
@@ -45,7 +45,7 @@
     (if (= off end)
       (throw (IllegalStateException. "dropFirst of empty chunk"))
       (new ArrayChunk am arr (inc off) end)))
-  
+
   (reduce [_ f init]
     (loop [ret init i off]
       (if (< i end)
@@ -55,32 +55,32 @@
             (recur ret (inc i))))
         ret))))
 
-(deftype VecSeq [^clojure.core.ArrayManager am ^clojure.core.IVecImpl vec anode ^int i ^int offset] 
+(deftype VecSeq [^clojure.core.ArrayManager am ^clojure.core.IVecImpl vec anode ^int i ^int offset]
   :no-print true
 
   clojure.core.protocols.InternalReduce
   (internal-reduce
-   [_ f val]
-   (loop [result val
-          aidx (+ i offset)]
-     (if (< aidx (count vec))
-       (let [node (.arrayFor vec aidx)
-             result (loop [result result
-                           node-idx (bit-and 0x1f aidx)]
-                      (if (< node-idx (.alength am node))
-                        (let [result (f result (.aget am node node-idx))]
-                          (if (reduced? result)
-                            result
-                            (recur result (inc node-idx))))
-                        result))]
-         (if (reduced? result)
-           @result
-           (recur result (bit-and 0xffe0 (+ aidx 32)))))
-       result)))
-  
+    [_ f val]
+    (loop [result val
+           aidx (+ i offset)]
+      (if (< aidx (count vec))
+        (let [node (.arrayFor vec aidx)
+              result (loop [result result
+                            node-idx (bit-and 0x1f aidx)]
+                       (if (< node-idx (.alength am node))
+                         (let [result (f result (.aget am node node-idx))]
+                           (if (reduced? result)
+                             result
+                             (recur result (inc node-idx))))
+                         result))]
+          (if (reduced? result)
+            @result
+            (recur result (bit-and 0xffe0 (+ aidx 32)))))
+        result)))
+
   clojure.lang.ISeq
   (first [_] (.aget am anode offset))
-  (next [this] 
+  (next [this]
     (if (< (inc offset) (.alength am anode))
       (new VecSeq am vec anode i (inc offset))
       (.chunkedNext this)))
@@ -99,28 +99,25 @@
         i)))
   (equiv [this o]
     (cond
-     (identical? this o) true
-     (or (instance? clojure.lang.Sequential o) (instance? java.util.List o))
-     (loop [me this
-            you (seq o)]
-       (if (nil? me)
-         (nil? you)
-         (and (clojure.lang.Util/equiv (first me) (first you))
-              (recur (next me) (next you)))))
-     :else false))
+      (identical? this o) true
+      (or (instance? clojure.lang.Sequential o) (instance? java.util.List o))
+      (loop [me this
+             you (seq o)]
+        (if (nil? me)
+          (nil? you)
+          (and (clojure.lang.Util/equiv (first me) (first you))
+               (recur (next me) (next you)))))
+      :else false))
   (empty [_]
-    clojure.lang.PersistentList/EMPTY)
-
-
-  clojure.lang.Seqable
+    clojure.lang.PersistentList/EMPTY) clojure.lang.Seqable
   (seq [this] this)
 
   clojure.lang.IChunkedSeq
   (chunkedFirst [_] (ArrayChunk. am anode offset (.alength am anode)))
-  (chunkedNext [_] 
-   (let [nexti (+ i (.alength am anode))]
-     (when (< nexti (count vec))
-       (new VecSeq am vec (.arrayFor vec nexti) nexti 0))))
+  (chunkedNext [_]
+    (let [nexti (+ i (.alength am anode))]
+      (when (< nexti (count vec))
+        (new VecSeq am vec (.arrayFor vec nexti) nexti 0))))
   (chunkedMore [this]
     (let [s (.chunkedNext this)]
       (or s (clojure.lang.PersistentList/EMPTY)))))
@@ -131,20 +128,20 @@
 (deftype Vec [^clojure.core.ArrayManager am ^int cnt ^int shift ^clojure.core.VecNode root tail _meta]
   Object
   (equals [this o]
-    (cond 
-     (identical? this o) true
-     (or (instance? clojure.lang.IPersistentVector o) (instance? java.util.RandomAccess o))
-       (and (= cnt (count o))
-            (loop [i (int 0)]
-              (cond
+    (cond
+      (identical? this o) true
+      (or (instance? clojure.lang.IPersistentVector o) (instance? java.util.RandomAccess o))
+      (and (= cnt (count o))
+           (loop [i (int 0)]
+             (cond
                (= i cnt) true
                (.equals (.nth this i) (nth o i)) (recur (inc i))
                :else false)))
-     (or (instance? clojure.lang.Sequential o) (instance? java.util.List o))
-       (if-let [st (seq this)]
-         (.equals st (seq o))
-         (nil? (seq o)))
-     :else false))
+      (or (instance? clojure.lang.Sequential o) (instance? java.util.List o))
+      (if-let [st (seq this)]
+        (.equals st (seq o))
+        (nil? (seq o)))
+      :else false))
 
   ;todo - cache
   (hashCode [this]
@@ -152,8 +149,8 @@
       (if (= i cnt)
         hash
         (let [val (.nth this i)]
-          (recur (unchecked-add-int (unchecked-multiply-int 31 hash) 
-                                (clojure.lang.Util/hash val)) 
+          (recur (unchecked-add-int (unchecked-multiply-int 31 hash)
+                                    (clojure.lang.Util/hash val))
                  (inc i))))))
 
   ;todo - cache
@@ -175,87 +172,87 @@
     (let [a (.arrayFor this i)]
       (.aget am a (bit-and i (int 0x1f)))))
   (nth [this i not-found]
-       (let [z (int 0)]
-         (if (and (>= i z) (< i (.count this)))
-           (.nth this i)
-           not-found)))
+    (let [z (int 0)]
+      (if (and (>= i z) (< i (.count this)))
+        (.nth this i)
+        not-found)))
 
   clojure.lang.IPersistentCollection
   (cons [this val]
-     (if (< (- cnt (.tailoff this)) (int 32))
+    (if (< (- cnt (.tailoff this)) (int 32))
       (let [new-tail (.array am (inc (.alength am tail)))]
         (System/arraycopy tail 0 new-tail 0 (.alength am tail))
         (.aset am new-tail (.alength am tail) val)
         (new Vec am (inc cnt) shift root new-tail (meta this)))
-      (let [tail-node (VecNode. (.edit root) tail)] 
+      (let [tail-node (VecNode. (.edit root) tail)]
         (if (> (bit-shift-right cnt (int 5)) (bit-shift-left (int 1) shift)) ;overflow root?
           (let [new-root (VecNode. (.edit root) (object-array 32))]
             (doto ^objects (.arr new-root)
               (aset 0 root)
               (aset 1 (.newPath this (.edit root) shift tail-node)))
             (new Vec am (inc cnt) (+ shift (int 5)) new-root (let [tl (.array am 1)] (.aset am  tl 0 val) tl) (meta this)))
-          (new Vec am (inc cnt) shift (.pushTail this shift root tail-node) 
-                 (let [tl (.array am 1)] (.aset am  tl 0 val) tl) (meta this))))))
+          (new Vec am (inc cnt) shift (.pushTail this shift root tail-node)
+               (let [tl (.array am 1)] (.aset am  tl 0 val) tl) (meta this))))))
 
-  (empty [_] (new Vec am 0 5 EMPTY-NODE (.array am 0) nil))                             
+  (empty [_] (new Vec am 0 5 EMPTY-NODE (.array am 0) nil))
   (equiv [this o]
-    (cond 
-     (or (instance? clojure.lang.IPersistentVector o) (instance? java.util.RandomAccess o))
-       (and (= cnt (count o))
-            (loop [i (int 0)]
-              (cond
+    (cond
+      (or (instance? clojure.lang.IPersistentVector o) (instance? java.util.RandomAccess o))
+      (and (= cnt (count o))
+           (loop [i (int 0)]
+             (cond
                (= i cnt) true
                (= (.nth this i) (nth o i)) (recur (inc i))
                :else false)))
-     (or (instance? clojure.lang.Sequential o) (instance? java.util.List o))
-       (clojure.lang.Util/equiv (seq this) (seq o))
-     :else false))
+      (or (instance? clojure.lang.Sequential o) (instance? java.util.List o))
+      (clojure.lang.Util/equiv (seq this) (seq o))
+      :else false))
 
   clojure.lang.IPersistentStack
   (peek [this]
-    (when (> cnt (int 0)) 
+    (when (> cnt (int 0))
       (.nth this (dec cnt))))
 
   (pop [this]
-   (cond
-    (zero? cnt) 
+    (cond
+      (zero? cnt)
       (throw (IllegalStateException. "Can't pop empty vector"))
-    (= 1 cnt) 
+      (= 1 cnt)
       (new Vec am 0 5 EMPTY-NODE (.array am 0) (meta this))
-    (> (- cnt (.tailoff this)) 1)
+      (> (- cnt (.tailoff this)) 1)
       (let [new-tail (.array am (dec (.alength am tail)))]
         (System/arraycopy tail 0 new-tail 0 (.alength am new-tail))
         (new Vec am (dec cnt) shift root new-tail (meta this)))
-    :else
+      :else
       (let [new-tail (.arrayFor this (- cnt 2))
             new-root ^clojure.core.VecNode (.popTail this shift root)]
         (cond
-         (nil? new-root) 
-           (new Vec am (dec cnt) shift EMPTY-NODE new-tail (meta this))
-         (and (> shift 5) (nil? (aget ^objects (.arr new-root) 1)))
-           (new Vec am (dec cnt) (- shift 5) (aget ^objects (.arr new-root) 0) new-tail (meta this))
-         :else
-           (new Vec am (dec cnt) shift new-root new-tail (meta this))))))
+          (nil? new-root)
+          (new Vec am (dec cnt) shift EMPTY-NODE new-tail (meta this))
+          (and (> shift 5) (nil? (aget ^objects (.arr new-root) 1)))
+          (new Vec am (dec cnt) (- shift 5) (aget ^objects (.arr new-root) 0) new-tail (meta this))
+          :else
+          (new Vec am (dec cnt) shift new-root new-tail (meta this))))))
 
   clojure.lang.IPersistentVector
   (assocN [this i val]
-    (cond 
-     (and (<= (int 0) i) (< i cnt))
-       (if (>= i (.tailoff this))
-         (let [new-tail (.array am (.alength am tail))]
-           (System/arraycopy tail 0 new-tail 0 (.alength am tail))
-           (.aset am new-tail (bit-and i (int 0x1f)) val)
-           (new Vec am cnt shift root new-tail (meta this)))
-         (new Vec am cnt shift (.doAssoc this shift root i val) tail (meta this)))
-     (= i cnt) (.cons this val)
-     :else (throw (IndexOutOfBoundsException.))))
-  
+    (cond
+      (and (<= (int 0) i) (< i cnt))
+      (if (>= i (.tailoff this))
+        (let [new-tail (.array am (.alength am tail))]
+          (System/arraycopy tail 0 new-tail 0 (.alength am tail))
+          (.aset am new-tail (bit-and i (int 0x1f)) val)
+          (new Vec am cnt shift root new-tail (meta this)))
+        (new Vec am cnt shift (.doAssoc this shift root i val) tail (meta this)))
+      (= i cnt) (.cons this val)
+      :else (throw (IndexOutOfBoundsException.))))
+
   clojure.lang.Reversible
   (rseq [this]
-        (if (> (.count this) 0)
-          (clojure.lang.APersistentVector$RSeq. this (dec (.count this)))
-          nil))
-  
+    (if (> (.count this) 0)
+      (clojure.lang.APersistentVector$RSeq. this (dec (.count this)))
+      nil))
+
   clojure.lang.Associative
   (assoc [this k v]
     (if (clojure.lang.Util/isInteger k)
@@ -289,18 +286,16 @@
           (.nth this i)
           (throw (IndexOutOfBoundsException.))))
       (throw (IllegalArgumentException. "Key must be integer"))))
-
-  
   clojure.lang.Seqable
-  (seq [this] 
-    (if (zero? cnt) 
+  (seq [this]
+    (if (zero? cnt)
       nil
       (VecSeq. am this (.arrayFor this 0) 0 0)))
 
   clojure.lang.Sequential ;marker, no methods
 
   clojure.core.IVecImpl
-  (tailoff [_] 
+  (tailoff [_]
     (- cnt (.alength am tail)))
 
   (arrayFor [this i]
@@ -310,7 +305,7 @@
         (loop [node root level shift]
           (if (zero? level)
             (.arr node)
-            (recur (aget ^objects (.arr node) (bit-and (bit-shift-right i level) (int 0x1f))) 
+            (recur (aget ^objects (.arr node) (bit-and (bit-shift-right i level) (int 0x1f)))
                    (- level (int 5))))))
       (throw (IndexOutOfBoundsException.))))
 
@@ -331,17 +326,17 @@
     (let [node ^clojure.core.VecNode node
           subidx (bit-and (bit-shift-right (- cnt (int 2)) level) (int 0x1f))]
       (cond
-       (> level 5) 
-         (let [new-child (.popTail this (- level 5) (aget ^objects (.arr node) subidx))]
-           (if (and (nil? new-child) (zero? subidx))
-             nil
-             (let [arr (aclone ^objects (.arr node))]
-               (aset arr subidx new-child)
-               (VecNode. (.edit root) arr))))
-       (zero? subidx) nil
-       :else (let [arr (aclone ^objects (.arr node))]
-               (aset arr subidx nil)
-               (VecNode. (.edit root) arr)))))
+        (> level 5)
+        (let [new-child (.popTail this (- level 5) (aget ^objects (.arr node) subidx))]
+          (if (and (nil? new-child) (zero? subidx))
+            nil
+            (let [arr (aclone ^objects (.arr node))]
+              (aset arr subidx new-child)
+              (VecNode. (.edit root) arr))))
+        (zero? subidx) nil
+        :else (let [arr (aclone ^objects (.arr node))]
+                (aset arr subidx nil)
+                (VecNode. (.edit root) arr)))))
 
   (newPath [this edit ^int level node]
     (if (zero? level)
@@ -351,7 +346,7 @@
         ret)))
 
   (doAssoc [this level node i val]
-    (let [node ^clojure.core.VecNode node]       
+    (let [node ^clojure.core.VecNode node]
       (if (zero? level)
         ;on this branch, array will need val type
         (let [arr (.aclone am (.arr node))]
@@ -372,13 +367,13 @@
           (< cnt vcnt) -1
           (> cnt vcnt) 1
           :else
-            (loop [i (int 0)]
-              (if (= i cnt)
-                0
-                (let [comp (clojure.lang.Util/compare (.nth this i) (.nth v i))]
-                  (if (= 0 comp)
-                    (recur (inc i))
-                    comp))))))))
+          (loop [i (int 0)]
+            (if (= i cnt)
+              0
+              (let [comp (clojure.lang.Util/compare (.nth this i) (.nth v i))]
+                (if (= 0 comp)
+                  (recur (inc i))
+                  comp))))))))
 
   java.lang.Iterable
   (iterator [this]
@@ -448,33 +443,30 @@
   (add [_ i o] (throw (UnsupportedOperationException.)))
   (addAll [_ i c] (throw (UnsupportedOperationException.)))
   (^Object remove [_ ^int i] (throw (UnsupportedOperationException.)))
-  (set [_ i e] (throw (UnsupportedOperationException.)))
-)
-
-(defmethod print-method ::Vec [v w]
-  ((get (methods print-method) clojure.lang.IPersistentVector) v w))
+  (set [_ i e] (throw (UnsupportedOperationException.)))) (defmethod print-method ::Vec [v w]
+                                                            ((get (methods print-method) clojure.lang.IPersistentVector) v w))
 
 (defmacro mk-am {:private true} [t]
   (let [garr (gensym)
         tgarr (with-meta garr {:tag (symbol (str t "s"))})]
     `(reify clojure.core.ArrayManager
-            (array [_ size#] (~(symbol (str t "-array")) size#))
-            (alength [_ ~garr] (alength ~tgarr))
-            (aclone [_ ~garr] (aclone ~tgarr))
-            (aget [_ ~garr i#] (aget ~tgarr i#))
-            (aset [_ ~garr i# val#] (aset ~tgarr i# (~t val#))))))
+       (array [_ size#] (~(symbol (str t "-array")) size#))
+       (alength [_ ~garr] (alength ~tgarr))
+       (aclone [_ ~garr] (aclone ~tgarr))
+       (aget [_ ~garr i#] (aget ~tgarr i#))
+       (aset [_ ~garr i# val#] (aset ~tgarr i# (~t val#))))))
 
 (def ^{:private true} ams
-     {:int (mk-am int)
-      :long (mk-am long)
-      :float (mk-am float)
-      :double (mk-am double)
-      :byte (mk-am byte)
-      :short (mk-am short)
-      :char (mk-am char)
-      :boolean (mk-am boolean)})
+  {:int (mk-am int)
+   :long (mk-am long)
+   :float (mk-am float)
+   :double (mk-am double)
+   :byte (mk-am byte)
+   :short (mk-am short)
+   :char (mk-am char)
+   :boolean (mk-am boolean)})
 
-(defn vector-of 
+(defn vector-of
   "Creates a new vector of a single primitive type t, where t is one
   of :int :long :float :double :byte :short :char or :boolean. The
   resulting vector complies with the interface of vectors in general,

--- a/src/clj/clojure/inspector.clj
+++ b/src/clj/clojure/inspector.clj
@@ -1,32 +1,32 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "Graphical object inspector for Clojure data structures."
-       :author "Rich Hickey"}
-    clojure.inspector
-    (:import
-     (java.awt BorderLayout)
-     (java.awt.event ActionEvent ActionListener)
-     (javax.swing.tree TreeModel)
-     (javax.swing.table TableModel AbstractTableModel)
-     (javax.swing JPanel JTree JTable JScrollPane JFrame JToolBar JButton SwingUtilities)))
+      :author "Rich Hickey"}
+ clojure.inspector
+  (:import
+   (java.awt BorderLayout)
+   (java.awt.event ActionEvent ActionListener)
+   (javax.swing.tree TreeModel)
+   (javax.swing.table TableModel AbstractTableModel)
+   (javax.swing JPanel JTree JTable JScrollPane JFrame JToolBar JButton SwingUtilities)))
 
 (defn atom? [x]
   (not (coll? x)))
 
 (defn collection-tag [x]
-  (cond 
-   (map-entry? x) :entry
-   (instance? java.util.Map x) :seqable
-   (instance? java.util.Set x) :seqable
-   (sequential? x) :seq
-   (instance? clojure.lang.Seqable x) :seqable
-   :else :atom))
+  (cond
+    (map-entry? x) :entry
+    (instance? java.util.Map x) :seqable
+    (instance? java.util.Set x) :seqable
+    (sequential? x) :seq
+    (instance? clojure.lang.Seqable x) :seqable
+    :else :atom))
 
 (defmulti is-leaf collection-tag)
 (defmulti get-child (fn [parent index] (collection-tag parent)))
@@ -60,7 +60,7 @@
     (getChild [parent index]
       (get-child parent index))
     (getChildCount [parent]
-       (get-child-count parent))
+      (get-child-count parent))
     (isLeaf [node]
       (is-leaf node))
     (valueForPathChanged [path newValue])
@@ -68,27 +68,26 @@
       -1)
     (removeTreeModelListener [treeModelListener])))
 
-
 (defn old-table-model [data]
   (let [row1 (first data)
-	colcnt (count row1)
-	cnt (count data)
-	vals (if (map? row1) vals identity)]
+        colcnt (count row1)
+        cnt (count data)
+        vals (if (map? row1) vals identity)]
     (proxy [TableModel] []
       (addTableModelListener [tableModelListener])
       (getColumnClass [columnIndex] Object)
       (getColumnCount [] colcnt)
       (getColumnName [columnIndex]
-	(if (map? row1)
-	  (name (nth (keys row1) columnIndex))
-	  (str columnIndex)))
+        (if (map? row1)
+          (name (nth (keys row1) columnIndex))
+          (str columnIndex)))
       (getRowCount [] cnt)
       (getValueAt [rowIndex columnIndex]
-	(nth (vals (nth data rowIndex)) columnIndex))
+        (nth (vals (nth data rowIndex)) columnIndex))
       (isCellEditable [rowIndex columnIndex] false)
       (removeTableModelListener [tableModelListener]))))
-      
-(defn inspect-tree 
+
+(defn inspect-tree
   "creates a graphical (Swing) inspector on the supplied hierarchical data"
   {:added "1.0"}
   [data]
@@ -97,17 +96,16 @@
     (.setSize 400 600)
     (.setVisible true)))
 
-(defn inspect-table 
+(defn inspect-table
   "creates a graphical (Swing) inspector on the supplied regular
   data, which must be a sequential data structure of data structures
   of equal length"
   {:added "1.0"}
-    [data]
+  [data]
   (doto (JFrame. "Clojure Inspector")
     (.add (JScrollPane. (JTable. (old-table-model data))))
     (.setSize 400 600)
     (.setVisible true)))
-
 
 (defmulti list-provider class)
 
@@ -116,14 +114,14 @@
 
 (defmethod list-provider java.util.List [c]
   (let [v (if (vector? c) c (vec c))]
-    {:nrows (count v) 
-     :get-value (fn [i] (v i)) 
+    {:nrows (count v)
+     :get-value (fn [i] (v i))
      :get-label (fn [i] i)}))
 
 (defmethod list-provider java.util.Map [c]
   (let [v (vec (sort (map (fn [[k v]] (vector k v)) c)))]
-    {:nrows (count v) 
-     :get-value (fn [i] ((v i) 1)) 
+    {:nrows (count v)
+     :get-value (fn [i] ((v i) 1))
      :get-label (fn [i] ((v i) 0))}))
 
 (defn list-model [provider]
@@ -132,9 +130,9 @@
       (getColumnCount [] 2)
       (getRowCount [] nrows)
       (getValueAt [rowIndex columnIndex]
-        (cond 
-         (= 0 columnIndex) (get-label rowIndex)
-         (= 1 columnIndex) (print-str (get-value rowIndex)))))))
+        (cond
+          (= 0 columnIndex) (get-label rowIndex)
+          (= 1 columnIndex) (print-str (get-value rowIndex)))))))
 
 (defmulti table-model class)
 
@@ -157,33 +155,30 @@
   [x]
   (doto (JFrame. "Clojure Inspector")
     (.add
-      (doto (JPanel. (BorderLayout.))
-        (.add (doto (JToolBar.)
-                (.add (JButton. "Back"))
-                (.addSeparator)
-                (.add (JButton. "List"))
-                (.add (JButton. "Table"))
-                (.add (JButton. "Bean"))
-                (.add (JButton. "Line"))
-                (.add (JButton. "Bar"))
-                (.addSeparator)
-                (.add (JButton. "Prev"))
-                (.add (JButton. "Next")))
-              BorderLayout/NORTH)
-        (.add
-          (JScrollPane. 
-            (doto (JTable. (list-model (list-provider x)))
-              (.setAutoResizeMode JTable/AUTO_RESIZE_LAST_COLUMN)))
-          BorderLayout/CENTER)))
+     (doto (JPanel. (BorderLayout.))
+       (.add (doto (JToolBar.)
+               (.add (JButton. "Back"))
+               (.addSeparator)
+               (.add (JButton. "List"))
+               (.add (JButton. "Table"))
+               (.add (JButton. "Bean"))
+               (.add (JButton. "Line"))
+               (.add (JButton. "Bar"))
+               (.addSeparator)
+               (.add (JButton. "Prev"))
+               (.add (JButton. "Next")))
+             BorderLayout/NORTH)
+       (.add
+        (JScrollPane.
+         (doto (JTable. (list-model (list-provider x)))
+           (.setAutoResizeMode JTable/AUTO_RESIZE_LAST_COLUMN)))
+        BorderLayout/CENTER)))
     (.setSize 400 400)
     (.setVisible true)))
 
-
 (comment
 
-(load-file "src/inspector.clj")
-(refer 'inspector)
-(inspect-tree {:a 1 :b 2 :c [1 2 3 {:d 4 :e 5 :f [6 7 8]}]})
-(inspect-table [[1 2 3][4 5 6][7 8 9][10 11 12]])
-
-)
+  (load-file "src/inspector.clj")
+  (refer 'inspector)
+  (inspect-tree {:a 1 :b 2 :c [1 2 3 {:d 4 :e 5 :f [6 7 8]}]})
+  (inspect-table [[1 2 3] [4 5 6] [7 8 9] [10 11 12]]))

--- a/src/clj/clojure/instant.clj
+++ b/src/clj/clojure/instant.clj
@@ -1,15 +1,14 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.instant
   (:import [java.util Calendar Date GregorianCalendar TimeZone]
            [java.sql Timestamp]))
-
 
 (set! *warn-on-reflection* true)
 
@@ -32,7 +31,6 @@
   [num div]
   (not (divisible? num div)))
 
-
 ;;; ------------------------------------------------------------------------
 ;;; parser implementation
 
@@ -48,7 +46,7 @@
                   (.toString b)))))
 
 (def parse-timestamp
-     "Parse a string containing an RFC3339-like like timestamp.
+  "Parse a string containing an RFC3339-like like timestamp.
 
 The function new-instant is called with the following arguments.
 
@@ -73,11 +71,11 @@ Grammar (of s):
   date-fullyear   = 4DIGIT
   date-month      = 2DIGIT  ; 01-12
   date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
-                            ; month/year
+;; month/year
   time-hour       = 2DIGIT  ; 00-23
   time-minute     = 2DIGIT  ; 00-59
   time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second
-                            ; rules
+;; rules
   time-secfrac    = '.' 1*DIGIT
   time-numoffset  = ('+' / '-') time-hour ':' time-minute
   time-offset     = 'Z' / time-numoffset
@@ -98,27 +96,26 @@ Though time-offset is syntactically optional, a missing time-offset
 will be treated as if the time-offset zero (+00:00) had been
 specified.
 "
-     (let [timestamp #"(\d\d\d\d)(?:-(\d\d)(?:-(\d\d)(?:[T](\d\d)(?::(\d\d)(?::(\d\d)(?:[.](\d+))?)?)?)?)?)?(?:[Z]|([-+])(\d\d):(\d\d))?"]
+  (let [timestamp #"(\d\d\d\d)(?:-(\d\d)(?:-(\d\d)(?:[T](\d\d)(?::(\d\d)(?::(\d\d)(?:[.](\d+))?)?)?)?)?)?(?:[Z]|([-+])(\d\d):(\d\d))?"]
 
-       (fn [new-instant ^CharSequence cs]
-         (if-let [[_ years months days hours minutes seconds fraction
-                   offset-sign offset-hours offset-minutes]
-                  (re-matches timestamp cs)]
-           (new-instant
-            (parse-int years)
-            (if-not months   1 (parse-int months))
-            (if-not days     1 (parse-int days))
-            (if-not hours    0 (parse-int hours))
-            (if-not minutes  0 (parse-int minutes))
-            (if-not seconds  0 (parse-int seconds))
-            (if-not fraction 0 (parse-int (zero-fill-right fraction 9)))
-            (cond (= "-" offset-sign) -1
-                  (= "+" offset-sign)  1
-                  :else                0)
-            (if-not offset-hours   0 (parse-int offset-hours))
-            (if-not offset-minutes 0 (parse-int offset-minutes)))
-           (fail (str "Unrecognized date/time syntax: " cs))))))
-
+    (fn [new-instant ^CharSequence cs]
+      (if-let [[_ years months days hours minutes seconds fraction
+                offset-sign offset-hours offset-minutes]
+               (re-matches timestamp cs)]
+        (new-instant
+         (parse-int years)
+         (if-not months   1 (parse-int months))
+         (if-not days     1 (parse-int days))
+         (if-not hours    0 (parse-int hours))
+         (if-not minutes  0 (parse-int minutes))
+         (if-not seconds  0 (parse-int seconds))
+         (if-not fraction 0 (parse-int (zero-fill-right fraction 9)))
+         (cond (= "-" offset-sign) -1
+               (= "+" offset-sign)  1
+               :else                0)
+         (if-not offset-hours   0 (parse-int offset-hours))
+         (if-not offset-minutes 0 (parse-int offset-minutes)))
+        (fail (str "Unrecognized date/time syntax: " cs))))))
 
 ;;; ------------------------------------------------------------------------
 ;;; Verification of Extra-Grammatical Restrictions from RFC3339
@@ -130,10 +127,10 @@ specified.
            (divisible? year 400))))
 
 (def ^:private days-in-month
-     (let [dim-norm [nil 31 28 31 30 31 30 31 31 30 31 30 31]
-           dim-leap [nil 31 29 31 30 31 30 31 31 30 31 30 31]]
-       (fn [month leap-year?]
-         ((if leap-year? dim-leap dim-norm) month))))
+  (let [dim-norm [nil 31 28 31 30 31 30 31 31 30 31 30 31]
+        dim-leap [nil 31 29 31 30 31 30 31 31 30 31 30 31]]
+    (fn [month leap-year?]
+      ((if leap-year? dim-leap dim-norm) month))))
 
 (defn validated
   "Return a function which constructs and instant by calling constructor
@@ -154,7 +151,6 @@ with invalid arguments."
     (verify (<= 0 offset-minutes 59))
     (new-instance years months days hours minutes seconds nanoseconds
                   offset-sign offset-hours offset-minutes)))
-
 
 ;;; ------------------------------------------------------------------------
 ;;; print integration
@@ -204,7 +200,6 @@ with invalid arguments."
   [^java.util.Calendar c, ^java.io.Writer w]
   (print-calendar c w))
 
-
 (def ^:private ^ThreadLocal thread-local-utc-timestamp-format
   ;; SimpleDateFormat is not thread-safe, so we use a ThreadLocal proxy for access.
   ;; http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4228335
@@ -231,7 +226,6 @@ with invalid arguments."
 (defmethod print-dup java.sql.Timestamp
   [^java.sql.Timestamp ts, ^java.io.Writer w]
   (print-timestamp ts w))
-
 
 ;;; ------------------------------------------------------------------------
 ;;; reader integration

--- a/src/clj/clojure/java/browse.clj
+++ b/src/clj/clojure/java/browse.clj
@@ -1,22 +1,22 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-(ns 
-  ^{:author "Christophe Grand",
-    :doc "Start a web browser from Clojure"}
-  clojure.java.browse
+(ns
+ ^{:author "Christophe Grand",
+   :doc "Start a web browser from Clojure"}
+ clojure.java.browse
   (:require [clojure.java.shell :as sh]
             [clojure.string :as str])
   (:import (java.net URI)))
 
 (defn- macosx? []
   (-> "os.name" System/getProperty .toLowerCase
-    (.startsWith "mac os x")))
+      (.startsWith "mac os x")))
 
 (defn- xdg-open-loc []
   ;; try/catch needed to mask exception on Windows without Cygwin
@@ -44,22 +44,22 @@
   work on all platforms.  Returns url on success, nil if not
   supported."
   [url]
-  (try 
-    (when (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop" 
-      "isDesktopSupported" (to-array nil))
-      (-> (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop" 
-            "getDesktop" (to-array nil))
-        (.browse (URI. url)))
+  (try
+    (when (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop"
+                                                     "isDesktopSupported" (to-array nil))
+      (-> (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop"
+                                                     "getDesktop" (to-array nil))
+          (.browse (URI. url)))
       url)
     (catch ClassNotFoundException e
-      nil)))        
+      nil)))
 
 (defn- open-url-in-swing
- "Opens url (a string) in a Swing window."
- [url]
-  ; the implementation of this function resides in another namespace to be loaded "on demand"
-  ; this fixes a bug on mac os x where the process turns into a GUI app
-  ; see http://code.google.com/p/clojure-contrib/issues/detail?id=32
+  "Opens url (a string) in a Swing window."
+  [url]
+;; the implementation of this function resides in another namespace to be loaded "on demand"
+;; this fixes a bug on mac os x where the process turns into a GUI app
+;; see http://code.google.com/p/clojure-contrib/issues/detail?id=32
   (require 'clojure.java.browse-ui)
   ((find-var 'clojure.java.browse-ui/open-url-in-swing) url))
 

--- a/src/clj/clojure/java/browse_ui.clj
+++ b/src/clj/clojure/java/browse_ui.clj
@@ -1,30 +1,30 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns
-    ^{:author "Christophe Grand",
-      :doc "Helper namespace for clojure.java.browse.
+ ^{:author "Christophe Grand",
+   :doc "Helper namespace for clojure.java.browse.
             Prevents console apps from becoming GUI unnecessarily."}
-  clojure.java.browse-ui)
+ clojure.java.browse-ui)
 
 (defn- open-url-in-swing
   [url]
   (let [htmlpane (javax.swing.JEditorPane. url)]
     (.setEditable htmlpane false)
     (.addHyperlinkListener htmlpane
-      (proxy [javax.swing.event.HyperlinkListener] []
-        (hyperlinkUpdate [^javax.swing.event.HyperlinkEvent e]
-          (when (= (.getEventType e) (. javax.swing.event.HyperlinkEvent$EventType ACTIVATED))
-            (if (instance? javax.swing.text.html.HTMLFrameHyperlinkEvent e)
-              (-> htmlpane .getDocument (.processHTMLFrameHyperlinkEvent e))
-              (.setPage htmlpane (.getURL e)))))))
+                           (proxy [javax.swing.event.HyperlinkListener] []
+                             (hyperlinkUpdate [^javax.swing.event.HyperlinkEvent e]
+                               (when (= (.getEventType e) (. javax.swing.event.HyperlinkEvent$EventType ACTIVATED))
+                                 (if (instance? javax.swing.text.html.HTMLFrameHyperlinkEvent e)
+                                   (-> htmlpane .getDocument (.processHTMLFrameHyperlinkEvent e))
+                                   (.setPage htmlpane (.getURL e)))))))
     (doto (javax.swing.JFrame.)
       (.setContentPane (javax.swing.JScrollPane. htmlpane))
       (.setBounds 32 32 700 900)
       (.show))))
-      
+

--- a/src/clj/clojure/java/io.clj
+++ b/src/clj/clojure/java/io.clj
@@ -1,36 +1,35 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-(ns 
-  ^{:author "Stuart Sierra, Chas Emerick, Stuart Halloway",
-     :doc "This file defines polymorphic I/O utility functions for Clojure."}
-    clojure.java.io
-    (:require clojure.string)
-    (:import 
-     (java.io Reader InputStream InputStreamReader PushbackReader
-              BufferedReader File OutputStream
-              OutputStreamWriter BufferedWriter Writer
-              FileInputStream FileOutputStream ByteArrayOutputStream
-              StringReader ByteArrayInputStream
-              BufferedInputStream BufferedOutputStream
-              CharArrayReader Closeable)
-     (java.net URI URL MalformedURLException Socket URLDecoder URLEncoder)))
-
-(def
-    ^{:doc "Type object for a Java primitive byte array."
-      :private true
-      }
- byte-array-type (class (make-array Byte/TYPE 0)))
+(ns
+ ^{:author "Stuart Sierra, Chas Emerick, Stuart Halloway",
+   :doc "This file defines polymorphic I/O utility functions for Clojure."}
+ clojure.java.io
+  (:require clojure.string)
+  (:import
+   (java.io Reader InputStream InputStreamReader PushbackReader
+            BufferedReader File OutputStream
+            OutputStreamWriter BufferedWriter Writer
+            FileInputStream FileOutputStream ByteArrayOutputStream
+            StringReader ByteArrayInputStream
+            BufferedInputStream BufferedOutputStream
+            CharArrayReader Closeable)
+   (java.net URI URL MalformedURLException Socket URLDecoder URLEncoder)))
 
 (def
-    ^{:doc "Type object for a Java primitive char array."
-      :private true}
- char-array-type (class (make-array Character/TYPE 0)))
+  ^{:doc "Type object for a Java primitive byte array."
+    :private true}
+  byte-array-type (class (make-array Byte/TYPE 0)))
+
+(def
+  ^{:doc "Type object for a Java primitive char array."
+    :private true}
+  char-array-type (class (make-array Character/TYPE 0)))
 
 (defprotocol ^{:added "1.2"} Coercions
   "Coerce between various 'resource-namish' things."
@@ -45,11 +44,11 @@
   nil
   (as-file [_] nil)
   (as-url [_] nil)
-  
+
   String
   (as-file [s] (File. s))
-  (as-url [s] (URL. s))  
-  
+  (as-url [s] (URL. s))
+
   File
   (as-file [f] f)
   (as-url [f] (.toURL (.toURI f)))
@@ -72,7 +71,7 @@
    be unequivocally converted to the requested kind of stream.
 
    Common options include
-   
+
      :append    true to open stream in append mode
      :encoding  string name of encoding to use, e.g. \"UTF-8\".
 
@@ -182,101 +181,101 @@
 (extend BufferedInputStream
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [x opts] x)
-    :make-reader inputstream->reader))
+         :make-input-stream (fn [x opts] x)
+         :make-reader inputstream->reader))
 
 (extend InputStream
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [x opts] (BufferedInputStream. x))
-    :make-reader inputstream->reader))
+         :make-input-stream (fn [x opts] (BufferedInputStream. x))
+         :make-reader inputstream->reader))
 
 (extend Reader
   IOFactory
   (assoc default-streams-impl
-    :make-reader (fn [x opts] (BufferedReader. x))))
+         :make-reader (fn [x opts] (BufferedReader. x))))
 
 (extend BufferedReader
   IOFactory
   (assoc default-streams-impl
-    :make-reader (fn [x opts] x)))
+         :make-reader (fn [x opts] x)))
 
 (extend Writer
   IOFactory
   (assoc default-streams-impl
-    :make-writer (fn [x opts] (BufferedWriter. x))))
+         :make-writer (fn [x opts] (BufferedWriter. x))))
 
 (extend BufferedWriter
   IOFactory
   (assoc default-streams-impl
-    :make-writer (fn [x opts] x)))
+         :make-writer (fn [x opts] x)))
 
 (extend OutputStream
   IOFactory
   (assoc default-streams-impl
-    :make-output-stream (fn [x opts] (BufferedOutputStream. x))
-    :make-writer outputstream->writer))
+         :make-output-stream (fn [x opts] (BufferedOutputStream. x))
+         :make-writer outputstream->writer))
 
 (extend BufferedOutputStream
   IOFactory
   (assoc default-streams-impl
-    :make-output-stream (fn [x opts] x)
-    :make-writer outputstream->writer))
+         :make-output-stream (fn [x opts] x)
+         :make-writer outputstream->writer))
 
 (extend File
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [^File x opts] (make-input-stream (FileInputStream. x) opts))
-    :make-output-stream (fn [^File x opts] (make-output-stream (FileOutputStream. x (append? opts)) opts))))
+         :make-input-stream (fn [^File x opts] (make-input-stream (FileInputStream. x) opts))
+         :make-output-stream (fn [^File x opts] (make-output-stream (FileOutputStream. x (append? opts)) opts))))
 
 (extend URL
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [^URL x opts]
-                         (make-input-stream
-                          (if (= "file" (.getProtocol x))
-                            (FileInputStream. (as-file x))
-                            (.openStream x)) opts))
-    :make-output-stream (fn [^URL x opts]
-                          (if (= "file" (.getProtocol x))
-                            (make-output-stream (as-file x) opts)
-                            (throw (IllegalArgumentException. (str "Can not write to non-file URL <" x ">")))))))
+         :make-input-stream (fn [^URL x opts]
+                              (make-input-stream
+                               (if (= "file" (.getProtocol x))
+                                 (FileInputStream. (as-file x))
+                                 (.openStream x)) opts))
+         :make-output-stream (fn [^URL x opts]
+                               (if (= "file" (.getProtocol x))
+                                 (make-output-stream (as-file x) opts)
+                                 (throw (IllegalArgumentException. (str "Can not write to non-file URL <" x ">")))))))
 
 (extend URI
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [^URI x opts] (make-input-stream (.toURL x) opts))
-    :make-output-stream (fn [^URI x opts] (make-output-stream (.toURL x) opts))))
+         :make-input-stream (fn [^URI x opts] (make-input-stream (.toURL x) opts))
+         :make-output-stream (fn [^URI x opts] (make-output-stream (.toURL x) opts))))
 
 (extend String
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [^String x opts]
-                         (try
-                          (make-input-stream (URL. x) opts)
-                          (catch MalformedURLException e
-                            (make-input-stream (File. x) opts))))
-    :make-output-stream (fn [^String x opts]
-                          (try
-                           (make-output-stream (URL. x) opts)
-                           (catch MalformedURLException err
-                             (make-output-stream (File. x) opts))))))
+         :make-input-stream (fn [^String x opts]
+                              (try
+                                (make-input-stream (URL. x) opts)
+                                (catch MalformedURLException e
+                                  (make-input-stream (File. x) opts))))
+         :make-output-stream (fn [^String x opts]
+                               (try
+                                 (make-output-stream (URL. x) opts)
+                                 (catch MalformedURLException err
+                                   (make-output-stream (File. x) opts))))))
 
 (extend Socket
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [^Socket x opts] (make-input-stream (.getInputStream x) opts))
-    :make-output-stream (fn [^Socket x opts] (make-output-stream (.getOutputStream x) opts))))
+         :make-input-stream (fn [^Socket x opts] (make-input-stream (.getInputStream x) opts))
+         :make-output-stream (fn [^Socket x opts] (make-output-stream (.getOutputStream x) opts))))
 
 (extend byte-array-type
   IOFactory
   (assoc default-streams-impl
-    :make-input-stream (fn [x opts] (make-input-stream (ByteArrayInputStream. x) opts))))
+         :make-input-stream (fn [x opts] (make-input-stream (ByteArrayInputStream. x) opts))))
 
 (extend char-array-type
   IOFactory
   (assoc default-streams-impl
-    :make-reader (fn [x opts] (make-reader (CharArrayReader. x) opts))))
+         :make-reader (fn [x opts] (make-reader (CharArrayReader. x) opts))))
 
 (extend Object
   IOFactory
@@ -285,17 +284,17 @@
 (extend nil
   IOFactory
   (assoc default-streams-impl
-    :make-reader (fn [x opts]
-                   (throw (IllegalArgumentException.
-                           (str "Cannot open <" (pr-str x) "> as a Reader."))))
-    :make-writer (fn [x opts]
-                   (throw (IllegalArgumentException.
-                           (str "Cannot open <" (pr-str x) "> as a Writer."))))))
+         :make-reader (fn [x opts]
+                        (throw (IllegalArgumentException.
+                                (str "Cannot open <" (pr-str x) "> as a Reader."))))
+         :make-writer (fn [x opts]
+                        (throw (IllegalArgumentException.
+                                (str "Cannot open <" (pr-str x) "> as a Writer."))))))
 
 (defmulti
   ^{:doc "Internal helper for copy"
-     :private true
-     :arglists '([input output opts])}
+    :private true
+    :arglists '([input output opts])}
   do-copy
   (fn [input output opts] [(type input) (type output)]))
 
@@ -397,9 +396,9 @@
 
     :buffer-size  buffer size to use, default is 1024.
     :encoding     encoding to use if converting between
-                  byte and char streams.   
+                  byte and char streams.
 
-  Does not close any streams except those it opens itself 
+  Does not close any streams except those it opens itself
   (on a File)."
   {:added "1.2"}
   [input output & opts]
@@ -420,12 +419,12 @@
    versions treat the first argument as parent and subsequent args as
    children relative to the parent."
   {:added "1.2"}
-  ([arg]                      
-     (as-file arg))
-  ([parent child]             
-     (File. ^File (as-file parent) ^String (as-relative-path child)))
+  ([arg]
+   (as-file arg))
+  ([parent child]
+   (File. ^File (as-file parent) ^String (as-relative-path child)))
   ([parent child & more]
-     (reduce file (file parent child) more)))
+   (reduce file (file parent child) more)))
 
 (defn delete-file
   "Delete file f. Raise an exception if it fails unless silently is true."

--- a/src/clj/clojure/java/javadoc.clj
+++ b/src/clj/clojure/java/javadoc.clj
@@ -1,15 +1,15 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
-(ns 
-  ^{:author "Christophe Grand, Stuart Sierra",
-     :doc "A repl helper to quickly open javadocs."}
-  clojure.java.javadoc
-  (:use [clojure.java.browse :only (browse-url)] )
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
+(ns
+ ^{:author "Christophe Grand, Stuart Sierra",
+   :doc "A repl helper to quickly open javadocs."}
+ clojure.java.javadoc
+  (:use [clojure.java.browse :only (browse-url)])
   (:import
    (java.io File)))
 
@@ -17,23 +17,23 @@
 (def ^:dynamic *feeling-lucky* true)
 
 (def ^:dynamic *local-javadocs* (ref (list)))
- 
+
 (def ^:dynamic *core-java-api*
   (case (System/getProperty "java.specification.version")
     "1.6" "http://java.sun.com/javase/6/docs/api/"
     "http://java.sun.com/javase/7/docs/api/"))
 
 (def ^:dynamic *remote-javadocs*
- (ref (sorted-map
-       "java." *core-java-api*
-       "javax." *core-java-api*
-       "org.ietf.jgss." *core-java-api*
-       "org.omg." *core-java-api*
-       "org.w3c.dom." *core-java-api*
-       "org.xml.sax." *core-java-api*
-       "org.apache.commons.codec." "http://commons.apache.org/codec/api-release/"
-       "org.apache.commons.io." "http://commons.apache.org/io/api-release/"
-       "org.apache.commons.lang." "http://commons.apache.org/lang/api-release/")))
+  (ref (sorted-map
+        "java." *core-java-api*
+        "javax." *core-java-api*
+        "org.ietf.jgss." *core-java-api*
+        "org.omg." *core-java-api*
+        "org.w3c.dom." *core-java-api*
+        "org.xml.sax." *core-java-api*
+        "org.apache.commons.codec." "http://commons.apache.org/codec/api-release/"
+        "org.apache.commons.io." "http://commons.apache.org/io/api-release/"
+        "org.apache.commons.lang." "http://commons.apache.org/lang/api-release/")))
 
 (defn add-local-javadoc
   "Adds to the list of local Javadoc paths."
@@ -57,26 +57,26 @@
   (let [file-path (.replace classname \. File/separatorChar)
         url-path (.replace classname \. \/)]
     (if-let [file ^File (first
-                           (filter #(.exists ^File %)
-                             (map #(File. (str %) (str file-path ".html"))
-                               @*local-javadocs*)))]
+                         (filter #(.exists ^File %)
+                                 (map #(File. (str %) (str file-path ".html"))
+                                      @*local-javadocs*)))]
       (-> file .toURI str)
       ;; If no local file, try remote URLs:
       (or (some (fn [[prefix url]]
                   (when (.startsWith classname prefix)
                     (str url url-path ".html")))
-            @*remote-javadocs*)
+                @*remote-javadocs*)
         ;; if *feeling-lucky* try a web search
-        (when *feeling-lucky* (str *feeling-lucky-url* url-path ".html"))))))
+          (when *feeling-lucky* (str *feeling-lucky-url* url-path ".html"))))))
 
 (defn javadoc
   "Opens a browser window displaying the javadoc for the argument.
   Tries *local-javadocs* first, then *remote-javadocs*."
   {:added "1.2"}
   [class-or-object]
-  (let [^Class c (if (instance? Class class-or-object) 
-                    class-or-object 
-                    (class class-or-object))]
+  (let [^Class c (if (instance? Class class-or-object)
+                   class-or-object
+                   (class class-or-object))]
     (if-let [url (javadoc-url (.getName c))]
       (browse-url url)
       (println "Could not find Javadoc for" c))))

--- a/src/clj/clojure/java/shell.clj
+++ b/src/clj/clojure/java/shell.clj
@@ -1,16 +1,16 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-(ns 
-  ^{:author "Chris Houser, Stuart Halloway",
-    :doc "Conveniently launch a sub-process providing its stdin and
+(ns
+ ^{:author "Chris Houser, Stuart Halloway",
+   :doc "Conveniently launch a sub-process providing its stdin and
 collecting its stdout"}
-  clojure.java.shell
+ clojure.java.shell
   (:use [clojure.java.io :only (as-file copy)])
   (:import (java.io ByteArrayOutputStream StringWriter)
            (java.nio.charset Charset)))
@@ -31,7 +31,7 @@ collecting its stdout"}
   [env & forms]
   `(binding [*sh-env* ~env]
      ~@forms))
-     
+
 (defn- aconcat
   "Concatenates arrays of given type."
   [type & xs]
@@ -49,13 +49,13 @@ collecting its stdout"}
         [cmd opts] (split-with string? args)]
     [cmd (merge default-opts (apply hash-map opts))]))
 
-(defn- ^"[Ljava.lang.String;" as-env-strings 
+(defn- ^"[Ljava.lang.String;" as-env-strings
   "Helper so that callers can pass a Clojure map for the :env to sh."
   [arg]
   (cond
-   (nil? arg) nil
-   (map? arg) (into-array String (map (fn [[k v]] (str (name k) "=" v)) arg))
-   true arg))
+    (nil? arg) nil
+    (map? arg) (into-array String (map (fn [[k v]] (str (name k) "=" v)) arg))
+    true arg))
 
 (defn- stream-to-bytes
   [in]
@@ -66,9 +66,9 @@ collecting its stdout"}
 (defn- stream-to-string
   ([in] (stream-to-string in (.name (Charset/defaultCharset))))
   ([in enc]
-     (with-open [bout (StringWriter.)]
-       (copy in bout :encoding enc)
-       (.toString bout))))
+   (with-open [bout (StringWriter.)]
+     (copy in bout :encoding enc)
+     (.toString bout))))
 
 (defn- stream-to-enc
   [stream enc]
@@ -110,10 +110,10 @@ collecting its stdout"}
   {:added "1.2"}
   [& args]
   (let [[cmd opts] (parse-args args)
-        proc (.exec (Runtime/getRuntime) 
-               ^"[Ljava.lang.String;" (into-array cmd)
-               (as-env-strings (:env opts))
-               (as-file (:dir opts)))
+        proc (.exec (Runtime/getRuntime)
+                    ^"[Ljava.lang.String;" (into-array cmd)
+                    (as-env-strings (:env opts))
+                    (as-file (:dir opts)))
         {:keys [in in-enc out-enc]} opts]
     (if in
       (future
@@ -129,14 +129,12 @@ collecting its stdout"}
 
 (comment
 
-(println (sh "ls" "-l"))
-(println (sh "ls" "-l" "/no-such-thing"))
-(println (sh "sed" "s/[aeiou]/oo/g" :in "hello there\n"))
-(println (sh "sed" "s/[aeiou]/oo/g" :in (java.io.StringReader. "hello there\n")))
-(println (sh "cat" :in "x\u25bax\n"))
-(println (sh "echo" "x\u25bax"))
-(println (sh "echo" "x\u25bax" :out-enc "ISO-8859-1")) ; reads 4 single-byte chars
-(println (sh "cat" "myimage.png" :out-enc :bytes)) ; reads binary file into bytes[]
-(println (sh "cmd" "/c dir 1>&2"))
-
-)
+  (println (sh "ls" "-l"))
+  (println (sh "ls" "-l" "/no-such-thing"))
+  (println (sh "sed" "s/[aeiou]/oo/g" :in "hello there\n"))
+  (println (sh "sed" "s/[aeiou]/oo/g" :in (java.io.StringReader. "hello there\n")))
+  (println (sh "cat" :in "x\u25bax\n"))
+  (println (sh "echo" "x\u25bax"))
+  (println (sh "echo" "x\u25bax" :out-enc "ISO-8859-1")) ; reads 4 single-byte chars
+  (println (sh "cat" "myimage.png" :out-enc :bytes)) ; reads binary file into bytes[]
+  (println (sh "cmd" "/c dir 1>&2")))

--- a/src/clj/clojure/main.clj
+++ b/src/clj/clojure/main.clj
@@ -9,23 +9,23 @@
 ;; Originally contributed by Stephen C. Gilardi
 
 (ns ^{:doc "Top-level main function for Clojure REPL and scripts."
-       :author "Stephen C. Gilardi and Rich Hickey"}
-  clojure.main
+      :author "Stephen C. Gilardi and Rich Hickey"}
+ clojure.main
   (:refer-clojure :exclude [with-bindings])
   (:import (clojure.lang Compiler Compiler$CompilerException
                          LineNumberingPushbackReader RT))
   ;;(:use [clojure.repl :only (demunge root-cause stack-element-str)])
-  )
+)
 
 (declare main)
 
 ;;;;;;;;;;;;;;;;;;; redundantly copied from clojure.repl to avoid dep ;;;;;;;;;;;;;;
 #_(defn root-cause [x] x)
 #_(defn stack-element-str
-  "Returns a (possibly unmunged) string representation of a StackTraceElement"
-  {:added "1.3"}
-  [^StackTraceElement el]
-  (.getClassName el))
+    "Returns a (possibly unmunged) string representation of a StackTraceElement"
+    {:added "1.3"}
+    [^StackTraceElement el]
+    (.getClassName el))
 
 (defn demunge
   "Given a string representation of a fn class,
@@ -84,7 +84,7 @@
              *2                       nil
              *3                       nil
              *e                       nil
-             *compiler-options*       *compiler-options*] 
+             *compiler-options*       *compiler-options*]
      ~@body))
 
 (defn repl-prompt
@@ -102,9 +102,9 @@
   [s]
   (let [c (.read s)]
     (cond
-     (= c (int \newline)) :line-start
-     (= c -1) :stream-end
-     :else (do (.unread s c) :body))))
+      (= c (int \newline)) :line-start
+      (= c -1) :stream-end
+      :else (do (.unread s c) :body))))
 
 (defn skip-whitespace
   "Skips whitespace characters on stream s. Returns :line-start, :stream-end,
@@ -118,11 +118,11 @@
   [s]
   (loop [c (.read s)]
     (cond
-     (= c (int \newline)) :line-start
-     (= c -1) :stream-end
-     (= c (int \;)) (do (.readLine s) :line-start)
-     (or (Character/isWhitespace (char c)) (= c (int \,))) (recur (.read s))
-     :else (do (.unread s c) :body))))
+      (= c (int \newline)) :line-start
+      (= c -1) :stream-end
+      (= c (int \;)) (do (.readLine s) :line-start)
+      (or (Character/isWhitespace (char c)) (= c (int \,))) (recur (.read s))
+      :else (do (.unread s c) :body))))
 
 (defn repl-read
   "Default :read hook for repl. Reads from *in* which must either be an
@@ -237,34 +237,34 @@ by default when a new command-line REPL is started."} repl-requires
           (try
             (let [read-eval *read-eval*
                   input (with-read-known (read request-prompt request-exit))]
-             (or (#{request-prompt request-exit} input)
-                 (let [value (binding [*read-eval* read-eval] (eval input))]
-                   (print value)
-                   (set! *3 *2)
-                   (set! *2 *1)
-                   (set! *1 value))))
-           (catch Throwable e
-             (caught e)
-             (set! *e e))))]
+              (or (#{request-prompt request-exit} input)
+                  (let [value (binding [*read-eval* read-eval] (eval input))]
+                    (print value)
+                    (set! *3 *2)
+                    (set! *2 *1)
+                    (set! *1 value))))
+            (catch Throwable e
+              (caught e)
+              (set! *e e))))]
     (with-bindings
-     (try
-      (init)
-      (catch Throwable e
-        (caught e)
-        (set! *e e)))
-     (prompt)
-     (flush)
-     (loop []
-       (when-not 
-       	 (try (identical? (read-eval-print) request-exit)
-	  (catch Throwable e
-	   (caught e)
-	   (set! *e e)
-	   nil))
-         (when (need-prompt)
-           (prompt)
-           (flush))
-         (recur))))))
+      (try
+        (init)
+        (catch Throwable e
+          (caught e)
+          (set! *e e)))
+      (prompt)
+      (flush)
+      (loop []
+        (when-not
+         (try (identical? (read-eval-print) request-exit)
+              (catch Throwable e
+                (caught e)
+                (set! *e e)
+                nil))
+          (when (need-prompt)
+            (prompt)
+            (flush))
+          (recur))))))
 
 (defn load-script
   "Loads Clojure source from a file or resource given its path. Paths
@@ -285,12 +285,12 @@ by default when a new command-line REPL is started."} repl-requires
   [str]
   (let [eof (Object.)
         reader (LineNumberingPushbackReader. (java.io.StringReader. str))]
-      (loop [input (with-read-known (read reader false eof))]
-        (when-not (= input eof)
-          (let [value (eval input)]
-            (when-not (nil? value)
-              (prn value))
-            (recur (with-read-known (read reader false eof))))))))
+    (loop [input (with-read-known (read reader false eof))]
+      (when-not (= input eof)
+        (let [value (eval input)]
+          (when-not (nil? value)
+            (prn value))
+          (recur (with-read-known (read reader false eof))))))))
 
 (defn- init-dispatch
   "Returns the handler associated with an init opt"
@@ -415,12 +415,12 @@ java -cp clojure.jar clojure.main -i init.clj script.clj args...")
   classpath. Classpath-relative paths have prefix of @ or @/"
   [& args]
   (try
-   (if args
-     (loop [[opt arg & more :as args] args inits []]
-       (if (init-dispatch opt)
-         (recur more (conj inits [opt arg]))
-         ((main-dispatch opt) args inits)))
-     (repl-opt nil nil))
-   (finally 
-     (flush))))
+    (if args
+      (loop [[opt arg & more :as args] args inits []]
+        (if (init-dispatch opt)
+          (recur more (conj inits [opt arg]))
+          ((main-dispatch opt) args inits)))
+      (repl-opt nil nil))
+    (finally
+      (flush))))
 

--- a/src/clj/clojure/parallel.clj
+++ b/src/clj/clojure/parallel.clj
@@ -1,14 +1,14 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "DEPRECATED Wrapper of the ForkJoin library (JSR-166)."
-       :author "Rich Hickey"}
-    clojure.parallel)
+      :author "Rich Hickey"}
+ clojure.parallel)
 (alias 'parallel 'clojure.parallel)
 
 (comment "
@@ -37,9 +37,9 @@ etc. A parallel array can be realized into a Clojure vector using
 pvec.
 ")
 
-(import '(jsr166y.forkjoin ParallelArray ParallelArrayWithBounds ParallelArrayWithFilter 
-                           ParallelArrayWithMapping 
-                           Ops$Op Ops$BinaryOp Ops$Reducer Ops$Predicate Ops$BinaryPredicate 
+(import '(jsr166y.forkjoin ParallelArray ParallelArrayWithBounds ParallelArrayWithFilter
+                           ParallelArrayWithMapping
+                           Ops$Op Ops$BinaryOp Ops$Reducer Ops$Predicate Ops$BinaryPredicate
                            Ops$IntAndObjectPredicate Ops$IntAndObjectToObject))
 
 (defn- op [f]
@@ -77,34 +77,34 @@ pvec.
   must precede maps. ops must be a set of keyword value pairs of the
   following forms:
 
-     :bound [start end] 
+     :bound [start end]
 
   Only elements from start (inclusive) to end (exclusive) will be
   processed when the array is realized.
 
-     :filter pred 
+     :filter pred
 
   Filter preds remove elements from processing when the array is realized. pred
   must be a function of one argument whose return will be processed
   via boolean.
 
-     :filter-index pred2 
+     :filter-index pred2
 
   pred2 must be a function of two arguments, which will be an element
   of the collection and the corresponding index, whose return will be
   processed via boolean.
 
-     :filter-with [pred2 coll2] 
+     :filter-with [pred2 coll2]
 
   pred2 must be a function of two arguments, which will be
   corresponding elements of the 2 collections.
 
-     :map f 
+     :map f
 
   Map fns will be used to transform elements when the array is
   realized. f must be a function of one argument.
 
-     :map-index f2 
+     :map-index f2
 
   f2 must be a function of two arguments, which will be an element of
   the collection and the corresponding index.
@@ -114,30 +114,30 @@ pvec.
   f2 must be a function of two arguments, which will be corresponding
   elements of the 2 collections."
 
-  ([coll] 
-     (if (instance? ParallelArrayWithMapping coll)
-       coll
-       (. ParallelArray createUsingHandoff  
-        (to-array coll) 
+  ([coll]
+   (if (instance? ParallelArrayWithMapping coll)
+     coll
+     (. ParallelArray createUsingHandoff
+        (to-array coll)
         (. ParallelArray defaultExecutor))))
   ([coll & ops]
-     (reduce (fn [pa [op args]] 
-                 (cond
-                  (= op :bound) (. pa withBounds (args 0) (args 1))
-                  (= op :filter) (. pa withFilter (predicate args))
-                  (= op :filter-with) (. pa withFilter (binary-predicate (args 0)) (par (args 1)))
-                  (= op :filter-index) (. pa withIndexedFilter (int-and-object-predicate args))
-                  (= op :map) (. pa withMapping (parallel/op args))
-                  (= op :map-with) (. pa withMapping (binary-op (args 0)) (par (args 1)))
-                  (= op :map-index) (. pa withIndexedMapping (int-and-object-to-object args))
-                  :else (throw (Exception. (str "Unsupported par op: " op)))))
-             (par coll) 
-             (partition 2 ops))))
+   (reduce (fn [pa [op args]]
+             (cond
+               (= op :bound) (. pa withBounds (args 0) (args 1))
+               (= op :filter) (. pa withFilter (predicate args))
+               (= op :filter-with) (. pa withFilter (binary-predicate (args 0)) (par (args 1)))
+               (= op :filter-index) (. pa withIndexedFilter (int-and-object-predicate args))
+               (= op :map) (. pa withMapping (parallel/op args))
+               (= op :map-with) (. pa withMapping (binary-op (args 0)) (par (args 1)))
+               (= op :map-index) (. pa withIndexedMapping (int-and-object-to-object args))
+               :else (throw (Exception. (str "Unsupported par op: " op)))))
+           (par coll)
+           (partition 2 ops))))
 
 ;;;;;;;;;;;;;;;;;;;;; aggregate operations ;;;;;;;;;;;;;;;;;;;;;;
 (defn pany
   "Returns some (random) element of the coll if it satisfies the bound/filter/map"
-  [coll] 
+  [coll]
   (. (par coll) any))
 
 (defn pmax
@@ -155,16 +155,16 @@ pvec.
 (defn- summary-map [s]
   {:min (.min s) :max (.max s) :size (.size s) :min-index (.indexOfMin s) :max-index (.indexOfMax s)})
 
-(defn psummary 
-  "Returns a map of summary statistics (min. max, size, min-index, max-index, 
+(defn psummary
+  "Returns a map of summary statistics (min. max, size, min-index, max-index,
   presuming Comparable elements, unless a Comparator comp is supplied"
   ([coll] (summary-map (. (par coll) summary)))
   ([coll comp] (summary-map (. (par coll) summary comp))))
 
-(defn preduce 
+(defn preduce
   "Returns the reduction of the realized elements of coll
   using function f. Note f will not necessarily be called
-  consecutively, and so must be commutative. Also note that 
+  consecutively, and so must be commutative. Also note that
   (f base an-element) might be performed many times, i.e. base is not
   an initial value as with sequential reduce."
   [f base coll]
@@ -182,7 +182,7 @@ pvec.
     (. coll all)
     (par coll)))
 
-(defn pvec 
+(defn pvec
   "Returns the realized contents of the parallel array pa as a Clojure vector"
   [pa] (pa-to-vec (pall pa)))
 
@@ -195,8 +195,8 @@ pvec.
 (defn- pcumulate [coll f init]
   (.. (pall coll) (precumulate (reducer f) init)))
 
-(defn psort 
-  "Returns a new vector consisting of the realized items in coll, sorted, 
+(defn psort
+  "Returns a new vector consisting of the realized items in coll, sorted,
   presuming Comparable elements, unless a Comparator comp is supplied"
   ([coll] (pa-to-vec (. (pall coll) sort)))
   ([coll comp] (pa-to-vec (. (pall coll) sort comp))))
@@ -206,45 +206,43 @@ pvec.
   [coll]
   (pa-to-vec (. (pall coll) removeNulls)))
 
-(defn pfilter-dupes 
-  "Returns a vector containing the (realized) elements of coll, 
+(defn pfilter-dupes
+  "Returns a vector containing the (realized) elements of coll,
   without any consecutive duplicates"
   [coll]
   (pa-to-vec (. (pall coll) removeConsecutiveDuplicates)))
 
-
 (comment
-(load-file "src/parallel.clj")
-(refer 'parallel)
-(pdistinct [1 2 3 2 1])
+  (load-file "src/parallel.clj")
+  (refer 'parallel)
+  (pdistinct [1 2 3 2 1])
 ;(pcumulate [1 2 3 2 1] + 0) ;broken, not exposed
-(def a (make-array Object 1000000))
-(dotimes i (count a)
-  (aset a i (rand-int i)))
-(time (reduce + 0 a))
-(time (preduce + 0 a))
-(time (count (distinct a)))
-(time (count (pdistinct a)))
+  (def a (make-array Object 1000000))
+  (dotimes i (count a)
+           (aset a i (rand-int i)))
+  (time (reduce + 0 a))
+  (time (preduce + 0 a))
+  (time (count (distinct a)))
+  (time (count (pdistinct a)))
 
-(preduce + 0 [1 2 3 2 1])
-(preduce + 0 (psort a))
-(pvec (par [11 2 3 2] :filter-index (fn [x i] (> i x))))
-(pvec (par [11 2 3 2] :filter-with [(fn [x y] (> y x)) [110 2 33 2]]))
+  (preduce + 0 [1 2 3 2 1])
+  (preduce + 0 (psort a))
+  (pvec (par [11 2 3 2] :filter-index (fn [x i] (> i x))))
+  (pvec (par [11 2 3 2] :filter-with [(fn [x y] (> y x)) [110 2 33 2]]))
 
-(psummary ;or pvec/pmax etc
- (par [11 2 3 2] 
-      :filter-with [(fn [x y] (> y x)) 
-                    [110 2 33 2]]
-      :map #(* % 2)))
+  (psummary ;or pvec/pmax etc
+   (par [11 2 3 2]
+        :filter-with [(fn [x y] (> y x))
+                      [110 2 33 2]]
+        :map #(* % 2)))
 
-(preduce + 0
-  (par [11 2 3 2] 
-       :filter-with [< [110 2 33 2]]))
+  (preduce + 0
+           (par [11 2 3 2]
+                :filter-with [< [110 2 33 2]]))
 
-(time (reduce + 0 (map #(* % %) (range 1000000))))
-(time (preduce + 0 (par (range 1000000) :map-index *)))
-(def v (range 1000000))
-(time (preduce + 0 (par v :map-index *)))
-(time (preduce + 0 (par v :map  #(* % %))))
-(time (reduce + 0 (map #(* % %) v)))
-)
+  (time (reduce + 0 (map #(* % %) (range 1000000))))
+  (time (preduce + 0 (par (range 1000000) :map-index *)))
+  (def v (range 1000000))
+  (time (preduce + 0 (par v :map-index *)))
+  (time (preduce + 0 (par v :map  #(* % %))))
+  (time (reduce + 0 (map #(* % %) v))))

--- a/src/clj/clojure/pprint.clj
+++ b/src/clj/clojure/pprint.clj
@@ -1,42 +1,42 @@
 ;;; pprint.clj -- Pretty printer and Common Lisp compatible format function (cl-format) for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
 
-(ns 
-    ^{:author "Tom Faulhaber",
-      :doc "A Pretty Printer for Clojure
+(ns
+ ^{:author "Tom Faulhaber",
+   :doc "A Pretty Printer for Clojure
 
 clojure.pprint implements a flexible system for printing structured data
-in a pleasing, easy-to-understand format. Basic use of the pretty printer is 
-simple, just call pprint instead of println. More advanced users can use 
-the building blocks provided to create custom output formats. 
+in a pleasing, easy-to-understand format. Basic use of the pretty printer is
+simple, just call pprint instead of println. More advanced users can use
+the building blocks provided to create custom output formats.
 
-Out of the box, pprint supports a simple structured format for basic data 
-and a specialized format for Clojure source code. More advanced formats, 
-including formats that don't look like Clojure data at all like XML and 
-JSON, can be rendered by creating custom dispatch functions. 
+Out of the box, pprint supports a simple structured format for basic data
+and a specialized format for Clojure source code. More advanced formats,
+including formats that don't look like Clojure data at all like XML and
+JSON, can be rendered by creating custom dispatch functions.
 
-In addition to the pprint function, this module contains cl-format, a text 
-formatting function which is fully compatible with the format function in 
+In addition to the pprint function, this module contains cl-format, a text
+formatting function which is fully compatible with the format function in
 Common Lisp. Because pretty printing directives are directly integrated with
 cl-format, it supports very concise custom dispatch. It also provides
 a more powerful alternative to Clojure's standard format function.
 
-See documentation for pprint and cl-format for more information or 
+See documentation for pprint and cl-format for more information or
 complete documentation on the the clojure web site on github.",
-       :added "1.2"}
-    clojure.pprint
-    (:refer-clojure :exclude (deftype))
-    (:use [clojure.walk :only [walk]]))
+   :added "1.2"}
+ clojure.pprint
+  (:refer-clojure :exclude (deftype))
+  (:use [clojure.walk :only [walk]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/clj/clojure/pprint/cl_format.clj
+++ b/src/clj/clojure/pprint/cl_format.clj
@@ -1,12 +1,12 @@
 ;;; cl_format.clj -- part of the pretty printer for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -24,37 +24,37 @@
 (declare init-navigator)
 ;;; End forward references
 
-(defn cl-format 
+(defn cl-format
   "An implementation of a Common Lisp compatible format function. cl-format formats its
-arguments to an output stream or string based on the format control string given. It 
+arguments to an output stream or string based on the format control string given. It
 supports sophisticated formatting of structured data.
 
-Writer is an instance of java.io.Writer, true to output to *out* or nil to output 
-to a string, format-in is the format control string and the remaining arguments 
+Writer is an instance of java.io.Writer, true to output to *out* or nil to output
+to a string, format-in is the format control string and the remaining arguments
 are the data to be formatted.
 
-The format control string is a string to be output with embedded 'format directives' 
+The format control string is a string to be output with embedded 'format directives'
 describing how to format the various arguments passed in.
 
-If writer is nil, cl-format returns the formatted result string. Otherwise, cl-format 
+If writer is nil, cl-format returns the formatted result string. Otherwise, cl-format
 returns nil.
 
 For example:
  (let [results [46 38 22]]
-        (cl-format true \"There ~[are~;is~:;are~]~:* ~d result~:p: ~{~d~^, ~}~%\" 
+        (cl-format true \"There ~[are~;is~:;are~]~:* ~d result~:p: ~{~d~^, ~}~%\"
                    (count results) results))
 
 Prints to *out*:
  There are 3 results: 46, 38, 22
 
-Detailed documentation on format control strings is available in the \"Common Lisp the 
+Detailed documentation on format control strings is available in the \"Common Lisp the
 Language, 2nd edition\", Chapter 22 (available online at:
-http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/cltl/clm/node200.html#SECTION002633000000000000000) 
-and in the Common Lisp HyperSpec at 
+http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/cltl/clm/node200.html#SECTION002633000000000000000)
+and in the Common Lisp HyperSpec at
 http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
 "
   {:added "1.2",
-   :see-also [["http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/cltl/clm/node200.html#SECTION002633000000000000000" 
+   :see-also [["http://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/cltl/clm/node200.html#SECTION002633000000000000000"
                "Common Lisp the Language"]
               ["http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm"
                "Common Lisp HyperSpec"]]}
@@ -65,9 +65,9 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
 
 (def ^:dynamic ^{:private true} *format-str* nil)
 
-(defn- format-error [message offset] 
-  (let [full-message (str message \newline *format-str* \newline 
-                           (apply str (repeat offset \space)) "^" \newline)]
+(defn- format-error [message offset]
+  (let [full-message (str message \newline *format-str* \newline
+                          (apply str (repeat offset \space)) "^" \newline)]
     (throw (RuntimeException. full-message))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -77,9 +77,9 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defstruct ^{:private true}
-  arg-navigator :seq :rest :pos )
+ arg-navigator :seq :rest :pos)
 
-(defn- init-navigator 
+(defn- init-navigator
   "Create a new arg-navigator from the sequence with the position set to 0"
   {:skip-wiki true}
   [s]
@@ -87,24 +87,24 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
     (struct arg-navigator s s 0)))
 
 ;; TODO call format-error with offset
-(defn- next-arg [ navigator ]
-  (let [ rst (:rest navigator) ]
+(defn- next-arg [navigator]
+  (let [rst (:rest navigator)]
     (if rst
-      [(first rst) (struct arg-navigator (:seq navigator ) (next rst) (inc (:pos navigator)))]
-     (throw (new Exception  "Not enough arguments for format definition")))))
+      [(first rst) (struct arg-navigator (:seq navigator) (next rst) (inc (:pos navigator)))]
+      (throw (new Exception  "Not enough arguments for format definition")))))
 
 (defn- next-arg-or-nil [navigator]
   (let [rst (:rest navigator)]
     (if rst
-      [(first rst) (struct arg-navigator (:seq navigator ) (next rst) (inc (:pos navigator)))]
+      [(first rst) (struct arg-navigator (:seq navigator) (next rst) (inc (:pos navigator)))]
       [nil navigator])))
 
 ;; Get an argument off the arg list and compile it if it's not already compiled
 (defn- get-format-arg [navigator]
   (let [[raw-format navigator] (next-arg navigator)
-        compiled-format (if (instance? String raw-format) 
-                               (compile-format raw-format)
-                               raw-format)]
+        compiled-format (if (instance? String raw-format)
+                          (compile-format raw-format)
+                          raw-format)]
     [compiled-format navigator]))
 
 (declare relative-reposition)
@@ -121,7 +121,7 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
       (struct arg-navigator (:seq navigator) (drop position (:rest navigator)) newpos))))
 
 (defstruct ^{:private true}
-  compiled-directive :func :def :params :offset)
+ compiled-directive :func :def :params :offset)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; When looking at the parameter list, we may need to manipulate
@@ -133,22 +133,22 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
 ;; TODO: validate parameters when they come from arg list
 (defn- realize-parameter [[param [raw-val offset]] navigator]
   (let [[real-param new-navigator]
-        (cond 
-         (contains? #{ :at :colon } param) ;pass flags through unchanged - this really isn't necessary
-         [raw-val navigator]
+        (cond
+          (contains? #{:at :colon} param) ;pass flags through unchanged - this really isn't necessary
+          [raw-val navigator]
 
-         (= raw-val :parameter-from-args) 
-         (next-arg navigator)
+          (= raw-val :parameter-from-args)
+          (next-arg navigator)
 
-         (= raw-val :remaining-arg-count) 
-         [(count (:rest navigator)) navigator]
+          (= raw-val :remaining-arg-count)
+          [(count (:rest navigator)) navigator]
 
-         true 
-         [raw-val navigator])]
+          true
+          [raw-val navigator])]
     [[param [real-param offset]] new-navigator]))
-         
+
 (defn- realize-parameter-list [parameter-map navigator]
-  (let [[pairs new-navigator] 
+  (let [[pairs new-navigator]
         (map-passing-context realize-parameter navigator parameter-map)]
     [(into {} pairs) new-navigator]))
 
@@ -163,10 +163,10 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
 (declare opt-base-str)
 
 (def ^{:private true}
-     special-radix-markers {2 "#b" 8 "#o", 16 "#x"})
+  special-radix-markers {2 "#b" 8 "#o", 16 "#x"})
 
 (defn- format-simple-number [n]
-  (cond 
+  (cond
     (integer? n) (if (= *print-base* 10)
                    (str n (if *print-radix* "."))
                    (str
@@ -180,18 +180,18 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
     :else nil))
 
 (defn- format-ascii [print-func params arg-navigator offsets]
-  (let [ [arg arg-navigator] (next-arg arg-navigator) 
-         ^String base-output (or (format-simple-number arg) (print-func arg))
-         base-width (.length base-output)
-         min-width (+ base-width (:minpad params))
-         width (if (>= min-width (:mincol params)) 
-                 min-width
-                 (+ min-width 
-                    (* (+ (quot (- (:mincol params) min-width 1) 
-                                (:colinc params) )
-                          1)
-                       (:colinc params))))
-         chars (apply str (repeat (- width base-width) (:padchar params)))]
+  (let [[arg arg-navigator] (next-arg arg-navigator)
+        ^String base-output (or (format-simple-number arg) (print-func arg))
+        base-width (.length base-output)
+        min-width (+ base-width (:minpad params))
+        width (if (>= min-width (:mincol params))
+                min-width
+                (+ min-width
+                   (* (+ (quot (- (:mincol params) min-width 1)
+                               (:colinc params))
+                         1)
+                      (:colinc params))))
+        chars (apply str (repeat (- width base-width) (:padchar params)))]
     (if (:at params)
       (print (str chars base-output))
       (print (str base-output chars)))
@@ -206,21 +206,21 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
   "returns true if a number is actually an integer (that is, has no fractional part)"
   [x]
   (cond
-   (integer? x) true
-   (decimal? x) (>= (.ulp (.stripTrailingZeros (bigdec 0))) 1) ; true iff no fractional part
-   (float? x)   (= x (Math/floor x))
-   (ratio? x)   (let [^clojure.lang.Ratio r x]
-                  (= 0 (rem (.numerator r) (.denominator r))))
-   :else        false))
+    (integer? x) true
+    (decimal? x) (>= (.ulp (.stripTrailingZeros (bigdec 0))) 1) ; true iff no fractional part
+    (float? x)   (= x (Math/floor x))
+    (ratio? x)   (let [^clojure.lang.Ratio r x]
+                   (= 0 (rem (.numerator r) (.denominator r))))
+    :else        false))
 
 (defn- remainders
   "Return the list of remainders (essentially the 'digits') of val in the given base"
   [base val]
-  (reverse 
-   (first 
-    (consume #(if (pos? %) 
-                [(rem % base) (quot % base)] 
-                [nil nil]) 
+  (reverse
+   (first
+    (consume #(if (pos? %)
+                [(rem % base) (quot % base)]
+                [nil nil])
              val))))
 
 ;;; TODO: xlated-val does not seem to be used here.
@@ -231,16 +231,16 @@ http://www.lispworks.com/documentation/HyperSpec/Body/22_c.htm
     "0"
     (let [xlated-val (cond
                        (float? val) (bigdec val)
-                       (ratio? val) (let [^clojure.lang.Ratio r val] 
+                       (ratio? val) (let [^clojure.lang.Ratio r val]
                                       (/ (.numerator r) (.denominator r)))
-                       :else val)] 
-      (apply str 
-             (map 
-              #(if (< % 10) (char (+ (int \0) %)) (char (+ (int \a) (- % 10)))) 
+                       :else val)]
+      (apply str
+             (map
+              #(if (< % 10) (char (+ (int \0) %)) (char (+ (int \a) (- % 10))))
               (remainders base val))))))
 
 (def ^{:private true}
-     java-base-formats {8 "%o", 10 "%d", 16 "%x"})
+  java-base-formats {8 "%o", 10 "%d", 16 "%x"})
 
 (defn- opt-base-str
   "Return val as a string in the given base, using clojure.core/format if supported
@@ -268,17 +268,17 @@ for improved performance"
                           (apply str (next (interleave commas groups))))
                         raw-str)
             ^String signed-str (cond
-                                  neg (str "-" group-str)
-                                  (:at params) (str "+" group-str)
-                                  true group-str)
+                                 neg (str "-" group-str)
+                                 (:at params) (str "+" group-str)
+                                 true group-str)
             padded-str (if (< (.length signed-str) (:mincol params))
-                         (str (apply str (repeat (- (:mincol params) (.length signed-str)) 
+                         (str (apply str (repeat (- (:mincol params) (.length signed-str))
                                                  (:padchar params)))
                               signed-str)
                          signed-str)]
         (print padded-str))
-      (format-ascii print-str {:mincol (:mincol params) :colinc 1 :minpad 0 
-                               :padchar (:padchar params) :at true} 
+      (format-ascii print-str {:mincol (:mincol params) :colinc 1 :minpad 0
+                               :padchar (:padchar params) :at true}
                     (init-navigator [arg]) nil))
     arg-navigator))
 
@@ -287,37 +287,37 @@ for improved performance"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:private true}
-     english-cardinal-units 
-     ["zero" "one" "two" "three" "four" "five" "six" "seven" "eight" "nine"
-      "ten" "eleven" "twelve" "thirteen" "fourteen"
-      "fifteen" "sixteen" "seventeen" "eighteen" "nineteen"])
+  english-cardinal-units
+  ["zero" "one" "two" "three" "four" "five" "six" "seven" "eight" "nine"
+   "ten" "eleven" "twelve" "thirteen" "fourteen"
+   "fifteen" "sixteen" "seventeen" "eighteen" "nineteen"])
 
 (def ^{:private true}
-     english-ordinal-units 
-     ["zeroth" "first" "second" "third" "fourth" "fifth" "sixth" "seventh" "eighth" "ninth"
-      "tenth" "eleventh" "twelfth" "thirteenth" "fourteenth"
-      "fifteenth" "sixteenth" "seventeenth" "eighteenth" "nineteenth"])
+  english-ordinal-units
+  ["zeroth" "first" "second" "third" "fourth" "fifth" "sixth" "seventh" "eighth" "ninth"
+   "tenth" "eleventh" "twelfth" "thirteenth" "fourteenth"
+   "fifteenth" "sixteenth" "seventeenth" "eighteenth" "nineteenth"])
 
 (def ^{:private true}
-     english-cardinal-tens
-     ["" "" "twenty" "thirty" "forty" "fifty" "sixty" "seventy" "eighty" "ninety"])
+  english-cardinal-tens
+  ["" "" "twenty" "thirty" "forty" "fifty" "sixty" "seventy" "eighty" "ninety"])
 
 (def ^{:private true}
-     english-ordinal-tens
-     ["" "" "twentieth" "thirtieth" "fortieth" "fiftieth"
-      "sixtieth" "seventieth" "eightieth" "ninetieth"])
+  english-ordinal-tens
+  ["" "" "twentieth" "thirtieth" "fortieth" "fiftieth"
+   "sixtieth" "seventieth" "eightieth" "ninetieth"])
 
 ;; We use "short scale" for our units (see http://en.wikipedia.org/wiki/Long_and_short_scales)
 ;; Number names from http://www.jimloy.com/math/billion.htm
 ;; We follow the rules for writing numbers from the Blue Book
 ;; (http://www.grammarbook.com/numbers/numbers.asp)
 (def ^{:private true}
-     english-scale-numbers 
-     ["" "thousand" "million" "billion" "trillion" "quadrillion" "quintillion" 
-      "sextillion" "septillion" "octillion" "nonillion" "decillion" 
-      "undecillion" "duodecillion" "tredecillion" "quattuordecillion" 
-      "quindecillion" "sexdecillion" "septendecillion" 
-      "octodecillion" "novemdecillion" "vigintillion"])
+  english-scale-numbers
+  ["" "thousand" "million" "billion" "trillion" "quadrillion" "quintillion"
+   "sextillion" "septillion" "octillion" "nonillion" "decillion"
+   "undecillion" "duodecillion" "tredecillion" "quattuordecillion"
+   "quindecillion" "sexdecillion" "septendecillion"
+   "octodecillion" "novemdecillion" "vigintillion"])
 
 (defn- format-simple-cardinal
   "Convert a number less than 1000 to a cardinal english string"
@@ -327,8 +327,8 @@ for improved performance"
     (str
      (if (pos? hundreds) (str (nth english-cardinal-units hundreds) " hundred"))
      (if (and (pos? hundreds) (pos? tens)) " ")
-     (if (pos? tens) 
-       (if (< tens 20) 
+     (if (pos? tens)
+       (if (< tens 20)
          (nth english-cardinal-units tens)
          (let [ten-digit (quot tens 10)
                unit-digit (rem tens 10)]
@@ -352,7 +352,7 @@ offset is a factor of 10^3 to multiply by"
              this
              (if (and (not (empty? this)) (pos? (+ pos offset)))
                (str " " (nth english-scale-numbers (+ pos offset)))))
-        (recur 
+        (recur
          (if (empty? this)
            acc
            (conj acc (str this " " (nth english-scale-numbers (+ pos offset)))))
@@ -372,9 +372,9 @@ offset is a factor of 10^3 to multiply by"
             (print (str (if (neg? arg) "minus ") full-str)))
           (format-integer ;; for numbers > 10^63, we fall back on ~D
            10
-           { :mincol 0, :padchar \space, :commachar \, :commainterval 3, :colon true}
+           {:mincol 0, :padchar \space, :commachar \, :commainterval 3, :colon true}
            (init-navigator [arg])
-           { :mincol 0, :padchar 0, :commachar 0 :commainterval 0}))))
+           {:mincol 0, :padchar 0, :commachar 0 :commainterval 0}))))
     navigator))
 
 (defn- format-simple-ordinal
@@ -386,8 +386,8 @@ Note this should only be used for the last one in the sequence"
     (str
      (if (pos? hundreds) (str (nth english-cardinal-units hundreds) " hundred"))
      (if (and (pos? hundreds) (pos? tens)) " ")
-     (if (pos? tens) 
-       (if (< tens 20) 
+     (if (pos? tens)
+       (if (< tens 20)
          (nth english-ordinal-units tens)
          (let [ten-digit (quot tens 10)
                unit-digit (rem tens 10)]
@@ -409,46 +409,45 @@ Note this should only be used for the last one in the sequence"
           (let [parts-strs (map format-simple-cardinal (drop-last parts))
                 head-str (add-english-scales parts-strs 1)
                 tail-str (format-simple-ordinal (last parts))]
-            (print (str (if (neg? arg) "minus ") 
-                        (cond 
-                         (and (not (empty? head-str)) (not (empty? tail-str))) 
-                         (str head-str ", " tail-str)
-                         
-                         (not (empty? head-str)) (str head-str "th")
-                         :else tail-str))))
+            (print (str (if (neg? arg) "minus ")
+                        (cond
+                          (and (not (empty? head-str)) (not (empty? tail-str)))
+                          (str head-str ", " tail-str)
+
+                          (not (empty? head-str)) (str head-str "th")
+                          :else tail-str))))
           (do (format-integer ;; for numbers > 10^63, we fall back on ~D
                10
-               { :mincol 0, :padchar \space, :commachar \, :commainterval 3, :colon true}
+               {:mincol 0, :padchar \space, :commachar \, :commainterval 3, :colon true}
                (init-navigator [arg])
-               { :mincol 0, :padchar 0, :commachar 0 :commainterval 0})
+               {:mincol 0, :padchar 0, :commachar 0 :commainterval 0})
               (let [low-two-digits (rem arg 100)
                     not-teens (or (< 11 low-two-digits) (> 19 low-two-digits))
                     low-digit (rem low-two-digits 10)]
-                (print (cond 
-                        (and (== low-digit 1) not-teens) "st"
-                        (and (== low-digit 2) not-teens) "nd"
-                        (and (== low-digit 3) not-teens) "rd"
-                        :else "th")))))))
+                (print (cond
+                         (and (== low-digit 1) not-teens) "st"
+                         (and (== low-digit 2) not-teens) "nd"
+                         (and (== low-digit 3) not-teens) "rd"
+                         :else "th")))))))
     navigator))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Support for roman numeral formats (~@R and ~@:R)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:private true}
-     old-roman-table
-     [[ "I" "II" "III" "IIII" "V" "VI" "VII" "VIII" "VIIII"]
-      [ "X" "XX" "XXX" "XXXX" "L" "LX" "LXX" "LXXX" "LXXXX"]
-      [ "C" "CC" "CCC" "CCCC" "D" "DC" "DCC" "DCCC" "DCCCC"]
-      [ "M" "MM" "MMM"]])
+  old-roman-table
+  [["I" "II" "III" "IIII" "V" "VI" "VII" "VIII" "VIIII"]
+   ["X" "XX" "XXX" "XXXX" "L" "LX" "LXX" "LXXX" "LXXXX"]
+   ["C" "CC" "CCC" "CCCC" "D" "DC" "DCC" "DCCC" "DCCCC"]
+   ["M" "MM" "MMM"]])
 
 (def ^{:private true}
-     new-roman-table
-     [[ "I" "II" "III" "IV" "V" "VI" "VII" "VIII" "IX"]
-      [ "X" "XX" "XXX" "XL" "L" "LX" "LXX" "LXXX" "XC"]
-      [ "C" "CC" "CCC" "CD" "D" "DC" "DCC" "DCCC" "CM"]
-      [ "M" "MM" "MMM"]])
+  new-roman-table
+  [["I" "II" "III" "IV" "V" "VI" "VII" "VIII" "IX"]
+   ["X" "XX" "XXX" "XL" "L" "LX" "LXX" "LXXX" "XC"]
+   ["C" "CC" "CCC" "CD" "D" "DC" "DCC" "DCCC" "CM"]
+   ["M" "MM" "MMM"]])
 
 (defn- format-roman
   "Format a roman numeral using the specified look-up table"
@@ -462,16 +461,16 @@ Note this should only be used for the last one in the sequence"
           (if (empty? digits)
             (print (apply str acc))
             (let [digit (first digits)]
-              (recur (if (= 0 digit) 
-                       acc 
+              (recur (if (= 0 digit)
+                       acc
                        (conj acc (nth (nth table pos) (dec digit))))
                      (dec pos)
                      (next digits))))))
       (format-integer ;; for anything <= 0 or > 3999, we fall back on ~D
-           10
-           { :mincol 0, :padchar \space, :commachar \, :commainterval 3, :colon true}
-           (init-navigator [arg])
-           { :mincol 0, :padchar 0, :commachar 0 :commainterval 0}))
+       10
+       {:mincol 0, :padchar \space, :commachar \, :commainterval 3, :colon true}
+       (init-navigator [arg])
+       {:mincol 0, :padchar 0, :commachar 0 :commainterval 0}))
     navigator))
 
 (defn- format-old-roman [params navigator offsets]
@@ -484,8 +483,8 @@ Note this should only be used for the last one in the sequence"
 ;;; Support for character formats (~C)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def ^{:private true} 
-     special-chars { 8 "Backspace", 9 "Tab",  10 "Newline", 13 "Return", 32 "Space"})
+(def ^{:private true}
+  special-chars {8 "Backspace", 9 "Tab",  10 "Newline", 13 "Return", 32 "Space"})
 
 (defn- pretty-character [params navigator offsets]
   (let [[c navigator] (next-arg navigator)
@@ -495,10 +494,10 @@ Note this should only be used for the last one in the sequence"
         special (get special-chars base-char)]
     (if (> meta 0) (print "Meta-"))
     (print (cond
-            special special
-            (< base-char 32) (str "Control-" (char (+ base-char 64)))
-            (= base-char 127) "Control-?"
-            :else (char base-char)))
+             special special
+             (< base-char 32) (str "Control-" (char (+ base-char 64)))
+             (= base-char 127) "Control-?"
+             :else (char base-char)))
     navigator))
 
 (defn- readable-character [params navigator offsets]
@@ -523,7 +522,7 @@ Note this should only be used for the last one in the sequence"
 ;; Handle the execution of "sub-clauses" in bracket constructions
 (defn- execute-sub-format [format args base-args]
   (second
-   (map-passing-context 
+   (map-passing-context
     (fn [element context]
       (if (abort? context)
         [nil context] ; just keep passing it along
@@ -553,7 +552,6 @@ Note this should only be used for the last one in the sequence"
         [(subs s 0 exploc) (subs s (inc exploc))]
         [(str (subs s 0 1) (subs s 2 exploc)) (subs s (inc exploc))]))))
 
-
 (defn- float-parts
   "Take care of leading and trailing zeros in decomposed floats"
   [f]
@@ -576,11 +574,11 @@ string, or one character longer."
   (let [len-1 (dec (count s))]
     (loop [i (int len-1)]
       (cond
-       (neg? i) (apply str "1" (repeat (inc len-1) "0"))
-       (= \9 (.charAt s i)) (recur (dec i))
-       :else (apply str (subs s 0 i)
-                    (char (inc (int (.charAt s i))))
-                    (repeat (- len-1 i) "0"))))))
+        (neg? i) (apply str "1" (repeat (inc len-1) "0"))
+        (= \9 (.charAt s i)) (recur (dec i))
+        :else (apply str (subs s 0 i)
+                     (char (inc (int (.charAt s i))))
+                     (repeat (- len-1 i) "0"))))))
 
 (defn- round-str [m e d w]
   (if (or d w)
@@ -592,7 +590,7 @@ string, or one character longer."
                      ;; If d was given, that forces the rounding
                      ;; position, regardless of any width that may
                      ;; have been specified.
-                     d (+ e d 1)
+                      d (+ e d 1)
                      ;; Otherwise w was specified, so pick round-pos
                      ;; based upon that.
                      ;; If e>=0, then abs value of number is >= 1.0,
@@ -600,10 +598,10 @@ string, or one character longer."
                      ;; decimal point when the number is written
                      ;; without scientific notation.  Never round the
                      ;; number before the decimal point.
-                     (>= e 0) (max (inc e) (dec w))
+                      (>= e 0) (max (inc e) (dec w))
                      ;; e < 0, so number abs value < 1.0
-                     :else (+ w e))
-          [m1 e1 round-pos len] (if (= round-pos 0) 
+                      :else (+ w e))
+          [m1 e1 round-pos len] (if (= round-pos 0)
                                   [(str "0" m) (inc e) 1 (inc len)]
                                   [m e round-pos len])]
       (if round-pos
@@ -630,8 +628,8 @@ string, or one character longer."
                   [m e])
         len (count m1)
         target-len (if d (+ e1 d 1) (inc e1))]
-    (if (< len target-len) 
-      (str m1 (apply str (repeat (- target-len len) \0))) 
+    (if (< len target-len)
+      (str m1 (apply str (repeat (- target-len len) \0)))
       m1)))
 
 (defn- insert-decimal
@@ -679,7 +677,7 @@ string, or one character longer."
         scaled-exp (+ exp (:k params))
         add-sign (or (:at params) (neg? arg))
         append-zero (and (not d) (<= (dec (count mantissa)) scaled-exp))
-        [rounded-mantissa scaled-exp expanded] (round-str mantissa scaled-exp 
+        [rounded-mantissa scaled-exp expanded] (round-str mantissa scaled-exp
                                                           d (if w (- w (if add-sign 1 0))))
         ^String fixed-repr (get-fixed rounded-mantissa (if expanded (inc scaled-exp) scaled-exp) d)
         fixed-repr (if (and w d
@@ -696,23 +694,22 @@ string, or one character longer."
             prepend-zero (and prepend-zero (not (>= signed-len w)))
             append-zero (and append-zero (not (>= signed-len w)))
             full-len (if (or prepend-zero append-zero)
-                       (inc signed-len) 
+                       (inc signed-len)
                        signed-len)]
         (if (and (> full-len w) (:overflowchar params))
           (print (apply str (repeat w (:overflowchar params))))
           (print (str
                   (apply str (repeat (- w full-len) (:padchar params)))
-                  (if add-sign sign) 
+                  (if add-sign sign)
                   (if prepend-zero "0")
                   fixed-repr
                   (if append-zero "0")))))
       (print (str
-              (if add-sign sign) 
+              (if add-sign sign)
               (if prepend-zero "0")
               fixed-repr
               (if append-zero "0"))))
     navigator))
-
 
 ;; the function to render ~E directives
 ;; TODO: support rationals. Back off to ~D/~A is the appropriate cases
@@ -730,30 +727,30 @@ string, or one character longer."
             prepend-zero (<= k 0)
             ^Integer scaled-exp (- exp (dec k))
             scaled-exp-str (str (Math/abs scaled-exp))
-            scaled-exp-str (str expchar (if (neg? scaled-exp) \- \+) 
-                                (if e (apply str 
-                                             (repeat 
-                                              (- e 
-                                                 (count scaled-exp-str)) 
-                                              \0))) 
+            scaled-exp-str (str expchar (if (neg? scaled-exp) \- \+)
+                                (if e (apply str
+                                             (repeat
+                                              (- e
+                                                 (count scaled-exp-str))
+                                              \0)))
                                 scaled-exp-str)
             exp-width (count scaled-exp-str)
             base-mantissa-width (count mantissa)
             scaled-mantissa (str (apply str (repeat (- k) \0))
                                  mantissa
-                                 (if d 
-                                   (apply str 
-                                          (repeat 
+                                 (if d
+                                   (apply str
+                                          (repeat
                                            (- d (dec base-mantissa-width)
                                               (if (neg? k) (- k) 0)) \0))))
             w-mantissa (if w (- w exp-width))
-            [rounded-mantissa _ incr-exp] (round-str 
+            [rounded-mantissa _ incr-exp] (round-str
                                            scaled-mantissa 0
                                            (cond
-                                            (= k 0) (dec d)
-                                            (pos? k) d
-                                            (neg? k) (dec d))
-                                           (if w-mantissa 
+                                             (= k 0) (dec d)
+                                             (pos? k) d
+                                             (neg? k) (dec d))
+                                           (if w-mantissa
                                              (- w-mantissa (if add-sign 1 0))))
             full-mantissa (insert-scaled-decimal rounded-mantissa k)
             append-zero (and (= k (count rounded-mantissa)) (nil? d))]
@@ -768,17 +765,17 @@ string, or one character longer."
                        (:overflowchar params))
                 (print (apply str (repeat w (:overflowchar params))))
                 (print (str
-                        (apply str 
-                               (repeat 
-                                (- w full-len (if append-zero 1 0) )
+                        (apply str
+                               (repeat
+                                (- w full-len (if append-zero 1 0))
                                 (:padchar params)))
-                        (if add-sign (if (neg? arg) \- \+)) 
+                        (if add-sign (if (neg? arg) \- \+))
                         (if prepend-zero "0")
                         full-mantissa
                         (if append-zero "0")
                         scaled-exp-str))))
             (print (str
-                    (if add-sign (if (neg? arg) \- \+)) 
+                    (if add-sign (if (neg? arg) \- \+))
                     (if prepend-zero "0")
                     full-mantissa
                     (if append-zero "0")
@@ -787,7 +784,7 @@ string, or one character longer."
     navigator))
 
 ;; the function to render ~G directives
-;; This just figures out whether to pass the request off to ~F or ~E based 
+;; This just figures out whether to pass the request off to ~F or ~E based
 ;; on the algorithm in CLtL.
 ;; TODO: support rationals. Back off to ~D/~A is the appropriate cases
 ;; TODO: refactor so that float-parts isn't called twice
@@ -804,9 +801,9 @@ string, or one character longer."
         d (if d d (max (count mantissa) (min n 7)))
         dd (- d n)]
     (if (<= 0 dd d)
-      (let [navigator (fixed-float {:w ww, :d dd, :k 0, 
+      (let [navigator (fixed-float {:w ww, :d dd, :k 0,
                                     :overflowchar (:overflowchar params),
-                                    :padchar (:padchar params), :at (:at params)} 
+                                    :padchar (:padchar params), :at (:at params)}
                                    navigator offsets)]
         (print (apply str (repeat ee \space)))
         navigator)
@@ -831,13 +828,13 @@ string, or one character longer."
             (if (and (not (:colon params)) add-sign) (if (neg? arg) \- \+))
             full-repr))
     navigator))
-        
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Support for the '~[...~]' conditional construct in its
 ;;; different flavors
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; ~[...~] without any modifiers chooses one of the clauses based on the param or 
+;; ~[...~] without any modifiers chooses one of the clauses based on the param or
 ;; next argument
 ;; TODO check arg is positive int
 (defn- choice-conditional [params arg-navigator offsets]
@@ -874,21 +871,20 @@ string, or one character longer."
         arg-navigator)
       navigator)))
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Support for the '~{...~}' iteration construct in its
 ;;; different flavors
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-;; ~{...~} without any modifiers uses the next argument as an argument list that 
+;; ~{...~} without any modifiers uses the next argument as an argument list that
 ;; is consumed by all the iterations
 (defn- iterate-sublist [params navigator offsets]
   (let [max-count (:max-iterations params)
         param-clause (first (:clauses params))
-        [clause navigator] (if (empty? param-clause) 
+        [clause navigator] (if (empty? param-clause)
                              (get-format-arg navigator)
-                             [param-clause navigator]) 
+                             [param-clause navigator])
         [arg-list navigator] (next-arg navigator)
         args (init-navigator arg-list)]
     (loop [count 0
@@ -901,7 +897,7 @@ string, or one character longer."
                    (or (not (:colon (:right-params params))) (> count 0)))
               (and max-count (>= count max-count)))
         navigator
-        (let [iter-result (execute-sub-format clause args (:base-args params))] 
+        (let [iter-result (execute-sub-format clause args (:base-args params))]
           (if (= :up-arrow (first iter-result))
             navigator
             (recur (inc count) iter-result (:pos args))))))))
@@ -911,9 +907,9 @@ string, or one character longer."
 (defn- iterate-list-of-sublists [params navigator offsets]
   (let [max-count (:max-iterations params)
         param-clause (first (:clauses params))
-        [clause navigator] (if (empty? param-clause) 
+        [clause navigator] (if (empty? param-clause)
                              (get-format-arg navigator)
-                             [param-clause navigator]) 
+                             [param-clause navigator])
         [arg-list navigator] (next-arg navigator)]
     (loop [count 0
            arg-list arg-list]
@@ -921,8 +917,8 @@ string, or one character longer."
                    (or (not (:colon (:right-params params))) (> count 0)))
               (and max-count (>= count max-count)))
         navigator
-        (let [iter-result (execute-sub-format 
-                           clause 
+        (let [iter-result (execute-sub-format
+                           clause
                            (init-navigator (first arg-list))
                            (init-navigator (next arg-list)))]
           (if (= :colon-up-arrow (first iter-result))
@@ -934,7 +930,7 @@ string, or one character longer."
 (defn- iterate-main-list [params navigator offsets]
   (let [max-count (:max-iterations params)
         param-clause (first (:clauses params))
-        [clause navigator] (if (empty? param-clause) 
+        [clause navigator] (if (empty? param-clause)
                              (get-format-arg navigator)
                              [param-clause navigator])]
     (loop [count 0
@@ -947,10 +943,10 @@ string, or one character longer."
                    (or (not (:colon (:right-params params))) (> count 0)))
               (and max-count (>= count max-count)))
         navigator
-        (let [iter-result (execute-sub-format clause navigator (:base-args params))] 
+        (let [iter-result (execute-sub-format clause navigator (:base-args params))]
           (if (= :up-arrow (first iter-result))
             (second iter-result)
-            (recur 
+            (recur
              (inc count) iter-result (:pos navigator))))))))
 
 ;; ~@:{...~} with both colon and at sign uses the main argument list as a set of sublists, one
@@ -958,10 +954,9 @@ string, or one character longer."
 (defn- iterate-main-sublists [params navigator offsets]
   (let [max-count (:max-iterations params)
         param-clause (first (:clauses params))
-        [clause navigator] (if (empty? param-clause) 
+        [clause navigator] (if (empty? param-clause)
                              (get-format-arg navigator)
-                             [param-clause navigator]) 
-        ]
+                             [param-clause navigator])]
     (loop [count 0
            navigator navigator]
       (if (or (and (empty? (:rest navigator))
@@ -979,11 +974,11 @@ string, or one character longer."
 ;;; in the '~<...~>' form it does justification, but with
 ;;; ~<...~:>' it represents the logical block operation of the
 ;;; pretty printer.
-;;; 
+;;;
 ;;; Unfortunately, the current architecture decides what function
 ;;; to call at form parsing time before the sub-clauses have been
 ;;; folded, so it is left to run-time to make the decision.
-;;; 
+;;;
 ;;; TODO: make it possible to make these decisions at compile-time.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1007,7 +1002,7 @@ string, or one character longer."
       [acc navigator]
       (let [clause (first clauses)
             [iter-result result-str] (binding [*out* (java.io.StringWriter.)]
-                                       [(execute-sub-format clause navigator base-navigator) 
+                                       [(execute-sub-format clause navigator base-navigator)
                                         (.toString *out*)])]
         (if (= :up-arrow (first iter-result))
           [acc (second iter-result)]
@@ -1033,7 +1028,7 @@ string, or one character longer."
         minpad (:minpad params)
         colinc (:colinc params)
         minout (+ chars (* slots minpad))
-        result-columns (if (<= minout mincol) 
+        result-columns (if (<= minout mincol)
                          mincol
                          (+ mincol (* colinc
                                       (+ 1 (quot (- minout mincol 1) colinc)))))
@@ -1041,7 +1036,7 @@ string, or one character longer."
         pad (max minpad (quot total-pad slots))
         extra-pad (- total-pad (* pad slots))
         pad-str (apply str (repeat pad (:padchar params)))]
-    (if (and eol-str (> (+ (get-column (:base @@*out*)) min-remaining result-columns) 
+    (if (and eol-str (> (+ (get-column (:base @@*out*)) min-remaining result-columns)
                         max-columns))
       (print eol-str))
     (loop [slots slots
@@ -1054,7 +1049,7 @@ string, or one character longer."
           (print (str (if (not pad-only) (first strs))
                       (if (or pad-only (next strs) (:at params)) pad-str)
                       (if (pos? extra-pad) (:padchar params))))
-          (recur 
+          (recur
            (dec slots)
            (dec extra-pad)
            (if pad-only strs (next strs))
@@ -1069,51 +1064,51 @@ string, or one character longer."
 ;;; that may block.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- downcase-writer 
+(defn- downcase-writer
   "Returns a proxy that wraps writer, converting all characters to lower case"
   [^java.io.Writer writer]
   (proxy [java.io.Writer] []
     (close [] (.close writer))
     (flush [] (.flush writer))
-    (write ([^chars cbuf ^Integer off ^Integer len] 
-              (.write writer cbuf off len))
-           ([x]
-              (condp = (class x)
-		String 
-		(let [s ^String x]
-		  (.write writer (.toLowerCase s)))
+    (write ([^chars cbuf ^Integer off ^Integer len]
+            (.write writer cbuf off len))
+      ([x]
+       (condp = (class x)
+         String
+         (let [s ^String x]
+           (.write writer (.toLowerCase s)))
 
-		Integer
-		(let [c ^Character x]
-		  (.write writer (int (Character/toLowerCase (char c))))))))))
+         Integer
+         (let [c ^Character x]
+           (.write writer (int (Character/toLowerCase (char c))))))))))
 
-(defn- upcase-writer 
+(defn- upcase-writer
   "Returns a proxy that wraps writer, converting all characters to upper case"
   [^java.io.Writer writer]
   (proxy [java.io.Writer] []
     (close [] (.close writer))
     (flush [] (.flush writer))
-    (write ([^chars cbuf ^Integer off ^Integer len] 
-              (.write writer cbuf off len))
-           ([x]
-              (condp = (class x)
-		String 
-		(let [s ^String x]
-		  (.write writer (.toUpperCase s)))
+    (write ([^chars cbuf ^Integer off ^Integer len]
+            (.write writer cbuf off len))
+      ([x]
+       (condp = (class x)
+         String
+         (let [s ^String x]
+           (.write writer (.toUpperCase s)))
 
-		Integer
-		(let [c ^Character x]
-		  (.write writer (int (Character/toUpperCase (char c))))))))))
+         Integer
+         (let [c ^Character x]
+           (.write writer (int (Character/toUpperCase (char c))))))))))
 
 (defn- capitalize-string
-  "Capitalizes the words in a string. If first? is false, don't capitalize the 
+  "Capitalizes the words in a string. If first? is false, don't capitalize the
                                       first character of the string even if it's a letter."
   [s first?]
-  (let [^Character f (first s) 
+  (let [^Character f (first s)
         s (if (and first? f (Character/isLetter f))
             (str (Character/toUpperCase f) (subs s 1))
             s)]
-    (apply str 
+    (apply str
            (first
             (consume
              (fn [s]
@@ -1123,7 +1118,7 @@ string, or one character longer."
                        match (re-find m)
                        offset (and match (inc (.start m)))]
                    (if offset
-                     [(str (subs s 0 offset) 
+                     [(str (subs s 0 offset)
                            (Character/toUpperCase ^Character (nth s offset)))
                       (subs s (inc offset))]
                      [s nil]))))
@@ -1132,81 +1127,81 @@ string, or one character longer."
 (defn- capitalize-word-writer
   "Returns a proxy that wraps writer, capitalizing all words"
   [^java.io.Writer writer]
-  (let [last-was-whitespace? (ref true)] 
+  (let [last-was-whitespace? (ref true)]
     (proxy [java.io.Writer] []
       (close [] (.close writer))
       (flush [] (.flush writer))
-      (write 
-       ([^chars cbuf ^Integer off ^Integer len] 
-          (.write writer cbuf off len))
-       ([x]
-          (condp = (class x)
-            String 
-            (let [s ^String x]
-              (.write writer 
-                      ^String (capitalize-string (.toLowerCase s) @last-was-whitespace?))
-              (when (pos? (.length s))
-                (dosync 
-                 (ref-set last-was-whitespace? 
-                          (Character/isWhitespace 
-                           ^Character (nth s (dec (count s))))))))
+      (write
+        ([^chars cbuf ^Integer off ^Integer len]
+         (.write writer cbuf off len))
+        ([x]
+         (condp = (class x)
+           String
+           (let [s ^String x]
+             (.write writer
+                     ^String (capitalize-string (.toLowerCase s) @last-was-whitespace?))
+             (when (pos? (.length s))
+               (dosync
+                (ref-set last-was-whitespace?
+                         (Character/isWhitespace
+                          ^Character (nth s (dec (count s))))))))
 
-            Integer
-            (let [c (char x)]
-              (let [mod-c (if @last-was-whitespace? (Character/toUpperCase (char x)) c)]
-                (.write writer (int mod-c))
-                (dosync (ref-set last-was-whitespace? (Character/isWhitespace (char x))))))))))))
+           Integer
+           (let [c (char x)]
+             (let [mod-c (if @last-was-whitespace? (Character/toUpperCase (char x)) c)]
+               (.write writer (int mod-c))
+               (dosync (ref-set last-was-whitespace? (Character/isWhitespace (char x))))))))))))
 
 (defn- init-cap-writer
   "Returns a proxy that wraps writer, capitalizing the first word"
   [^java.io.Writer writer]
-  (let [capped (ref false)] 
+  (let [capped (ref false)]
     (proxy [java.io.Writer] []
       (close [] (.close writer))
       (flush [] (.flush writer))
-      (write ([^chars cbuf ^Integer off ^Integer len] 
-                (.write writer cbuf off len))
-             ([x]
-                (condp = (class x)
-                 String 
-                 (let [s (.toLowerCase ^String x)]
-                   (if (not @capped) 
-                     (let [m (re-matcher #"\S" s)
-                           match (re-find m)
-                           offset (and match (.start m))]
-                       (if offset
-                         (do (.write writer 
-                                   (str (subs s 0 offset) 
-                                        (Character/toUpperCase ^Character (nth s offset))
-                                        (.toLowerCase ^String (subs s (inc offset)))))
-                           (dosync (ref-set capped true)))
-                         (.write writer s))) 
-                     (.write writer (.toLowerCase s))))
+      (write ([^chars cbuf ^Integer off ^Integer len]
+              (.write writer cbuf off len))
+        ([x]
+         (condp = (class x)
+           String
+           (let [s (.toLowerCase ^String x)]
+             (if (not @capped)
+               (let [m (re-matcher #"\S" s)
+                     match (re-find m)
+                     offset (and match (.start m))]
+                 (if offset
+                   (do (.write writer
+                               (str (subs s 0 offset)
+                                    (Character/toUpperCase ^Character (nth s offset))
+                                    (.toLowerCase ^String (subs s (inc offset)))))
+                       (dosync (ref-set capped true)))
+                   (.write writer s)))
+               (.write writer (.toLowerCase s))))
 
-                 Integer
-                 (let [c ^Character (char x)]
-                   (if (and (not @capped) (Character/isLetter c))
-                     (do
-                       (dosync (ref-set capped true))
-                       (.write writer (int (Character/toUpperCase c))))
-                     (.write writer (int (Character/toLowerCase c)))))))))))
+           Integer
+           (let [c ^Character (char x)]
+             (if (and (not @capped) (Character/isLetter c))
+               (do
+                 (dosync (ref-set capped true))
+                 (.write writer (int (Character/toUpperCase c))))
+               (.write writer (int (Character/toLowerCase c)))))))))))
 
 (defn- modify-case [make-writer params navigator offsets]
   (let [clause (first (:clauses params))]
-    (binding [*out* (make-writer *out*)] 
+    (binding [*out* (make-writer *out*)]
       (execute-sub-format clause navigator (:base-args params)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; If necessary, wrap the writer in a PrettyWriter object
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn get-pretty-writer 
-  "Returns the java.io.Writer passed in wrapped in a pretty writer proxy, unless it's 
+(defn get-pretty-writer
+  "Returns the java.io.Writer passed in wrapped in a pretty writer proxy, unless it's
 already a pretty writer. Generally, it is unnecessary to call this function, since pprint,
-write, and cl-format all call it if they need to. However if you want the state to be 
-preserved across calls, you will want to wrap them with this. 
+write, and cl-format all call it if they need to. However if you want the state to be
+preserved across calls, you will want to wrap them with this.
 
-For example, when you want to generate column-aware output with multiple calls to cl-format, 
+For example, when you want to generate column-aware output with multiple calls to cl-format,
 do it like in this example:
 
     (defn print-table [aseq column-width]
@@ -1222,22 +1217,22 @@ Now when you run:
 
 It prints a table of squares and cubes for the numbers from 1 to 10:
 
-       1      1       1    
-       2      4       8    
-       3      9      27    
-       4     16      64    
-       5     25     125    
-       6     36     216    
-       7     49     343    
-       8     64     512    
-       9     81     729    
+       1      1       1
+       2      4       8
+       3      9      27
+       4     16      64
+       5     25     125
+       6     36     216
+       7     49     343
+       8     64     512
+       9     81     729
       10    100    1000"
   {:added "1.2"}
   [writer]
-  (if (pretty-writer? writer) 
+  (if (pretty-writer? writer)
     writer
     (pretty-writer writer *print-right-margin* *print-miser-width*)))
- 
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Support for column-aware operations ~&, ~T
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1253,25 +1248,24 @@ not a pretty writer (which keeps track of columns), this function always outputs
     (prn)))
 
 (defn- absolute-tabulation [params navigator offsets]
-  (let [colnum (:colnum params) 
+  (let [colnum (:colnum params)
         colinc (:colinc params)
         current (get-column (:base @@*out*))
         space-count (cond
-                     (< current colnum) (- colnum current)
-                     (= colinc 0) 0
-                     :else (- colinc (rem (- current colnum) colinc)))]
+                      (< current colnum) (- colnum current)
+                      (= colinc 0) 0
+                      :else (- colinc (rem (- current colnum) colinc)))]
     (print (apply str (repeat space-count \space))))
   navigator)
 
 (defn- relative-tabulation [params navigator offsets]
-  (let [colrel (:colnum params) 
+  (let [colrel (:colnum params)
         colinc (:colinc params)
         start-col (+ colrel (get-column (:base @@*out*)))
         offset (if (pos? colinc) (rem start-col colinc) 0)
         space-count (+ colrel (if (= 0 offset) 0 (- colinc offset)))]
     (print (apply str (repeat space-count \space))))
   navigator)
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Support for accessing the pretty printer from a format
@@ -1283,18 +1277,18 @@ not a pretty writer (which keeps track of columns), this function always outputs
   (let [clauses (:clauses params)
         clause-count (count clauses)
         prefix (cond
-                (> clause-count 1) (:string (:params (first (first clauses))))
-                (:colon params) "(")
+                 (> clause-count 1) (:string (:params (first (first clauses))))
+                 (:colon params) "(")
         body (nth clauses (if (> clause-count 1) 1 0))
         suffix (cond
-                (> clause-count 2) (:string (:params (first (nth clauses 2))))
-                (:colon params) ")")
+                 (> clause-count 2) (:string (:params (first (nth clauses 2))))
+                 (:colon params) ")")
         [arg navigator] (next-arg navigator)]
     (pprint-logical-block :prefix prefix :suffix suffix
-      (execute-sub-format 
-       body 
-       (init-navigator arg)
-       (:base-args params)))
+                          (execute-sub-format
+                           body
+                           (init-navigator arg)
+                           (:base-args params)))
     navigator))
 
 (defn- set-indent [params navigator offsets]
@@ -1305,7 +1299,7 @@ not a pretty writer (which keeps track of columns), this function always outputs
 ;;; TODO: support ~:T section options for ~T
 
 (defn- conditional-newline [params navigator offsets]
-  (let [kind (if (:colon params) 
+  (let [kind (if (:colon params)
                (if (:at params) :mandatory :fill)
                (if (:at params) :miser :linear))]
     (pprint-newline kind)
@@ -1317,59 +1311,59 @@ not a pretty writer (which keeps track of columns), this function always outputs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; We start with a couple of helpers
-(defn- process-directive-table-element [ [ char params flags bracket-info & generator-fn ] ]
-  [char, 
+(defn- process-directive-table-element [[char params flags bracket-info & generator-fn]]
+  [char,
    {:directive char,
     :params `(array-map ~@params),
     :flags flags,
     :bracket-info bracket-info,
-    :generator-fn (concat '(fn [ params offset]) generator-fn) }])
+    :generator-fn (concat '(fn [params offset]) generator-fn)}])
 
 (defmacro ^{:private true}
-  defdirectives 
-  [ & directives ]
+  defdirectives
+  [& directives]
   `(def ^{:private true}
-        directive-table (hash-map ~@(mapcat process-directive-table-element directives))))
+     directive-table (hash-map ~@(mapcat process-directive-table-element directives))))
 
-(defdirectives 
-  (\A 
-   [ :mincol [0 Integer] :colinc [1 Integer] :minpad [0 Integer] :padchar [\space Character] ] 
-   #{ :at :colon :both} {}
+(defdirectives
+  (\A
+   [:mincol [0 Integer] :colinc [1 Integer] :minpad [0 Integer] :padchar [\space Character]]
+   #{:at :colon :both} {}
    #(format-ascii print-str %1 %2 %3))
 
-  (\S 
-   [ :mincol [0 Integer] :colinc [1 Integer] :minpad [0 Integer] :padchar [\space Character] ] 
-   #{ :at :colon :both} {}
+  (\S
+   [:mincol [0 Integer] :colinc [1 Integer] :minpad [0 Integer] :padchar [\space Character]]
+   #{:at :colon :both} {}
    #(format-ascii pr-str %1 %2 %3))
 
   (\D
-   [ :mincol [0 Integer] :padchar [\space Character] :commachar [\, Character] 
-    :commainterval [ 3 Integer]]
-   #{ :at :colon :both } {}
+   [:mincol [0 Integer] :padchar [\space Character] :commachar [\, Character]
+    :commainterval [3 Integer]]
+   #{:at :colon :both} {}
    #(format-integer 10 %1 %2 %3))
 
   (\B
-   [ :mincol [0 Integer] :padchar [\space Character] :commachar [\, Character] 
-    :commainterval [ 3 Integer]]
-   #{ :at :colon :both } {}
+   [:mincol [0 Integer] :padchar [\space Character] :commachar [\, Character]
+    :commainterval [3 Integer]]
+   #{:at :colon :both} {}
    #(format-integer 2 %1 %2 %3))
 
   (\O
-   [ :mincol [0 Integer] :padchar [\space Character] :commachar [\, Character] 
-    :commainterval [ 3 Integer]]
-   #{ :at :colon :both } {}
+   [:mincol [0 Integer] :padchar [\space Character] :commachar [\, Character]
+    :commainterval [3 Integer]]
+   #{:at :colon :both} {}
    #(format-integer 8 %1 %2 %3))
 
   (\X
-   [ :mincol [0 Integer] :padchar [\space Character] :commachar [\, Character] 
-    :commainterval [ 3 Integer]]
-   #{ :at :colon :both } {}
+   [:mincol [0 Integer] :padchar [\space Character] :commachar [\, Character]
+    :commainterval [3 Integer]]
+   #{:at :colon :both} {}
    #(format-integer 16 %1 %2 %3))
 
   (\R
-   [:base [nil Integer] :mincol [0 Integer] :padchar [\space Character] :commachar [\, Character] 
-    :commainterval [ 3 Integer]]
-   #{ :at :colon :both } {}
+   [:base [nil Integer] :mincol [0 Integer] :padchar [\space Character] :commachar [\, Character]
+    :commainterval [3 Integer]]
+   #{:at :colon :both} {}
    (do
      (cond                          ; ~R is overloaded with bizareness
        (first (:base params))     #(format-integer (:base %1) %1 %2 %3)
@@ -1379,8 +1373,8 @@ not a pretty writer (which keeps track of columns), this function always outputs
        true                       #(format-cardinal-english %1 %2 %3))))
 
   (\P
-   [ ]
-   #{ :at :colon :both } {}
+   []
+   #{:at :colon :both} {}
    (fn [params navigator offsets]
      (let [navigator (if (:colon params) (relative-reposition navigator -1) navigator)
            strs (if (:at params) ["y" "ies"] ["" "s"])
@@ -1390,48 +1384,48 @@ not a pretty writer (which keeps track of columns), this function always outputs
 
   (\C
    [:char-format [nil Character]]
-   #{ :at :colon :both } {}
+   #{:at :colon :both} {}
    (cond
      (:colon params) pretty-character
      (:at params) readable-character
      :else plain-character))
 
   (\F
-   [ :w [nil Integer] :d [nil Integer] :k [0 Integer] :overflowchar [nil Character] 
-    :padchar [\space Character] ]
-   #{ :at } {}
+   [:w [nil Integer] :d [nil Integer] :k [0 Integer] :overflowchar [nil Character]
+    :padchar [\space Character]]
+   #{:at} {}
    fixed-float)
 
   (\E
-   [ :w [nil Integer] :d [nil Integer] :e [nil Integer] :k [1 Integer] 
-    :overflowchar [nil Character] :padchar [\space Character] 
-    :exponentchar [nil Character] ]
-   #{ :at } {}
+   [:w [nil Integer] :d [nil Integer] :e [nil Integer] :k [1 Integer]
+    :overflowchar [nil Character] :padchar [\space Character]
+    :exponentchar [nil Character]]
+   #{:at} {}
    exponential-float)
 
   (\G
-   [ :w [nil Integer] :d [nil Integer] :e [nil Integer] :k [1 Integer] 
-    :overflowchar [nil Character] :padchar [\space Character] 
-    :exponentchar [nil Character] ]
-   #{ :at } {}
+   [:w [nil Integer] :d [nil Integer] :e [nil Integer] :k [1 Integer]
+    :overflowchar [nil Character] :padchar [\space Character]
+    :exponentchar [nil Character]]
+   #{:at} {}
    general-float)
 
   (\$
-   [ :d [2 Integer] :n [1 Integer] :w [0 Integer] :padchar [\space Character]]
-   #{ :at :colon :both} {}
+   [:d [2 Integer] :n [1 Integer] :w [0 Integer] :padchar [\space Character]]
+   #{:at :colon :both} {}
    dollar-float)
 
-  (\% 
-   [ :count [1 Integer] ] 
-   #{ } {}
+  (\%
+   [:count [1 Integer]]
+   #{} {}
    (fn [params arg-navigator offsets]
      (dotimes [i (:count params)]
        (prn))
      arg-navigator))
 
   (\&
-   [ :count [1 Integer] ] 
-   #{ :pretty } {}
+   [:count [1 Integer]]
+   #{:pretty} {}
    (fn [params arg-navigator offsets]
      (let [cnt (:count params)]
        (if (pos? cnt) (fresh-line))
@@ -1439,24 +1433,24 @@ not a pretty writer (which keeps track of columns), this function always outputs
          (prn)))
      arg-navigator))
 
-  (\| 
-   [ :count [1 Integer] ] 
-   #{ } {}
+  (\|
+   [:count [1 Integer]]
+   #{} {}
    (fn [params arg-navigator offsets]
      (dotimes [i (:count params)]
        (print \formfeed))
      arg-navigator))
 
-  (\~ 
-   [ :n [1 Integer] ] 
-   #{ } {}
+  (\~
+   [:n [1 Integer]]
+   #{} {}
    (fn [params arg-navigator offsets]
      (let [n (:n params)]
        (print (apply str (repeat n \~)))
        arg-navigator)))
 
   (\newline ;; Whitespace supression is handled in the compilation loop
-   [ ] 
+   []
    #{:colon :at} {}
    (fn [params arg-navigator offsets]
      (if (:at params)
@@ -1464,15 +1458,15 @@ not a pretty writer (which keeps track of columns), this function always outputs
      arg-navigator))
 
   (\T
-   [ :colnum [1 Integer] :colinc [1 Integer] ] 
-   #{ :at :pretty } {}
+   [:colnum [1 Integer] :colinc [1 Integer]]
+   #{:at :pretty} {}
    (if (:at params)
      #(relative-tabulation %1 %2 %3)
      #(absolute-tabulation %1 %2 %3)))
 
-  (\* 
-   [ :n [nil Integer] ] 
-   #{ :colon :at } {}
+  (\*
+   [:n [nil Integer]]
+   #{:colon :at} {}
    (if (:at params)
      (fn [params navigator offsets]
        (let [n (or (:n params) 0)] ; ~@* has a default n = 0
@@ -1481,9 +1475,9 @@ not a pretty writer (which keeps track of columns), this function always outputs
        (let [n (or (:n params) 1)] ; whereas ~* and ~:* have a default n = 1
          (relative-reposition navigator (if (:colon params) (- n) n))))))
 
-  (\? 
-   [ ] 
-   #{ :at } {}
+  (\?
+   []
+   #{:at} {}
    (if (:at params)
      (fn [params navigator offsets]     ; args from main arg list
        (let [[subformat navigator] (get-format-arg navigator)]
@@ -1494,11 +1488,10 @@ not a pretty writer (which keeps track of columns), this function always outputs
              sub-navigator (init-navigator subargs)]
          (execute-sub-format subformat sub-navigator (:base-args params))
          navigator))))
-       
 
   (\(
-   [ ]
-   #{ :colon :at :both} { :right \), :allows-separator nil, :else nil }
+   []
+   #{:colon :at :both} {:right \), :allows-separator nil, :else nil}
    (let [mod-case-writer (cond
                            (and (:at params) (:colon params))
                            upcase-writer
@@ -1513,11 +1506,11 @@ not a pretty writer (which keeps track of columns), this function always outputs
                            downcase-writer)]
      #(modify-case mod-case-writer %1 %2 %3)))
 
-  (\) [] #{} {} nil) 
+  (\) [] #{} {} nil)
 
   (\[
-   [ :selector [nil Integer] ]
-   #{ :colon :at } { :right \], :allows-separator true, :else :last }
+   [:selector [nil Integer]]
+   #{:colon :at} {:right \], :allows-separator true, :else :last}
    (cond
      (:colon params)
      boolean-conditional
@@ -1528,14 +1521,14 @@ not a pretty writer (which keeps track of columns), this function always outputs
      true
      choice-conditional))
 
-  (\; [:min-remaining [nil Integer] :max-columns [nil Integer]] 
-   #{ :colon } { :separator true } nil) 
-   
-  (\] [] #{} {} nil) 
+  (\; [:min-remaining [nil Integer] :max-columns [nil Integer]]
+      #{:colon} {:separator true} nil)
+
+  (\] [] #{} {} nil)
 
   (\{
-   [ :max-iterations [nil Integer] ]
-   #{ :colon :at :both} { :right \}, :allows-separator false }
+   [:max-iterations [nil Integer]]
+   #{:colon :at :both} {:right \}, :allows-separator false}
    (cond
      (and (:at params) (:colon params))
      iterate-main-sublists
@@ -1548,43 +1541,41 @@ not a pretty writer (which keeps track of columns), this function always outputs
 
      true
      iterate-sublist))
-
-   
-  (\} [] #{:colon} {} nil) 
+  (\} [] #{:colon} {} nil)
 
   (\<
    [:mincol [0 Integer] :colinc [1 Integer] :minpad [0 Integer] :padchar [\space Character]]
-   #{:colon :at :both :pretty} { :right \>, :allows-separator true, :else :first }
+   #{:colon :at :both :pretty} {:right \>, :allows-separator true, :else :first}
    logical-block-or-justify)
 
-  (\> [] #{:colon} {} nil) 
+  (\> [] #{:colon} {} nil)
 
   ;; TODO: detect errors in cases where colon not allowed
-  (\^ [:arg1 [nil Integer] :arg2 [nil Integer] :arg3 [nil Integer]] 
-   #{:colon} {} 
-   (fn [params navigator offsets]
-     (let [arg1 (:arg1 params)
-           arg2 (:arg2 params)
-           arg3 (:arg3 params)
-           exit (if (:colon params) :colon-up-arrow :up-arrow)]
-       (cond
-         (and arg1 arg2 arg3)
-         (if (<= arg1 arg2 arg3) [exit navigator] navigator)
+  (\^ [:arg1 [nil Integer] :arg2 [nil Integer] :arg3 [nil Integer]]
+      #{:colon} {}
+      (fn [params navigator offsets]
+        (let [arg1 (:arg1 params)
+              arg2 (:arg2 params)
+              arg3 (:arg3 params)
+              exit (if (:colon params) :colon-up-arrow :up-arrow)]
+          (cond
+            (and arg1 arg2 arg3)
+            (if (<= arg1 arg2 arg3) [exit navigator] navigator)
 
-         (and arg1 arg2)
-         (if (= arg1 arg2) [exit navigator] navigator)
+            (and arg1 arg2)
+            (if (= arg1 arg2) [exit navigator] navigator)
 
-         arg1
-         (if (= arg1 0) [exit navigator] navigator)
+            arg1
+            (if (= arg1 0) [exit navigator] navigator)
 
-         true     ; TODO: handle looking up the arglist stack for info
-         (if (if (:colon params) 
-               (empty? (:rest (:base-args params)))
-               (empty? (:rest navigator)))
-           [exit navigator] navigator))))) 
+            true     ; TODO: handle looking up the arglist stack for info
+            (if (if (:colon params)
+                  (empty? (:rest (:base-args params)))
+                  (empty? (:rest navigator)))
+              [exit navigator] navigator)))))
 
-  (\W 
-   [] 
+  (\W
+   []
    #{:at :colon :both :pretty} {}
    (if (or (:at params) (:colon params))
      (let [bindings (concat
@@ -1609,8 +1600,7 @@ not a pretty writer (which keeps track of columns), this function always outputs
   (\I
    [:n [0 Integer]]
    #{:colon} {}
-   set-indent)
-  )
+   set-indent))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Code to manage the parameters and flags associated with each
@@ -1618,9 +1608,9 @@ not a pretty writer (which keeps track of columns), this function always outputs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:private true}
-     param-pattern #"^([vV]|#|('.)|([+-]?\d+)|(?=,))")
+  param-pattern #"^([vV]|#|('.)|([+-]?\d+)|(?=,))")
 (def ^{:private true}
-     special-params #{ :parameter-from-args :remaining-arg-count })
+  special-params #{:parameter-from-args :remaining-arg-count})
 
 (defn- extract-param [[s offset saw-comma]]
   (let [m (re-matcher param-pattern s)
@@ -1630,30 +1620,29 @@ not a pretty writer (which keeps track of columns), this function always outputs
             remainder (subs s (.end m))
             new-offset (+ offset (.end m))]
         (if (not (= \, (nth remainder 0)))
-          [ [token-str offset] [remainder new-offset false]]
-          [ [token-str offset] [(subs remainder 1) (inc new-offset) true]]))
-      (if saw-comma 
+          [[token-str offset] [remainder new-offset false]]
+          [[token-str offset] [(subs remainder 1) (inc new-offset) true]]))
+      (if saw-comma
         (format-error "Badly formed parameters in format directive" offset)
-        [ nil [s offset]]))))
+        [nil [s offset]]))))
 
-
-(defn- extract-params [s offset] 
+(defn- extract-params [s offset]
   (consume extract-param [s offset false]))
 
 (defn- translate-param
   "Translate the string representation of a param to the internalized
                                       representation"
   [[^String p offset]]
-  [(cond 
-    (= (.length p) 0) nil
-    (and (= (.length p) 1) (contains? #{\v \V} (nth p 0))) :parameter-from-args
-    (and (= (.length p) 1) (= \# (nth p 0))) :remaining-arg-count
-    (and (= (.length p) 2) (= \' (nth p 0))) (nth p 1)
-    true (new Integer p))
+  [(cond
+     (= (.length p) 0) nil
+     (and (= (.length p) 1) (contains? #{\v \V} (nth p 0))) :parameter-from-args
+     (and (= (.length p) 1) (= \# (nth p 0))) :remaining-arg-count
+     (and (= (.length p) 2) (= \' (nth p 0))) (nth p 1)
+     true (new Integer p))
    offset])
- 
+
 (def ^{:private true}
-     flag-defs { \: :colon, \@ :at })
+  flag-defs {\: :colon, \@ :at})
 
 (defn- extract-flags [s offset]
   (consume
@@ -1663,7 +1652,7 @@ not a pretty writer (which keeps track of columns), this function always outputs
        (let [flag (get flag-defs (first s))]
          (if flag
            (if (contains? flags flag)
-             (format-error 
+             (format-error
               (str "Flag \"" (first s) "\" appears more than once in a directive")
               offset)
              [true [(subs s 1) (inc offset) (assoc flags flag [true offset])]])
@@ -1679,7 +1668,7 @@ not a pretty writer (which keeps track of columns), this function always outputs
       (format-error (str "\":\" is an illegal flag for format directive \"" (:directive def) "\"")
                     (nth (:colon flags) 1)))
     (if (and (not (:both allowed)) (:at flags) (:colon flags))
-      (format-error (str "Cannot combine \"@\" and \":\" flags for format directive \"" 
+      (format-error (str "Cannot combine \"@\" and \":\" flags for format directive \""
                          (:directive def) "\"")
                     (min (nth (:colon flags) 1) (nth (:at flags) 1))))))
 
@@ -1691,22 +1680,22 @@ of parameters as well."
   [def params flags offset]
   (check-flags def flags)
   (if (> (count params) (count (:params def)))
-    (format-error 
-     (cl-format 
-      nil 
+    (format-error
+     (cl-format
+      nil
       "Too many parameters for directive \"~C\": ~D~:* ~[were~;was~:;were~] specified but only ~D~:* ~[are~;is~:;are~] allowed"
       (:directive def) (count params) (count (:params def)))
      (second (first params))))
   (doall
    (map #(let [val (first %1)]
-           (if (not (or (nil? val) (contains? special-params val) 
+           (if (not (or (nil? val) (contains? special-params val)
                         (instance? (second (second %2)) val)))
              (format-error (str "Parameter " (name (first %2))
                                 " has bad type in directive \"" (:directive def) "\": "
                                 (class val))
-                           (second %1))) )
+                           (second %1))))
         params (:params def)))
-     
+
   (merge                                ; create the result map
    (into (array-map) ; start with the default values, make sure the order is right
          (reverse (for [[name [default]] (:params def)] [name [default offset]])))
@@ -1724,7 +1713,7 @@ of parameters as well."
     (if (not def)
       (format-error (str "Directive \"" directive "\" is undefined") offset))
     [(struct compiled-directive ((:generator-fn def) params offset) def params offset)
-     (let [remainder (subs rest 1) 
+     (let [remainder (subs rest 1)
            offset (inc offset)
            trim? (and (= \newline (:directive def))
                       (not (:colon params)))
@@ -1732,107 +1721,106 @@ of parameters as well."
            remainder (subs remainder trim-count)
            offset (+ offset trim-count)]
        [remainder offset])]))
-    
+
 (defn- compile-raw-string [s offset]
-  (struct compiled-directive (fn [_ a _] (print s) a) nil { :string s } offset))
+  (struct compiled-directive (fn [_ a _] (print s) a) nil {:string s} offset))
 
 (defn- right-bracket [this] (:right (:bracket-info (:def this))))
 (defn- separator? [this] (:separator (:bracket-info (:def this))))
-(defn- else-separator? [this] 
+(defn- else-separator? [this]
   (and (:separator (:bracket-info (:def this)))
        (:colon (:params this))))
-  
 
 (declare collect-clauses)
 
 (defn- process-bracket [this remainder]
   (let [[subex remainder] (collect-clauses (:bracket-info (:def this))
                                            (:offset this) remainder)]
-    [(struct compiled-directive 
-             (:func this) (:def this) 
+    [(struct compiled-directive
+             (:func this) (:def this)
              (merge (:params this) (tuple-map subex (:offset this)))
              (:offset this))
      remainder]))
 
 (defn- process-clause [bracket-info offset remainder]
-  (consume 
+  (consume
    (fn [remainder]
      (if (empty? remainder)
        (format-error "No closing bracket found." offset)
        (let [this (first remainder)
              remainder (next remainder)]
          (cond
-          (right-bracket this)
-          (process-bracket this remainder)
+           (right-bracket this)
+           (process-bracket this remainder)
 
-          (= (:right bracket-info) (:directive (:def this)))
-          [ nil [:right-bracket (:params this) nil remainder]]
+           (= (:right bracket-info) (:directive (:def this)))
+           [nil [:right-bracket (:params this) nil remainder]]
 
-          (else-separator? this)
-          [nil [:else nil (:params this) remainder]]
+           (else-separator? this)
+           [nil [:else nil (:params this) remainder]]
 
-          (separator? this)
-          [nil [:separator nil nil remainder]] ;; TODO: check to make sure that there are no params on ~;
+           (separator? this)
+           [nil [:separator nil nil remainder]] ;; TODO: check to make sure that there are no params on ~;
 
-          true
-          [this remainder]))))
+           true
+           [this remainder]))))
    remainder))
 
 (defn- collect-clauses [bracket-info offset remainder]
   (second
    (consume
     (fn [[clause-map saw-else remainder]]
-      (let [[clause [type right-params else-params remainder]] 
+      (let [[clause [type right-params else-params remainder]]
             (process-clause bracket-info offset remainder)]
         (cond
-         (= type :right-bracket)
-         [nil [(merge-with concat clause-map 
-                           {(if saw-else :else :clauses) [clause] 
-                            :right-params right-params})
-               remainder]]
+          (= type :right-bracket)
+          [nil [(merge-with concat clause-map
+                            {(if saw-else :else :clauses) [clause]
+                             :right-params right-params})
+                remainder]]
 
-         (= type :else)
-         (cond
-          (:else clause-map)
-          (format-error "Two else clauses (\"~:;\") inside bracket construction." offset)
-         
-          (not (:else bracket-info))
-          (format-error "An else clause (\"~:;\") is in a bracket type that doesn't support it." 
-                        offset)
+          (= type :else)
+          (cond
+            (:else clause-map)
+            (format-error "Two else clauses (\"~:;\") inside bracket construction." offset)
 
-          (and (= :first (:else bracket-info)) (seq (:clauses clause-map)))
-          (format-error
-           "The else clause (\"~:;\") is only allowed in the first position for this directive." 
-           offset)
-         
-          true         ; if the ~:; is in the last position, the else clause
-                                        ; is next, this was a regular clause
-          (if (= :first (:else bracket-info))
-            [true [(merge-with concat clause-map { :else [clause] :else-params else-params})
-                   false remainder]]
-            [true [(merge-with concat clause-map { :clauses [clause] })
-                   true remainder]]))
+            (not (:else bracket-info))
+            (format-error "An else clause (\"~:;\") is in a bracket type that doesn't support it."
+                          offset)
 
-         (= type :separator)
-         (cond
-          saw-else
-          (format-error "A plain clause (with \"~;\") follows an else clause (\"~:;\") inside bracket construction." offset)
-         
-          (not (:allows-separator bracket-info))
-          (format-error "A separator (\"~;\") is in a bracket type that doesn't support it." 
-                        offset)
-         
-          true
-          [true [(merge-with concat clause-map { :clauses [clause] })
-                 false remainder]]))))
-    [{ :clauses [] } false remainder])))
+            (and (= :first (:else bracket-info)) (seq (:clauses clause-map)))
+            (format-error
+             "The else clause (\"~:;\") is only allowed in the first position for this directive."
+             offset)
+
+            true         ; if the ~:; is in the last position, the else clause
+;; is next, this was a regular clause
+            (if (= :first (:else bracket-info))
+              [true [(merge-with concat clause-map {:else [clause] :else-params else-params})
+                     false remainder]]
+              [true [(merge-with concat clause-map {:clauses [clause]})
+                     true remainder]]))
+
+          (= type :separator)
+          (cond
+            saw-else
+            (format-error "A plain clause (with \"~;\") follows an else clause (\"~:;\") inside bracket construction." offset)
+
+            (not (:allows-separator bracket-info))
+            (format-error "A separator (\"~;\") is in a bracket type that doesn't support it."
+                          offset)
+
+            true
+            [true [(merge-with concat clause-map {:clauses [clause]})
+                   false remainder]]))))
+    [{:clauses []} false remainder])))
 
 (defn- process-nesting
-  "Take a linearly compiled format and process the bracket directives to give it 
+  "Take a linearly compiled format and process the bracket directives to give it
    the appropriate tree structure"
   [format]
   (first
-   (consume 
+   (consume
     (fn [remainder]
       (let [this (first remainder)
             remainder (next remainder)
@@ -1842,28 +1830,28 @@ of parameters as well."
           [this remainder])))
     format)))
 
-(defn- compile-format 
+(defn- compile-format
   "Compiles format-str into a compiled format which can be used as an argument
-to cl-format just like a plain format string. Use this function for improved 
+to cl-format just like a plain format string. Use this function for improved
 performance when you're using the same format string repeatedly"
-  [ format-str ]
+  [format-str]
 ;  (prlabel compiling format-str)
   (binding [*format-str* format-str]
     (process-nesting
-     (first 
-      (consume 
+     (first
+      (consume
        (fn [[^String s offset]]
          (if (empty? s)
            [nil s]
            (let [tilde (.indexOf s (int \~))]
              (cond
-              (neg? tilde) [(compile-raw-string s offset) ["" (+ offset (.length s))]]
-              (zero? tilde)  (compile-directive (subs s 1) (inc offset))
-              true 
-              [(compile-raw-string (subs s 0 tilde) offset) [(subs s tilde) (+ tilde offset)]]))))
+               (neg? tilde) [(compile-raw-string s offset) ["" (+ offset (.length s))]]
+               (zero? tilde)  (compile-directive (subs s 1) (inc offset))
+               true
+               [(compile-raw-string (subs s 0 tilde) offset) [(subs s tilde) (+ tilde offset)]]))))
        [format-str 0])))))
 
-(defn- needs-pretty 
+(defn- needs-pretty
   "determine whether a given compiled format has any directives that depend on the
 column number or pretty printing"
   [format]
@@ -1876,38 +1864,38 @@ column number or pretty printing"
         true
         (recur (next format))))))
 
-(defn- execute-format 
+(defn- execute-format
   "Executes the format with the arguments."
   {:skip-wiki true}
   ([stream format args]
-     (let [^java.io.Writer real-stream (cond 
-                                         (not stream) (java.io.StringWriter.)
-                                         (true? stream) *out*
-                                         :else stream)
-           ^java.io.Writer wrapped-stream (if (and (needs-pretty format) 
-                                                    (not (pretty-writer? real-stream)))
-                                             (get-pretty-writer real-stream)
-                                             real-stream)]
-       (binding [*out* wrapped-stream]
-         (try
-          (execute-format format args)
-          (finally
+   (let [^java.io.Writer real-stream (cond
+                                       (not stream) (java.io.StringWriter.)
+                                       (true? stream) *out*
+                                       :else stream)
+         ^java.io.Writer wrapped-stream (if (and (needs-pretty format)
+                                                 (not (pretty-writer? real-stream)))
+                                          (get-pretty-writer real-stream)
+                                          real-stream)]
+     (binding [*out* wrapped-stream]
+       (try
+         (execute-format format args)
+         (finally
            (if-not (identical? real-stream wrapped-stream)
              (.flush wrapped-stream))))
-         (if (not stream) (.toString real-stream)))))
+       (if (not stream) (.toString real-stream)))))
   ([format args]
-     (map-passing-context 
-      (fn [element context]
-        (if (abort? context)
-          [nil context]
-          (let [[params args] (realize-parameter-list 
-                               (:params element) context)
-                [params offsets] (unzip-map params)
-                params (assoc params :base-args args)]
-            [nil (apply (:func element) [params args offsets])])))
-      args
-      format)
-     nil))
+   (map-passing-context
+    (fn [element context]
+      (if (abort? context)
+        [nil context]
+        (let [[params args] (realize-parameter-list
+                             (:params element) context)
+              [params offsets] (unzip-map params)
+              params (assoc params :base-args args)]
+          [nil (apply (:func element) [params args offsets])])))
+    args
+    format)
+   nil))
 
 ;;; This is a bad idea, but it prevents us from leaking private symbols
 ;;; This should all be replaced by really compiled formats anyway.
@@ -1915,7 +1903,7 @@ column number or pretty printing"
 
 (defmacro formatter
   "Makes a function which can directly run format-in. The function is
-fn [stream & args] ... and returns nil unless the stream is nil (meaning 
+fn [stream & args] ... and returns nil unless the stream is nil (meaning
 output to a string) in which case it returns the resulting string.
 
 format-in can be either a control string or a previously compiled format."

--- a/src/clj/clojure/pprint/column_writer.clj
+++ b/src/clj/clojure/pprint/column_writer.clj
@@ -1,13 +1,13 @@
 ;;; column_writer.clj -- part of the pretty printer for Clojure
 
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -25,7 +25,7 @@
 (defn- get-field [^Writer this sym]
   (sym @@this))
 
-(defn- set-field [^Writer this sym new-val] 
+(defn- set-field [^Writer this sym new-val]
   (alter @this assoc sym new-val))
 
 (defn- get-column [this]
@@ -46,38 +46,38 @@
 
 (defn- c-write-char [^Writer this ^Integer c]
   (dosync (if (= c (int \newline))
-	    (do
+            (do
               (set-field this :cur 0)
               (set-field this :line (inc (get-field this :line))))
-	    (set-field this :cur (inc (get-field this :cur)))))
+            (set-field this :cur (inc (get-field this :cur)))))
   (.write ^Writer (get-field this :base) c))
 
-(defn- column-writer   
+(defn- column-writer
   ([writer] (column-writer writer *default-page-width*))
   ([^Writer writer max-columns]
-     (let [fields (ref {:max max-columns, :cur 0, :line 0 :base writer})]
-       (proxy [Writer IDeref] []
-         (deref [] fields)
-         (flush []
-           (.flush writer))
-         (write
-          ([^chars cbuf ^Integer off ^Integer len] 
-             (let [^Writer writer (get-field this :base)] 
-               (.write writer cbuf off len)))
-          ([x]
-             (condp = (class x)
-               String 
-               (let [^String s x
-                     nl (.lastIndexOf s (int \newline))]
-                 (dosync (if (neg? nl)
-                           (set-field this :cur (+ (get-field this :cur) (count s)))
-                           (do
-                             (set-field this :cur (- (count s) nl 1))
-                             (set-field this :line (+ (get-field this :line)
-                                                      (count (filter #(= % \newline) s)))))))
-                 (.write ^Writer (get-field this :base) s))
+   (let [fields (ref {:max max-columns, :cur 0, :line 0 :base writer})]
+     (proxy [Writer IDeref] []
+       (deref [] fields)
+       (flush []
+         (.flush writer))
+       (write
+         ([^chars cbuf ^Integer off ^Integer len]
+          (let [^Writer writer (get-field this :base)]
+            (.write writer cbuf off len)))
+         ([x]
+          (condp = (class x)
+            String
+            (let [^String s x
+                  nl (.lastIndexOf s (int \newline))]
+              (dosync (if (neg? nl)
+                        (set-field this :cur (+ (get-field this :cur) (count s)))
+                        (do
+                          (set-field this :cur (- (count s) nl 1))
+                          (set-field this :line (+ (get-field this :line)
+                                                   (count (filter #(= % \newline) s)))))))
+              (.write ^Writer (get-field this :base) s))
 
-               Integer
-               (c-write-char this x)
-               Long
-               (c-write-char this x))))))))
+            Integer
+            (c-write-char this x)
+            Long
+            (c-write-char this x))))))))

--- a/src/clj/clojure/pprint/dispatch.clj
+++ b/src/clj/clojure/pprint/dispatch.clj
@@ -1,12 +1,12 @@
 ;; dispatch.clj -- part of the pretty printer for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -27,7 +27,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;; Handle forms that can be "back-translated" to reader macros
-;;; Not all reader macros can be dealt with this way or at all. 
+;;; Not all reader macros can be dealt with this way or at all.
 ;;; Macros that we can't deal with at all are:
 ;;; ;  - The comment character is absorbed by the reader and never is part of the form
 ;;; `  - Is fully processed at read time into a lisp expression (which will contain concats
@@ -43,8 +43,8 @@
 ;;; :keyword, \char, or ""). The notable exception is #() which is special-cased.
 
 (def ^{:private true} reader-macros
-     {'quote "'", 'clojure.core/deref "@", 
-      'var "#'", 'clojure.core/unquote "~"})
+  {'quote "'", 'clojure.core/deref "@",
+   'var "#'", 'clojure.core/unquote "~"})
 
 (defn- pprint-reader-macro [alis]
   (let [^String macro-char (reader-macros (first alis))]
@@ -65,13 +65,13 @@
 ;;; (def pprint-simple-list (formatter-out "~:<~@{~w~^ ~_~}~:>"))
 (defn- pprint-simple-list [alis]
   (pprint-logical-block :prefix "(" :suffix ")"
-    (print-length-loop [alis (seq alis)]
-      (when alis
-	(write-out (first alis))
-	(when (next alis)
-	  (.write ^java.io.Writer *out* " ")
-	  (pprint-newline :linear)
-	  (recur (next alis)))))))
+                        (print-length-loop [alis (seq alis)]
+                                           (when alis
+                                             (write-out (first alis))
+                                             (when (next alis)
+                                               (.write ^java.io.Writer *out* " ")
+                                               (pprint-newline :linear)
+                                               (recur (next alis)))))))
 
 (defn- pprint-list [alis]
   (if-not (pprint-reader-macro alis)
@@ -80,39 +80,39 @@
 ;;; (def pprint-vector (formatter-out "~<[~;~@{~w~^ ~_~}~;]~:>"))
 (defn- pprint-vector [avec]
   (pprint-logical-block :prefix "[" :suffix "]"
-    (print-length-loop [aseq (seq avec)]
-      (when aseq
-	(write-out (first aseq))
-	(when (next aseq)
-	  (.write ^java.io.Writer *out* " ")
-	  (pprint-newline :linear)
-	  (recur (next aseq)))))))
+                        (print-length-loop [aseq (seq avec)]
+                                           (when aseq
+                                             (write-out (first aseq))
+                                             (when (next aseq)
+                                               (.write ^java.io.Writer *out* " ")
+                                               (pprint-newline :linear)
+                                               (recur (next aseq)))))))
 
 (def ^{:private true} pprint-array (formatter-out "~<[~;~@{~w~^, ~:_~}~;]~:>"))
 
 ;;; (def pprint-map (formatter-out "~<{~;~@{~<~w~^ ~_~w~:>~^, ~_~}~;}~:>"))
 (defn- pprint-map [amap]
   (pprint-logical-block :prefix "{" :suffix "}"
-    (print-length-loop [aseq (seq amap)]
-      (when aseq
-	(pprint-logical-block 
-          (write-out (ffirst aseq))
-          (.write ^java.io.Writer *out* " ")
-          (pprint-newline :linear)
-          (set! *current-length* 0)     ; always print both parts of the [k v] pair
-          (write-out (fnext (first aseq))))
-        (when (next aseq)
-          (.write ^java.io.Writer *out* ", ")
-          (pprint-newline :linear)
-          (recur (next aseq)))))))
+                        (print-length-loop [aseq (seq amap)]
+                                           (when aseq
+                                             (pprint-logical-block
+                                              (write-out (ffirst aseq))
+                                              (.write ^java.io.Writer *out* " ")
+                                              (pprint-newline :linear)
+                                              (set! *current-length* 0)     ; always print both parts of the [k v] pair
+                                              (write-out (fnext (first aseq))))
+                                             (when (next aseq)
+                                               (.write ^java.io.Writer *out* ", ")
+                                               (pprint-newline :linear)
+                                               (recur (next aseq)))))))
 
 (def ^{:private true} pprint-set (formatter-out "~<#{~;~@{~w~^ ~:_~}~;}~:>"))
 
-(def ^{:private true} 
-     type-map {"core$future_call" "Future",
-               "core$promise" "Promise"})
+(def ^{:private true}
+  type-map {"core$future_call" "Future",
+            "core$promise" "Promise"})
 
-(defn- map-ref-type 
+(defn- map-ref-type
   "Map ugly type names to something simpler"
   [name]
   (or (when-let [match (re-find #"^[^$]+\$[^$]+" name)]
@@ -130,24 +130,23 @@
     (pprint-logical-block  :prefix prefix :suffix ">"
                            (pprint-indent :block (-> (count prefix) (- 2) -))
                            (pprint-newline :linear)
-                           (write-out (cond 
-                                       (and (future? o) (not (future-done? o))) :pending
-                                       (and (instance? clojure.lang.IPending o) (not (.isRealized ^clojure.lang.IPending o))) :not-delivered
-                                       :else @o)))))
+                           (write-out (cond
+                                        (and (future? o) (not (future-done? o))) :pending
+                                        (and (instance? clojure.lang.IPending o) (not (.isRealized ^clojure.lang.IPending o))) :not-delivered
+                                        :else @o)))))
 
 (def ^{:private true} pprint-pqueue (formatter-out "~<<-(~;~@{~w~^ ~_~}~;)-<~:>"))
 
 (defn- pprint-simple-default [obj]
-  (cond 
+  (cond
     (.isArray (class obj)) (pprint-array obj)
     (and *print-suppress-namespaces* (symbol? obj)) (print (name obj))
     :else (pr obj)))
 
-
-(defmulti 
+(defmulti
   simple-dispatch
   "The pretty print dispatch function for simple data structure format."
-  {:added "1.2" :arglists '[[object]]} 
+  {:added "1.2" :arglists '[[object]]}
   class)
 
 (use-method simple-dispatch clojure.lang.ISeq pprint-list)
@@ -186,37 +185,37 @@
     (let [[start end] (brackets reference)
           [keyw & args] reference]
       (pprint-logical-block :prefix start :suffix end
-        ((formatter-out "~w~:i") keyw)
-        (loop [args args]
-          (when (seq args)
-            ((formatter-out " "))
-            (let [arg (first args)]
-              (if (sequential? arg)
-                (let [[start end] (brackets arg)]
-                  (pprint-logical-block :prefix start :suffix end
-                    (if (and (= (count arg) 3) (keyword? (second arg)))
-                      (let [[ns kw lis] arg]
-                        ((formatter-out "~w ~w ") ns kw)
-                        (if (sequential? lis)
-                          ((formatter-out (if (vector? lis)
-                                            "~<[~;~@{~w~^ ~:_~}~;]~:>"
-                                            "~<(~;~@{~w~^ ~:_~}~;)~:>"))
-                           lis)
-                          (write-out lis)))
-                      (apply (formatter-out "~w ~:i~@{~w~^ ~:_~}") arg)))
-                  (when (next args)
-                    ((formatter-out "~_"))))
-                (do
-                  (write-out arg)
-                  (when (next args)
-                    ((formatter-out "~:_"))))))
-            (recur (next args))))))
+                            ((formatter-out "~w~:i") keyw)
+                            (loop [args args]
+                              (when (seq args)
+                                ((formatter-out " "))
+                                (let [arg (first args)]
+                                  (if (sequential? arg)
+                                    (let [[start end] (brackets arg)]
+                                      (pprint-logical-block :prefix start :suffix end
+                                                            (if (and (= (count arg) 3) (keyword? (second arg)))
+                                                              (let [[ns kw lis] arg]
+                                                                ((formatter-out "~w ~w ") ns kw)
+                                                                (if (sequential? lis)
+                                                                  ((formatter-out (if (vector? lis)
+                                                                                    "~<[~;~@{~w~^ ~:_~}~;]~:>"
+                                                                                    "~<(~;~@{~w~^ ~:_~}~;)~:>"))
+                                                                   lis)
+                                                                  (write-out lis)))
+                                                              (apply (formatter-out "~w ~:i~@{~w~^ ~:_~}") arg)))
+                                      (when (next args)
+                                        ((formatter-out "~_"))))
+                                    (do
+                                      (write-out arg)
+                                      (when (next args)
+                                        ((formatter-out "~:_"))))))
+                                (recur (next args))))))
     (when reference (write-out reference))))
 
 (defn- pprint-ns
   "The pretty print dispatch chunk for the ns macro"
   [alis]
-  (if (next alis) 
+  (if (next alis)
     (let [[ns-sym ns-name & stuff] alis
           [doc-str stuff] (if (string? (first stuff))
                             [(first stuff) (next stuff)]
@@ -225,18 +224,18 @@
                                   [(first stuff) (next stuff)]
                                   [nil stuff])]
       (pprint-logical-block :prefix "(" :suffix ")"
-        ((formatter-out "~w ~1I~@_~w") ns-sym ns-name)
-        (when (or doc-str attr-map (seq references))
-          ((formatter-out "~@:_")))
-        (when doc-str
-          (cl-format true "\"~a\"~:[~;~:@_~]" doc-str (or attr-map (seq references))))
-        (when attr-map
-          ((formatter-out "~w~:[~;~:@_~]") attr-map (seq references)))
-        (loop [references references]
-          (pprint-ns-reference (first references))
-          (when-let [references (next references)]
-            (pprint-newline :linear)
-            (recur references)))))
+                            ((formatter-out "~w ~1I~@_~w") ns-sym ns-name)
+                            (when (or doc-str attr-map (seq references))
+                              ((formatter-out "~@:_")))
+                            (when doc-str
+                              (cl-format true "\"~a\"~:[~;~:@_~]" doc-str (or attr-map (seq references))))
+                            (when attr-map
+                              ((formatter-out "~w~:[~;~:@_~]") attr-map (seq references)))
+                            (loop [references references]
+                              (pprint-ns-reference (first references))
+                              (when-let [references (next references)]
+                                (pprint-newline :linear)
+                                (recur references)))))
     (write-out alis)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -264,10 +263,10 @@
   (if (seq alis)
     ((formatter-out " ~_~{~w~^ ~_~}") alis)))
 
-;;; TODO: figure out how to support capturing metadata in defns (we might need a 
+;;; TODO: figure out how to support capturing metadata in defns (we might need a
 ;;; special reader)
 (defn- pprint-defn [alis]
-  (if (next alis) 
+  (if (next alis)
     (let [[defn-sym defn-name & stuff] alis
           [doc-str stuff] (if (string? (first stuff))
                             [(first stuff) (next stuff)]
@@ -276,15 +275,15 @@
                              [(first stuff) (next stuff)]
                              [nil stuff])]
       (pprint-logical-block :prefix "(" :suffix ")"
-        ((formatter-out "~w ~1I~@_~w") defn-sym defn-name)
-        (if doc-str
-          ((formatter-out " ~_~w") doc-str))
-        (if attr-map
-          ((formatter-out " ~_~w") attr-map))
+                            ((formatter-out "~w ~1I~@_~w") defn-sym defn-name)
+                            (if doc-str
+                              ((formatter-out " ~_~w") doc-str))
+                            (if attr-map
+                              ((formatter-out " ~_~w") attr-map))
         ;; Note: the multi-defn case will work OK for malformed defns too
-        (cond
-         (vector? (first stuff)) (single-defn stuff (or doc-str attr-map))
-         :else (multi-defn stuff (or doc-str attr-map)))))
+                            (cond
+                              (vector? (first stuff)) (single-defn stuff (or doc-str attr-map))
+                              :else (multi-defn stuff (or doc-str attr-map)))))
     (pprint-simple-code-list alis)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -293,29 +292,28 @@
 
 (defn- pprint-binding-form [binding-vec]
   (pprint-logical-block :prefix "[" :suffix "]"
-    (print-length-loop [binding binding-vec]
-      (when (seq binding)
-        (pprint-logical-block binding
-          (write-out (first binding))
-          (when (next binding)
-            (.write ^java.io.Writer *out* " ")
-            (pprint-newline :miser)
-            (write-out (second binding))))
-        (when (next (rest binding))
-          (.write ^java.io.Writer *out* " ")
-          (pprint-newline :linear)
-          (recur (next (rest binding))))))))
+                        (print-length-loop [binding binding-vec]
+                                           (when (seq binding)
+                                             (pprint-logical-block binding
+                                                                   (write-out (first binding))
+                                                                   (when (next binding)
+                                                                     (.write ^java.io.Writer *out* " ")
+                                                                     (pprint-newline :miser)
+                                                                     (write-out (second binding))))
+                                             (when (next (rest binding))
+                                               (.write ^java.io.Writer *out* " ")
+                                               (pprint-newline :linear)
+                                               (recur (next (rest binding))))))))
 
 (defn- pprint-let [alis]
   (let [base-sym (first alis)]
     (pprint-logical-block :prefix "(" :suffix ")"
-      (if (and (next alis) (vector? (second alis)))
-        (do
-          ((formatter-out "~w ~1I~@_") base-sym)
-          (pprint-binding-form (second alis))
-          ((formatter-out " ~_~{~w~^ ~_~}") (next (rest alis))))
-        (pprint-simple-code-list alis)))))
-
+                          (if (and (next alis) (vector? (second alis)))
+                            (do
+                              ((formatter-out "~w ~1I~@_") base-sym)
+                              (pprint-binding-form (second alis))
+                              ((formatter-out " ~_~{~w~^ ~_~}") (next (rest alis))))
+                            (pprint-simple-code-list alis)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Format something that looks like "if"
@@ -325,41 +323,41 @@
 
 (defn- pprint-cond [alis]
   (pprint-logical-block :prefix "(" :suffix ")"
-    (pprint-indent :block 1)
-    (write-out (first alis))
-    (when (next alis)
-      (.write ^java.io.Writer *out* " ")
-      (pprint-newline :linear)
-     (print-length-loop [alis (next alis)]
-       (when alis
-         (pprint-logical-block alis
-          (write-out (first alis))
-          (when (next alis)
-            (.write ^java.io.Writer *out* " ")
-            (pprint-newline :miser)
-            (write-out (second alis))))
-         (when (next (rest alis))
-           (.write ^java.io.Writer *out* " ")
-           (pprint-newline :linear)
-           (recur (next (rest alis)))))))))
+                        (pprint-indent :block 1)
+                        (write-out (first alis))
+                        (when (next alis)
+                          (.write ^java.io.Writer *out* " ")
+                          (pprint-newline :linear)
+                          (print-length-loop [alis (next alis)]
+                                             (when alis
+                                               (pprint-logical-block alis
+                                                                     (write-out (first alis))
+                                                                     (when (next alis)
+                                                                       (.write ^java.io.Writer *out* " ")
+                                                                       (pprint-newline :miser)
+                                                                       (write-out (second alis))))
+                                               (when (next (rest alis))
+                                                 (.write ^java.io.Writer *out* " ")
+                                                 (pprint-newline :linear)
+                                                 (recur (next (rest alis)))))))))
 
 (defn- pprint-condp [alis]
-  (if (> (count alis) 3) 
+  (if (> (count alis) 3)
     (pprint-logical-block :prefix "(" :suffix ")"
-      (pprint-indent :block 1)
-      (apply (formatter-out "~w ~@_~w ~@_~w ~_") alis)
-      (print-length-loop [alis (seq (drop 3 alis))]
-        (when alis
-          (pprint-logical-block alis
-            (write-out (first alis))
-            (when (next alis)
-              (.write ^java.io.Writer *out* " ")
-              (pprint-newline :miser)
-              (write-out (second alis))))
-          (when (next (rest alis))
-            (.write ^java.io.Writer *out* " ")
-            (pprint-newline :linear)
-            (recur (next (rest alis)))))))
+                          (pprint-indent :block 1)
+                          (apply (formatter-out "~w ~@_~w ~@_~w ~_") alis)
+                          (print-length-loop [alis (seq (drop 3 alis))]
+                                             (when alis
+                                               (pprint-logical-block alis
+                                                                     (write-out (first alis))
+                                                                     (when (next alis)
+                                                                       (.write ^java.io.Writer *out* " ")
+                                                                       (pprint-newline :miser)
+                                                                       (write-out (second alis))))
+                                               (when (next (rest alis))
+                                                 (.write ^java.io.Writer *out* " ")
+                                                 (pprint-newline :linear)
+                                                 (recur (next (rest alis)))))))
     (pprint-simple-code-list alis)))
 
 ;;; The map of symbols that are defined in an enclosing #() anonymous function
@@ -369,12 +367,12 @@
   (let [args (second alis)
         nlis (first (rest (rest alis)))]
     (if (vector? args)
-      (binding [*symbol-map* (if (= 1 (count args)) 
+      (binding [*symbol-map* (if (= 1 (count args))
                                {(first args) "%"}
-                               (into {} 
-                                     (map 
-                                      #(vector %1 (str \% %2)) 
-                                      args 
+                               (into {}
+                                     (map
+                                      #(vector %1 (str \% %2))
+                                      args
                                       (range 1 (inc (count args))))))]
         ((formatter-out "~<#(~;~@{~w~^ ~_~}~;)~:>") nlis))
       (pprint-simple-code-list alis))))
@@ -389,67 +387,66 @@
 
 (defn- pprint-simple-code-list [alis]
   (pprint-logical-block :prefix "(" :suffix ")"
-    (pprint-indent :block 1)
-    (print-length-loop [alis (seq alis)]
-      (when alis
-	(write-out (first alis))
-	(when (next alis)
-	  (.write ^java.io.Writer *out* " ")
-	  (pprint-newline :linear)
-	  (recur (next alis)))))))
+                        (pprint-indent :block 1)
+                        (print-length-loop [alis (seq alis)]
+                                           (when alis
+                                             (write-out (first alis))
+                                             (when (next alis)
+                                               (.write ^java.io.Writer *out* " ")
+                                               (pprint-newline :linear)
+                                               (recur (next alis)))))))
 
 ;;; Take a map with symbols as keys and add versions with no namespace.
 ;;; That is, if ns/sym->val is in the map, add sym->val to the result.
 (defn- two-forms [amap]
-  (into {} 
-        (mapcat 
-         identity 
-         (for [x amap] 
+  (into {}
+        (mapcat
+         identity
+         (for [x amap]
            [x [(symbol (name (first x))) (second x)]]))))
 
 (defn- add-core-ns [amap]
   (let [core "clojure.core"]
     (into {}
-          (map #(let [[s f] %] 
+          (map #(let [[s f] %]
                   (if (not (or (namespace s) (special-symbol? s)))
                     [(symbol core (name s)) f]
                     %))
                amap))))
 
 (def ^:dynamic ^{:private true} *code-table*
-     (two-forms
-      (add-core-ns
-       {'def pprint-hold-first, 'defonce pprint-hold-first, 
-	'defn pprint-defn, 'defn- pprint-defn, 'defmacro pprint-defn, 'fn pprint-defn,
-        'let pprint-let, 'loop pprint-let, 'binding pprint-let,
-        'with-local-vars pprint-let, 'with-open pprint-let, 'when-let pprint-let,
-	'if-let pprint-let, 'doseq pprint-let, 'dotimes pprint-let,
-	'when-first pprint-let,
-        'if pprint-if, 'if-not pprint-if, 'when pprint-if, 'when-not pprint-if,
-        'cond pprint-cond, 'condp pprint-condp,
-        'fn* pprint-anon-func,
-        '. pprint-hold-first, '.. pprint-hold-first, '-> pprint-hold-first,
-        'locking pprint-hold-first, 'struct pprint-hold-first,
-        'struct-map pprint-hold-first, 'ns pprint-ns 
-        })))
+  (two-forms
+   (add-core-ns
+    {'def pprint-hold-first, 'defonce pprint-hold-first,
+     'defn pprint-defn, 'defn- pprint-defn, 'defmacro pprint-defn, 'fn pprint-defn,
+     'let pprint-let, 'loop pprint-let, 'binding pprint-let,
+     'with-local-vars pprint-let, 'with-open pprint-let, 'when-let pprint-let,
+     'if-let pprint-let, 'doseq pprint-let, 'dotimes pprint-let,
+     'when-first pprint-let,
+     'if pprint-if, 'if-not pprint-if, 'when pprint-if, 'when-not pprint-if,
+     'cond pprint-cond, 'condp pprint-condp,
+     'fn* pprint-anon-func,
+     '. pprint-hold-first, '.. pprint-hold-first, '-> pprint-hold-first,
+     'locking pprint-hold-first, 'struct pprint-hold-first,
+     'struct-map pprint-hold-first, 'ns pprint-ns})))
 
 (defn- pprint-code-list [alis]
-  (if-not (pprint-reader-macro alis) 
+  (if-not (pprint-reader-macro alis)
     (if-let [special-form (*code-table* (first alis))]
       (special-form alis)
       (pprint-simple-code-list alis))))
 
-(defn- pprint-code-symbol [sym] 
+(defn- pprint-code-symbol [sym]
   (if-let [arg-num (sym *symbol-map*)]
     (print arg-num)
-    (if *print-suppress-namespaces* 
+    (if *print-suppress-namespaces*
       (print (name sym))
       (pr sym))))
 
-(defmulti 
+(defmulti
   code-dispatch
   "The pretty print dispatch function for pretty printing Clojure code."
-  {:added "1.2" :arglists '[[object]]} 
+  {:added "1.2" :arglists '[[object]]}
   class)
 
 (use-method code-dispatch clojure.lang.ISeq pprint-code-list)
@@ -466,33 +463,32 @@
 
 (set-pprint-dispatch simple-dispatch)
 
-
 ;;; For testing
 (comment
 
-(with-pprint-dispatch code-dispatch 
-  (pprint 
-   '(defn cl-format 
-      "An implementation of a Common Lisp compatible format function"
-      [stream format-in & args]
-      (let [compiled-format (if (string? format-in) (compile-format format-in) format-in)
-            navigator (init-navigator args)]
-        (execute-format stream compiled-format navigator)))))
+  (with-pprint-dispatch code-dispatch
+    (pprint
+     '(defn cl-format
+        "An implementation of a Common Lisp compatible format function"
+        [stream format-in & args]
+        (let [compiled-format (if (string? format-in) (compile-format format-in) format-in)
+              navigator (init-navigator args)]
+          (execute-format stream compiled-format navigator)))))
 
-(with-pprint-dispatch code-dispatch 
-  (pprint 
-   '(defn cl-format 
-      [stream format-in & args]
-      (let [compiled-format (if (string? format-in) (compile-format format-in) format-in)
-            navigator (init-navigator args)]
-        (execute-format stream compiled-format navigator)))))
+  (with-pprint-dispatch code-dispatch
+    (pprint
+     '(defn cl-format
+        [stream format-in & args]
+        (let [compiled-format (if (string? format-in) (compile-format format-in) format-in)
+              navigator (init-navigator args)]
+          (execute-format stream compiled-format navigator)))))
 
-(with-pprint-dispatch code-dispatch 
-  (pprint
-   '(defn- -write 
-      ([this x]
+  (with-pprint-dispatch code-dispatch
+    (pprint
+     '(defn- -write
+        ([this x]
          (condp = (class x)
-           String 
+           String
            (let [s0 (write-initial-lines this x)
                  s (.replaceFirst s0 "\\s+$" "")
                  white-space (.substring s0 (count s))
@@ -507,35 +503,33 @@
            Integer
            (let [c ^Character x]
              (if (= (getf :mode) :writing)
-               (do 
+               (do
                  (write-white-space this)
                  (.col_write this x))
                (if (= c (int \newline))
                  (write-initial-lines this "\n")
                  (add-to-buffer this (make-buffer-blob (str (char c)) nil))))))))))
 
-(with-pprint-dispatch code-dispatch 
-  (pprint 
-   '(defn pprint-defn [writer alis]
-      (if (next alis) 
-        (let [[defn-sym defn-name & stuff] alis
-              [doc-str stuff] (if (string? (first stuff))
-                                [(first stuff) (next stuff)]
-                                [nil stuff])
-              [attr-map stuff] (if (map? (first stuff))
-                                 [(first stuff) (next stuff)]
-                                 [nil stuff])]
-          (pprint-logical-block writer :prefix "(" :suffix ")"
-                                (cl-format true "~w ~1I~@_~w" defn-sym defn-name)
-                                (if doc-str
-                                  (cl-format true " ~_~w" doc-str))
-                                (if attr-map
-                                  (cl-format true " ~_~w" attr-map))
+  (with-pprint-dispatch code-dispatch
+    (pprint
+     '(defn pprint-defn [writer alis]
+        (if (next alis)
+          (let [[defn-sym defn-name & stuff] alis
+                [doc-str stuff] (if (string? (first stuff))
+                                  [(first stuff) (next stuff)]
+                                  [nil stuff])
+                [attr-map stuff] (if (map? (first stuff))
+                                   [(first stuff) (next stuff)]
+                                   [nil stuff])]
+            (pprint-logical-block writer :prefix "(" :suffix ")"
+                                  (cl-format true "~w ~1I~@_~w" defn-sym defn-name)
+                                  (if doc-str
+                                    (cl-format true " ~_~w" doc-str))
+                                  (if attr-map
+                                    (cl-format true " ~_~w" attr-map))
                                 ;; Note: the multi-defn case will work OK for malformed defns too
-                                (cond
-                                  (vector? (first stuff)) (single-defn stuff (or doc-str attr-map))
-                                  :else (multi-defn stuff (or doc-str attr-map)))))
-        (pprint-simple-code-list writer alis)))))
-)
+                                  (cond
+                                    (vector? (first stuff)) (single-defn stuff (or doc-str attr-map))
+                                    :else (multi-defn stuff (or doc-str attr-map)))))
+          (pprint-simple-code-list writer alis))))))
 nil
-

--- a/src/clj/clojure/pprint/pprint_base.clj
+++ b/src/clj/clojure/pprint/pprint_base.clj
@@ -1,12 +1,12 @@
 ;;; pprint_base.clj -- part of the pretty printer for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -28,77 +28,75 @@
 
 
 (def ^:dynamic
- ^{:doc "Bind to true if you want write to use pretty printing", :added "1.2"}
- *print-pretty* true)
+  ^{:doc "Bind to true if you want write to use pretty printing", :added "1.2"}
+  *print-pretty* true)
 
 (defonce ^:dynamic ; If folks have added stuff here, don't overwrite
- ^{:doc "The pretty print dispatch function. Use with-pprint-dispatch or set-pprint-dispatch
+  ^{:doc "The pretty print dispatch function. Use with-pprint-dispatch or set-pprint-dispatch
 to modify.",
-   :added "1.2"}
- *print-pprint-dispatch* nil)
+    :added "1.2"}
+  *print-pprint-dispatch* nil)
 
 (def ^:dynamic
- ^{:doc "Pretty printing will try to avoid anything going beyond this column.
-Set it to nil to have pprint let the line be arbitrarily long. This will ignore all 
+  ^{:doc "Pretty printing will try to avoid anything going beyond this column.
+Set it to nil to have pprint let the line be arbitrarily long. This will ignore all
 non-mandatory newlines.",
-   :added "1.2"}
- *print-right-margin* 72)
+    :added "1.2"}
+  *print-right-margin* 72)
 
 (def ^:dynamic
- ^{:doc "The column at which to enter miser style. Depending on the dispatch table, 
-miser style add newlines in more places to try to keep lines short allowing for further 
+  ^{:doc "The column at which to enter miser style. Depending on the dispatch table,
+miser style add newlines in more places to try to keep lines short allowing for further
 levels of nesting.",
-   :added "1.2"}
- *print-miser-width* 40)
+    :added "1.2"}
+  *print-miser-width* 40)
 
 ;;; TODO implement output limiting
 (def ^:dynamic
- ^{:private true,
-   :doc "Maximum number of lines to print in a pretty print instance (N.B. This is not yet used)"}
- *print-lines* nil)
+  ^{:private true,
+    :doc "Maximum number of lines to print in a pretty print instance (N.B. This is not yet used)"}
+  *print-lines* nil)
 
 ;;; TODO: implement circle and shared
 (def ^:dynamic
- ^{:private true,
-   :doc "Mark circular structures (N.B. This is not yet used)"}
- *print-circle* nil)
+  ^{:private true,
+    :doc "Mark circular structures (N.B. This is not yet used)"}
+  *print-circle* nil)
 
 ;;; TODO: should we just use *print-dup* here?
 (def ^:dynamic
- ^{:private true,
-   :doc "Mark repeated structures rather than repeat them (N.B. This is not yet used)"}
- *print-shared* nil)
+  ^{:private true,
+    :doc "Mark repeated structures rather than repeat them (N.B. This is not yet used)"}
+  *print-shared* nil)
 
 (def ^:dynamic
- ^{:doc "Don't print namespaces with symbols. This is particularly useful when 
+  ^{:doc "Don't print namespaces with symbols. This is particularly useful when
 pretty printing the results of macro expansions"
-   :added "1.2"}
- *print-suppress-namespaces* nil)
+    :added "1.2"}
+  *print-suppress-namespaces* nil)
 
 ;;; TODO: support print-base and print-radix in cl-format
 ;;; TODO: support print-base and print-radix in rationals
 (def ^:dynamic
- ^{:doc "Print a radix specifier in front of integers and rationals. If *print-base* is 2, 8, 
-or 16, then the radix specifier used is #b, #o, or #x, respectively. Otherwise the 
+  ^{:doc "Print a radix specifier in front of integers and rationals. If *print-base* is 2, 8,
+or 16, then the radix specifier used is #b, #o, or #x, respectively. Otherwise the
 radix specifier is in the form #XXr where XX is the decimal value of *print-base* "
-   :added "1.2"}
- *print-radix* nil)
+    :added "1.2"}
+  *print-radix* nil)
 
 (def ^:dynamic
- ^{:doc "The base to use for printing integers and rationals."
-   :added "1.2"}
- *print-base* 10)
-
-
+  ^{:doc "The base to use for printing integers and rationals."
+    :added "1.2"}
+  *print-base* 10)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Internal variables that keep track of where we are in the 
+;; Internal variables that keep track of where we are in the
 ;; structure
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def  ^:dynamic ^{ :private true } *current-level* 0)
+(def  ^:dynamic ^{:private true} *current-level* 0)
 
-(def ^:dynamic ^{ :private true } *current-length* nil)
+(def ^:dynamic ^{:private true} *current-length* nil)
 
 ;; TODO: add variables for length, lines.
 
@@ -116,43 +114,42 @@ radix specifier is in the form #XXr where XX is the decimal value of *print-base
     (orig-pr x)))
 
 (def ^{:private true} write-option-table
-     {;:array            *print-array*
-      :base             'clojure.pprint/*print-base*,
+  {;:array            *print-array*
+   :base             'clojure.pprint/*print-base*,
       ;;:case             *print-case*,
-      :circle           'clojure.pprint/*print-circle*,
+   :circle           'clojure.pprint/*print-circle*,
       ;;:escape           *print-escape*,
       ;;:gensym           *print-gensym*,
-      :length           'clojure.core/*print-length*,
-      :level            'clojure.core/*print-level*,
-      :lines            'clojure.pprint/*print-lines*,
-      :miser-width      'clojure.pprint/*print-miser-width*,
-      :dispatch         'clojure.pprint/*print-pprint-dispatch*,
-      :pretty           'clojure.pprint/*print-pretty*,
-      :radix            'clojure.pprint/*print-radix*,
-      :readably         'clojure.core/*print-readably*,
-      :right-margin     'clojure.pprint/*print-right-margin*,
-      :suppress-namespaces 'clojure.pprint/*print-suppress-namespaces*})
-
+   :length           'clojure.core/*print-length*,
+   :level            'clojure.core/*print-level*,
+   :lines            'clojure.pprint/*print-lines*,
+   :miser-width      'clojure.pprint/*print-miser-width*,
+   :dispatch         'clojure.pprint/*print-pprint-dispatch*,
+   :pretty           'clojure.pprint/*print-pretty*,
+   :radix            'clojure.pprint/*print-radix*,
+   :readably         'clojure.core/*print-readably*,
+   :right-margin     'clojure.pprint/*print-right-margin*,
+   :suppress-namespaces 'clojure.pprint/*print-suppress-namespaces*})
 
 (defmacro ^{:private true} binding-map [amap & body]
   (let []
     `(do
        (. clojure.lang.Var (pushThreadBindings ~amap))
        (try
-        ~@body
-        (finally
-         (. clojure.lang.Var (popThreadBindings)))))))
+         ~@body
+         (finally
+           (. clojure.lang.Var (popThreadBindings)))))))
 
-(defn- table-ize [t m] 
-  (apply hash-map (mapcat 
-                   #(when-let [v (get t (key %))] [(find-var v) (val %)]) 
+(defn- table-ize [t m]
+  (apply hash-map (mapcat
+                   #(when-let [v (get t (key %))] [(find-var v) (val %)])
                    m)))
 
-(defn- pretty-writer? 
+(defn- pretty-writer?
   "Return true iff x is a PrettyWriter"
   [x] (and (instance? clojure.lang.IDeref x) (:pretty-writer @@x)))
 
-(defn- make-pretty-writer 
+(defn- make-pretty-writer
   "Wrap base-writer in a PrettyWriter with the specified right-margin and miser-width"
   [base-writer right-margin miser-width]
   (pretty-writer base-writer right-margin miser-width))
@@ -161,27 +158,26 @@ radix specifier is in the form #XXr where XX is the decimal value of *print-base
   `(let [base-writer# ~base-writer
          new-writer# (not (pretty-writer? base-writer#))]
      (binding [*out* (if new-writer#
-                      (make-pretty-writer base-writer# *print-right-margin* *print-miser-width*)
-                      base-writer#)]
+                       (make-pretty-writer base-writer# *print-right-margin* *print-miser-width*)
+                       base-writer#)]
        ~@body
        (.ppflush ^PrettyFlush *out*))))
 
-
 ;;;TODO: if pretty print is not set, don't use pr but rather something that respects *print-base*, etc.
-(defn write-out 
-  "Write an object to *out* subject to the current bindings of the printer control 
-variables. Use the kw-args argument to override individual variables for this call (and 
+(defn write-out
+  "Write an object to *out* subject to the current bindings of the printer control
+variables. Use the kw-args argument to override individual variables for this call (and
 any recursive calls).
 
 *out* must be a PrettyWriter if pretty printing is enabled. This is the responsibility
 of the caller.
 
-This method is primarily intended for use by pretty print dispatch functions that 
+This method is primarily intended for use by pretty print dispatch functions that
 already know that the pretty printer will have set up their environment appropriately.
 Normal library clients should use the standard \"write\" interface. "
   {:added "1.2"}
   [object]
-  (let [length-reached (and 
+  (let [length-reached (and
                         *current-length*
                         *print-length*
                         (>= *current-length* *print-length*))]
@@ -194,9 +190,9 @@ Normal library clients should use the standard \"write\" interface. "
           (*print-pprint-dispatch* object))))
     length-reached))
 
-(defn write 
+(defn write
   "Write an object subject to the current bindings of the printer control variables.
-Use the kw-args argument to override individual variables for this call (and any 
+Use the kw-args argument to override individual variables for this call (and any
 recursive calls). Returns the string result if :stream is nil or nil otherwise.
 
 The following keyword arguments can be passed with values:
@@ -220,49 +216,48 @@ The following keyword arguments can be passed with values:
   {:added "1.2"}
   [object & kw-args]
   (let [options (merge {:stream true} (apply hash-map kw-args))]
-    (binding-map (table-ize write-option-table options) 
-      (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {}) 
-        (let [optval (if (contains? options :stream) 
-                       (:stream options)
-                       true) 
-              base-writer (condp = optval
-                            nil (java.io.StringWriter.)
-                            true *out*
-                            optval)]
-          (if *print-pretty*
-            (with-pretty-writer base-writer
-              (write-out object))
-            (binding [*out* base-writer]
-              (pr object)))
-          (if (nil? optval) 
-            (.toString ^java.io.StringWriter base-writer)))))))
+    (binding-map (table-ize write-option-table options)
+                 (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {})
+                              (let [optval (if (contains? options :stream)
+                                             (:stream options)
+                                             true)
+                                    base-writer (condp = optval
+                                                  nil (java.io.StringWriter.)
+                                                  true *out*
+                                                  optval)]
+                                (if *print-pretty*
+                                  (with-pretty-writer base-writer
+                                    (write-out object))
+                                  (binding [*out* base-writer]
+                                    (pr object)))
+                                (if (nil? optval)
+                                  (.toString ^java.io.StringWriter base-writer)))))))
 
-
-(defn pprint 
-  "Pretty print object to the optional output writer. If the writer is not provided, 
+(defn pprint
+  "Pretty print object to the optional output writer. If the writer is not provided,
 print the object to the currently bound value of *out*."
   {:added "1.2"}
-  ([object] (pprint object *out*)) 
+  ([object] (pprint object *out*))
   ([object writer]
-     (with-pretty-writer writer
-       (binding [*print-pretty* true]
-         (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {}) 
-           (write-out object)))
-       (if (not (= 0 (get-column *out*)))
-         (prn)))))
+   (with-pretty-writer writer
+     (binding [*print-pretty* true]
+       (binding-map (if (or (not (= *print-base* 10)) *print-radix*) {#'pr pr-with-base} {})
+                    (write-out object)))
+     (if (not (= 0 (get-column *out*)))
+       (prn)))))
 
-(defmacro pp 
+(defmacro pp
   "A convenience macro that pretty prints the last thing output. This is
 exactly equivalent to (pprint *1)."
   {:added "1.2"}
   [] `(pprint *1))
 
-(defn set-pprint-dispatch  
+(defn set-pprint-dispatch
   "Set the pretty print dispatch function to a function matching (fn [obj] ...)
 where obj is the object to pretty print. That function will be called with *out* set
 to a pretty printing writer to which it should do its printing.
 
-For example functions, see simple-dispatch and code-dispatch in 
+For example functions, see simple-dispatch and code-dispatch in
 clojure.pprint.dispatch.clj."
   {:added "1.2"}
   [function]
@@ -271,7 +266,7 @@ clojure.pprint.dispatch.clj."
     (alter-meta! #'*print-pprint-dispatch* (constantly old-meta)))
   nil)
 
-(defmacro with-pprint-dispatch 
+(defmacro with-pprint-dispatch
   "Execute body with the pretty print dispatch function bound to function."
   {:added "1.2"}
   [function & body]
@@ -291,71 +286,71 @@ clojure.pprint.dispatch.clj."
 
 (defn- check-enumerated-arg [arg choices]
   (if-not (choices arg)
-          (throw
-           (IllegalArgumentException.
+    (throw
+     (IllegalArgumentException.
             ;; TODO clean up choices string
-            (str "Bad argument: " arg ". It must be one of " choices)))))
+      (str "Bad argument: " arg ". It must be one of " choices)))))
 
 (defn- level-exceeded []
   (and *print-level* (>= *current-level* *print-level*)))
 
-(defmacro pprint-logical-block 
-  "Execute the body as a pretty printing logical block with output to *out* which 
-must be a pretty printing writer. When used from pprint or cl-format, this can be 
-assumed. 
+(defmacro pprint-logical-block
+  "Execute the body as a pretty printing logical block with output to *out* which
+must be a pretty printing writer. When used from pprint or cl-format, this can be
+assumed.
 
 This function is intended for use when writing custom dispatch functions.
 
-Before the body, the caller can optionally specify options: :prefix, :per-line-prefix, 
+Before the body, the caller can optionally specify options: :prefix, :per-line-prefix,
 and :suffix."
   {:added "1.2", :arglists '[[options* body]]}
   [& args]
   (let [[options body] (parse-lb-options #{:prefix :per-line-prefix :suffix} args)]
-    `(do (if (#'clojure.pprint/level-exceeded) 
+    `(do (if (#'clojure.pprint/level-exceeded)
            (.write ^java.io.Writer *out* "#")
-           (do 
+           (do
              (push-thread-bindings {#'clojure.pprint/*current-level*
                                     (inc (var-get #'clojure.pprint/*current-level*))
                                     #'clojure.pprint/*current-length* 0})
-             (try  
-              (#'clojure.pprint/start-block *out*
-                           ~(:prefix options) ~(:per-line-prefix options) ~(:suffix options))
-              ~@body
-              (#'clojure.pprint/end-block *out*)
-              (finally 
-               (pop-thread-bindings)))))
+             (try
+               (#'clojure.pprint/start-block *out*
+                                             ~(:prefix options) ~(:per-line-prefix options) ~(:suffix options))
+               ~@body
+               (#'clojure.pprint/end-block *out*)
+               (finally
+                 (pop-thread-bindings)))))
          nil)))
 
 (defn pprint-newline
-  "Print a conditional newline to a pretty printing stream. kind specifies if the 
-newline is :linear, :miser, :fill, or :mandatory. 
+  "Print a conditional newline to a pretty printing stream. kind specifies if the
+newline is :linear, :miser, :fill, or :mandatory.
 
 This function is intended for use when writing custom dispatch functions.
 
 Output is sent to *out* which must be a pretty printing writer."
   {:added "1.2"}
-  [kind] 
+  [kind]
   (check-enumerated-arg kind #{:linear :miser :fill :mandatory})
   (nl *out* kind))
 
-(defn pprint-indent 
-  "Create an indent at this point in the pretty printing stream. This defines how 
-following lines are indented. relative-to can be either :block or :current depending 
+(defn pprint-indent
+  "Create an indent at this point in the pretty printing stream. This defines how
+following lines are indented. relative-to can be either :block or :current depending
 whether the indent should be computed relative to the start of the logical block or
-the current column position. n is an offset. 
+the current column position. n is an offset.
 
 This function is intended for use when writing custom dispatch functions.
 
 Output is sent to *out* which must be a pretty printing writer."
   {:added "1.2"}
-  [relative-to n] 
+  [relative-to n]
   (check-enumerated-arg relative-to #{:block :current})
   (indent *out* relative-to n))
 
 ;; TODO a real implementation for pprint-tab
-(defn pprint-tab 
+(defn pprint-tab
   "Tab at this point in the pretty printing stream. kind specifies whether the tab
-is :line, :section, :line-relative, or :section-relative. 
+is :line, :section, :line-relative, or :section-relative.
 
 Colnum and colinc specify the target column and the increment to move the target
 forward if the output is already past the original target.
@@ -366,10 +361,9 @@ Output is sent to *out* which must be a pretty printing writer.
 
 THIS FUNCTION IS NOT YET IMPLEMENTED."
   {:added "1.2"}
-  [kind colnum colinc] 
+  [kind colnum colinc]
   (check-enumerated-arg kind #{:line :section :line-relative :section-relative})
   (throw (UnsupportedOperationException. "pprint-tab is not yet implemented")))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -379,17 +373,17 @@ THIS FUNCTION IS NOT YET IMPLEMENTED."
 
 (defn- pll-mod-body [var-sym body]
   (letfn [(inner [form]
-                 (if (seq? form)
-                   (let [form (macroexpand form)] 
-                     (condp = (first form)
-                       'loop* form
-                       'recur (concat `(recur (inc ~var-sym)) (rest form))
-                       (walk inner identity form)))
-                   form))]
+            (if (seq? form)
+              (let [form (macroexpand form)]
+                (condp = (first form)
+                  'loop* form
+                  'recur (concat `(recur (inc ~var-sym)) (rest form))
+                  (walk inner identity form)))
+              form))]
     (walk inner identity body)))
 
 (defmacro print-length-loop
-  "A version of loop that iterates at most *print-length* times. This is designed 
+  "A version of loop that iterates at most *print-length* times. This is designed
 for use in pretty-printer dispatch functions."
   {:added "1.3"}
   [bindings & body]

--- a/src/clj/clojure/pprint/print_table.clj
+++ b/src/clj/clojure/pprint/print_table.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (in-ns 'clojure.pprint)
 
@@ -14,22 +14,22 @@
    in ks. If ks are not specified, use the keys of the first item in rows."
   {:added "1.3"}
   ([ks rows]
-     (when (seq rows)
-       (let [widths (map
-                     (fn [k]
-                       (apply max (count (str k)) (map #(count (str (get % k))) rows)))
-                     ks)
-             spacers (map #(apply str (repeat % "-")) widths)
-             fmts (map #(str "%" % "s") widths)
-             fmt-row (fn [leader divider trailer row]
-                       (str leader
-                            (apply str (interpose divider
-                                                  (for [[col fmt] (map vector (map #(get row %) ks) fmts)]
-                                                    (format fmt (str col)))))
-                            trailer))]
-         (println)
-         (println (fmt-row "| " " | " " |" (zipmap ks ks)))
-         (println (fmt-row "|-" "-+-" "-|" (zipmap ks spacers)))
-         (doseq [row rows]
-           (println (fmt-row "| " " | " " |" row))))))
+   (when (seq rows)
+     (let [widths (map
+                   (fn [k]
+                     (apply max (count (str k)) (map #(count (str (get % k))) rows)))
+                   ks)
+           spacers (map #(apply str (repeat % "-")) widths)
+           fmts (map #(str "%" % "s") widths)
+           fmt-row (fn [leader divider trailer row]
+                     (str leader
+                          (apply str (interpose divider
+                                                (for [[col fmt] (map vector (map #(get row %) ks) fmts)]
+                                                  (format fmt (str col)))))
+                          trailer))]
+       (println)
+       (println (fmt-row "| " " | " " |" (zipmap ks ks)))
+       (println (fmt-row "|-" "-+-" "-|" (zipmap ks spacers)))
+       (doseq [row rows]
+         (println (fmt-row "| " " | " " |" row))))))
   ([rows] (print-table (keys (first rows)) rows)))

--- a/src/clj/clojure/pprint/utilities.clj
+++ b/src/clj/clojure/pprint/utilities.clj
@@ -1,12 +1,12 @@
 ;;; utilities.clj -- part of the pretty printer for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -29,10 +29,10 @@
          acc []]
     (if (empty? lis)
       [acc context]
-    (let [this (first lis)
-          remainder (next lis)
-          [result new-context] (apply func [this context])]
-      (recur new-context remainder (conj acc result))))))
+      (let [this (first lis)
+            remainder (next lis)
+            [result new-context] (apply func [this context])]
+        (recur new-context remainder (conj acc result))))))
 
 (defn- consume [func initial-context]
   (loop [context initial-context
@@ -40,7 +40,7 @@
     (let [[result new-context] (apply func [context])]
       (if (not result)
         [acc new-context]
-      (recur new-context (conj acc result))))))
+        (recur new-context (conj acc result))))))
 
 (defn- consume-while [func initial-context]
   (loop [context initial-context
@@ -48,11 +48,11 @@
     (let [[result continue new-context] (apply func [context])]
       (if (not continue)
         [acc context]
-      (recur new-context (conj acc result))))))
+        (recur new-context (conj acc result))))))
 
 (defn- unzip-map [m]
-  "Take a  map that has pairs in the value slots and produce a pair of maps, 
-   the first having all the first elements of the pairs and the second all 
+  "Take a  map that has pairs in the value slots and produce a pair of maps,
+   the first having all the first elements of the pairs and the second all
    the second elements of the pairs"
   [(into {} (for [[k [v1 v2]] m] [k v1]))
    (into {} (for [[k [v1 v2]] m] [k v2]))])
@@ -66,10 +66,10 @@
   (let [len (count s)]
     (if (and (pos? len) (= (nth s (dec (count s))) c))
       (loop [n (dec len)]
-        (cond 
-         (neg? n) ""
-         (not (= (nth s n) c)) (subs s 0 (inc n))
-         true (recur (dec n))))
+        (cond
+          (neg? n) ""
+          (not (= (nth s n) c)) (subs s 0 (inc n))
+          true (recur (dec n))))
       s)))
 
 (defn- ltrim [s c]
@@ -83,24 +83,24 @@
       s)))
 
 (defn- prefix-count [aseq val]
-  "Return the number of times that val occurs at the start of sequence aseq, 
+  "Return the number of times that val occurs at the start of sequence aseq,
 if val is a seq itself, count the number of times any element of val occurs at the
 beginning of aseq"
   (let [test (if (coll? val) (set val) #{val})]
     (loop [pos 0]
-     (if (or (= pos (count aseq)) (not (test (nth aseq pos))))
-       pos
-       (recur (inc pos))))))
+      (if (or (= pos (count aseq)) (not (test (nth aseq pos))))
+        pos
+        (recur (inc pos))))))
 
 (defn- prerr [& args]
   "Println to *err*"
   (binding [*out* *err*]
     (apply println args)))
-       
+
 (defmacro ^{:private true} prlabel [prefix arg & more-args]
   "Print args to *err* in name = value format"
-  `(prerr ~@(cons (list 'quote prefix) (mapcat #(list (list 'quote %) "=" %) 
-                                                  (cons arg (seq more-args))))))
+  `(prerr ~@(cons (list 'quote prefix) (mapcat #(list (list 'quote %) "=" %)
+                                               (cons arg (seq more-args))))))
 
 ;; Flush the pretty-print buffer without flushing the underlying stream
 (definterface PrettyFlush

--- a/src/clj/clojure/reflect.clj
+++ b/src/clj/clojure/reflect.clj
@@ -1,17 +1,17 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:author "Stuart Halloway"
       :added "1.3"
       :doc "Reflection on Host Types
 Alpha - subject to change.
 
-Two main entry points: 
+Two main entry points:
 
 * type-reflect reflects on something that implements TypeReference.
 * reflect (for REPL use) reflects on the class of an instance, or
@@ -38,7 +38,7 @@ Platform implementers must:
 * Create an implementation of Reflector.
 * Create one or more implementations of TypeReference.
 * def default-reflector to be an instance that satisfies Reflector."}
-  clojure.reflect
+ clojure.reflect
   (:require [clojure.set :as set]))
 
 (defprotocol Reflector
@@ -67,7 +67,7 @@ Platform implementers must:
                      and can be a constructor, method, or field.
 
    Keys common to all members:
-   :name             name of the type 
+   :name             name of the type
    :declaring-class  name of the declarer
    :flags            keyword naming boolean attributes of the member
 
@@ -101,11 +101,11 @@ Platform implementers must:
     ;; could make simpler loop of two args: names an
     (if ancestors
       (let [make-ancestor-map (fn [names]
-                            (zipmap names (map refl names)))]
+                                (zipmap names (map refl names)))]
         (loop [reflections (make-ancestor-map (:bases result))]
           (let [ancestors-visited (set (keys reflections))
                 ancestors-to-visit (set/difference (set (mapcat :bases (vals reflections)))
-                                               ancestors-visited)]
+                                                   ancestors-visited)]
             (if (seq ancestors-to-visit)
               (recur (merge reflections (make-ancestor-map ancestors-to-visit)))
               (apply merge-with into result {:ancestors ancestors-visited}

--- a/src/clj/clojure/reflect/java.clj
+++ b/src/clj/clojure/reflect/java.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Java-specific parts of clojure.reflect
 (in-ns 'clojure.reflect)
@@ -12,23 +12,23 @@
 (require '[clojure.set :as set]
          '[clojure.string :as str])
 (import '[clojure.asm ClassReader ClassVisitor Type Opcodes]
-         '[java.lang.reflect Modifier]
-         java.io.InputStream)
+        '[java.lang.reflect Modifier]
+        java.io.InputStream)
 
 (extend-protocol TypeReference
   clojure.lang.Symbol
   (typename [s] (str/replace (str s) "<>" "[]"))
-  
+
   Class
   ;; neither .getName not .getSimpleName returns the right thing, so best to delegate to Type
   (typename
-   [c]
-   (typename (Type/getType c)))
-  
+    [c]
+    (typename (Type/getType c)))
+
   Type
   (typename
-   [t]
-   (-> (.getClassName t))))
+    [t]
+    (-> (.getClassName t))))
 
 (defn- typesym
   "Given a typeref, create a legal Clojure symbol version of the
@@ -80,7 +80,7 @@ the kinds of objects to which they can apply."}
          [:final 0x0010  :class :field :method]
          ;; :super is ancient history and is unfindable (?) by
          ;; reflection. skip it
-         #_[:super 0x0020  :class]        
+         #_[:super 0x0020  :class]
          [:synchronized 0x0020  :method]
          [:volatile 0x0040  :field]
          [:bridge 0x0040  :method]
@@ -107,7 +107,7 @@ the kinds of objects to which they can apply."}
    flag-descriptors))
 
 (defrecord Constructor
-  [name declaring-class parameter-types exception-types flags])
+           [name declaring-class parameter-types exception-types flags])
 
 (defn- constructor->map
   [^java.lang.reflect.Constructor constructor]
@@ -126,7 +126,7 @@ the kinds of objects to which they can apply."}
         (.getDeclaredConstructors cls))))
 
 (defrecord Method
-  [name return-type declaring-class parameter-types exception-types flags])
+           [name return-type declaring-class parameter-types exception-types flags])
 
 (defn- method->map
   [^java.lang.reflect.Method method]
@@ -146,7 +146,7 @@ the kinds of objects to which they can apply."}
         (.getDeclaredMethods cls))))
 
 (defrecord Field
-  [name type declaring-class flags])
+           [name type declaring-class flags])
 
 (defn- field->map
   [^java.lang.reflect.Field field]
@@ -166,15 +166,15 @@ the kinds of objects to which they can apply."}
 (deftype JavaReflector [classloader]
   Reflector
   (do-reflect [_ typeref]
-           (let [cls (clojure.lang.RT/classForName (typename typeref) false classloader)]
-             {:bases (not-empty (set (map typesym (bases cls))))
-              :flags (parse-flags (.getModifiers cls) :class)
-              :members (set/union (declared-fields cls)
-                                  (declared-methods cls)
-                                  (declared-constructors cls))})))
+    (let [cls (clojure.lang.RT/classForName (typename typeref) false classloader)]
+      {:bases (not-empty (set (map typesym (bases cls))))
+       :flags (parse-flags (.getModifiers cls) :class)
+       :members (set/union (declared-fields cls)
+                           (declared-methods cls)
+                           (declared-constructors cls))})))
 
 (def ^:private default-reflector
-     (JavaReflector. (.getContextClassLoader (Thread/currentThread))))
+  (JavaReflector. (.getContextClassLoader (Thread/currentThread))))
 
 (defn- parse-method-descriptor
   [^String md]
@@ -183,15 +183,15 @@ the kinds of objects to which they can apply."}
 
 (defprotocol ClassResolver
   (^InputStream resolve-class [this name]
-                "Given a class name, return that typeref's class bytes as an InputStream."))
+    "Given a class name, return that typeref's class bytes as an InputStream."))
 
 (extend-protocol ClassResolver
   clojure.lang.Fn
   (resolve-class [this typeref] (this typeref))
-  
+
   ClassLoader
   (resolve-class [this typeref]
-                 (.getResourceAsStream this (resource-name typeref))))
+    (.getResourceAsStream this (resource-name typeref))))
 
 (deftype AsmReflector [class-resolver]
   Reflector
@@ -205,51 +205,50 @@ the kinds of objects to which they can apply."}
          (proxy
           [ClassVisitor]
           [Opcodes/ASM4]
-          (visit [version access name signature superName interfaces]
-                 (let [flags (parse-flags access :class)
+           (visit [version access name signature superName interfaces]
+             (let [flags (parse-flags access :class)
                        ;; ignore java.lang.Object on interfaces to match reflection
-                       superName (if (and (flags :interface)
-                                          (= superName "java/lang/Object"))
-                                   nil
-                                   superName)
-                       bases (->> (cons superName interfaces)
-                                  (remove nil?)
-                                  (map internal-name->class-symbol)
-                                  (map symbol)
-                                  (set)
-                                  (not-empty))]
-                   (swap! result merge {:bases bases 
-                                        :flags flags})))
-          (visitAnnotation [desc visible])
-          (visitSource [name debug])
-          (visitInnerClass [name outerName innerName access])
-          (visitField [access name desc signature value]
-                      (swap! result update :members (fnil conj #{})
-                             (Field. (symbol name)
-                                     (field-descriptor->class-symbol desc)
+                   superName (if (and (flags :interface)
+                                      (= superName "java/lang/Object"))
+                               nil
+                               superName)
+                   bases (->> (cons superName interfaces)
+                              (remove nil?)
+                              (map internal-name->class-symbol)
+                              (map symbol)
+                              (set)
+                              (not-empty))]
+               (swap! result merge {:bases bases
+                                    :flags flags})))
+           (visitAnnotation [desc visible])
+           (visitSource [name debug])
+           (visitInnerClass [name outerName innerName access])
+           (visitField [access name desc signature value]
+             (swap! result update :members (fnil conj #{})
+                    (Field. (symbol name)
+                            (field-descriptor->class-symbol desc)
+                            class-symbol
+                            (parse-flags access :field)))
+             nil)
+           (visitMethod [access name desc signature exceptions]
+             (when-not (= name "<clinit>")
+               (let [constructor? (= name "<init>")]
+                 (swap! result update :members (fnil conj #{})
+                        (let [{:keys [parameter-types return-type]} (parse-method-descriptor desc)
+                              flags (parse-flags access :method)]
+                          (if constructor?
+                            (Constructor. class-symbol
+                                          class-symbol
+                                          parameter-types
+                                          (vec (map internal-name->class-symbol exceptions))
+                                          flags)
+                            (Method. (symbol name)
+                                     return-type
                                      class-symbol
-                                     (parse-flags access :field)))
-                      nil)
-          (visitMethod [access name desc signature exceptions]
-                       (when-not (= name "<clinit>")
-                         (let [constructor? (= name "<init>")]
-                           (swap! result update :members (fnil conj #{})
-                                  (let [{:keys [parameter-types return-type]} (parse-method-descriptor desc)
-                                        flags (parse-flags access :method)]
-                                    (if constructor?
-                                      (Constructor. class-symbol
-                                                    class-symbol
-                                                    parameter-types
-                                                    (vec (map internal-name->class-symbol exceptions))
-                                                    flags)
-                                      (Method. (symbol name)
-                                               return-type
-                                               class-symbol
-                                               parameter-types
-                                               (vec (map internal-name->class-symbol exceptions))
-                                               flags))))))
-                       nil)
-          (visitEnd [])
-          ) 0)
+                                     parameter-types
+                                     (vec (map internal-name->class-symbol exceptions))
+                                     flags))))))
+             nil)
+           (visitEnd [])) 0)
         @result))))
 

--- a/src/clj/clojure/repl.clj
+++ b/src/clj/clojure/repl.clj
@@ -1,17 +1,17 @@
-;   Copyright (c) Chris Houser, Dec 2008. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Common Public License 1.0 (http://opensource.org/licenses/cpl.php)
-;   which can be found in the file CPL.TXT at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Chris Houser, Dec 2008. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Common Public License 1.0 (http://opensource.org/licenses/cpl.php)
+;;    which can be found in the file CPL.TXT at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Utilities meant to be used interactively at the REPL
+;; Utilities meant to be used interactively at the REPL
 
 (ns
-  ^{:author "Chris Houser, Christophe Grand, Stephen Gilardi, Michel Salim"
-    :doc "Utilities meant to be used interactively at the REPL"}
-  clojure.repl
+ ^{:author "Chris Houser, Christophe Grand, Stephen Gilardi, Michel Salim"
+   :doc "Utilities meant to be used interactively at the REPL"}
+ clojure.repl
   (:import (java.io LineNumberReader InputStreamReader PushbackReader)
            (clojure.lang RT Reflector)))
 
@@ -53,9 +53,9 @@
            :doc "Evaluates the exprs in order, then, in parallel, rebinds
   the bindings of the recursion point to the values of the exprs.
   Execution then jumps back to the recursion point, a loop or fn method."}
-    set! {:forms[(set! var-symbol expr)
-                 (set! (. instance-expr instanceFieldName-symbol) expr)
-                 (set! (. Classname-symbol staticFieldName-symbol) expr)]
+    set! {:forms [(set! var-symbol expr)
+                  (set! (. instance-expr instanceFieldName-symbol) expr)
+                  (set! (. Classname-symbol staticFieldName-symbol) expr)]
           :url "vars#set"
           :doc "Used to set thread-local-bound vars, Java object instance
 fields, and Java class static fields."}
@@ -90,7 +90,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x)."}})
   (if (:special-form m)
     (do
       (println "Special Form")
-      (println " " (:doc m)) 
+      (println " " (:doc m))
       (if (contains? m :url)
         (when (:url m)
           (println (str "\n  Please see http://clojure.org/" (:url m))))
@@ -98,7 +98,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x)."}})
                       (:name m)))))
     (do
       (when (:macro m)
-        (println "Macro")) 
+        (println "Macro"))
       (println " " (:doc m)))))
 
 (defn find-doc
@@ -106,16 +106,16 @@ itself (not its value) is returned. The reader macro #'x expands to (var x)."}})
  contains a match for re-string-or-pattern"
   {:added "1.0"}
   [re-string-or-pattern]
-    (let [re (re-pattern re-string-or-pattern)
-          ms (concat (mapcat #(sort-by :name (map meta (vals (ns-interns %))))
-                             (all-ns))
-                     (map namespace-doc (all-ns))
-                     (map special-doc (keys special-doc-map)))]
-      (doseq [m ms
-              :when (and (:doc m)
-                         (or (re-find (re-matcher re (:doc m)))
-                             (re-find (re-matcher re (str (:name m))))))]
-               (print-doc m))))
+  (let [re (re-pattern re-string-or-pattern)
+        ms (concat (mapcat #(sort-by :name (map meta (vals (ns-interns %))))
+                           (all-ns))
+                   (map namespace-doc (all-ns))
+                   (map special-doc (keys special-doc-map)))]
+    (doseq [m ms
+            :when (and (:doc m)
+                       (or (re-find (re-matcher re (:doc m)))
+                           (re-find (re-matcher re (str (:name m))))))]
+      (print-doc m))))
 
 (defmacro doc
   "Prints documentation for a var or special form given its name"
@@ -234,26 +234,26 @@ str-or-pattern."
   {:added "1.3"}
   ([] (pst 12))
   ([e-or-depth]
-     (if (instance? Throwable e-or-depth)
-       (pst e-or-depth 12)
-       (when-let [e *e]
-         (pst (root-cause e) e-or-depth))))
+   (if (instance? Throwable e-or-depth)
+     (pst e-or-depth 12)
+     (when-let [e *e]
+       (pst (root-cause e) e-or-depth))))
   ([^Throwable e depth]
-     (binding [*out* *err*]
-       (println (str (-> e class .getSimpleName) " "
-                     (.getMessage e)
-                     (when-let [info (ex-data e)] (str " " (pr-str info)))))
-       (let [st (.getStackTrace e)
-             cause (.getCause e)]
-         (doseq [el (take depth
-                          (remove #(#{"clojure.lang.RestFn" "clojure.lang.AFn"} (.getClassName %))
-                                  st))]
-           (println (str \tab (stack-element-str el))))
-         (when cause
-           (println "Caused by:")
-           (pst cause (min depth
-                           (+ 2 (- (count (.getStackTrace cause))
-                                   (count st))))))))))
+   (binding [*out* *err*]
+     (println (str (-> e class .getSimpleName) " "
+                   (.getMessage e)
+                   (when-let [info (ex-data e)] (str " " (pr-str info)))))
+     (let [st (.getStackTrace e)
+           cause (.getCause e)]
+       (doseq [el (take depth
+                        (remove #(#{"clojure.lang.RestFn" "clojure.lang.AFn"} (.getClassName %))
+                                st))]
+         (println (str \tab (stack-element-str el))))
+       (when cause
+         (println "Caused by:")
+         (pst cause (min depth
+                         (+ 2 (- (count (.getStackTrace cause))
+                                 (count st))))))))))
 
 ;; ----------------------------------------------------------------------
 ;; Handle Ctrl-C keystrokes
@@ -271,7 +271,7 @@ str-or-pattern."
   ([] (set-break-handler! (thread-stopper)))
   ([f]
    (sun.misc.Signal/handle
-     (sun.misc.Signal. "INT")
-     (proxy [sun.misc.SignalHandler] []
-       (handle [signal]
-         (f (str "-- caught signal " signal)))))))
+    (sun.misc.Signal. "INT")
+    (proxy [sun.misc.SignalHandler] []
+      (handle [signal]
+        (f (str "-- caught signal " signal)))))))

--- a/src/clj/clojure/set.clj
+++ b/src/clj/clojure/set.clj
@@ -1,17 +1,17 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "Set operations such as union/intersection."
-       :author "Rich Hickey"}
-       clojure.set)
+      :author "Rich Hickey"}
+ clojure.set)
 
 (defn- bubble-max-key [k coll]
-  "Move a maximal element of coll according to fn k (which returns a number) 
+  "Move a maximal element of coll according to fn k (which returns a number)
    to the front of coll."
   (let [max (apply max-key k coll)]
     (cons max (remove #(identical? max %) coll))))
@@ -22,51 +22,50 @@
   ([] #{})
   ([s1] s1)
   ([s1 s2]
-     (if (< (count s1) (count s2))
-       (reduce conj s2 s1)
-       (reduce conj s1 s2)))
+   (if (< (count s1) (count s2))
+     (reduce conj s2 s1)
+     (reduce conj s1 s2)))
   ([s1 s2 & sets]
-     (let [bubbled-sets (bubble-max-key count (conj sets s2 s1))]
-       (reduce into (first bubbled-sets) (rest bubbled-sets)))))
+   (let [bubbled-sets (bubble-max-key count (conj sets s2 s1))]
+     (reduce into (first bubbled-sets) (rest bubbled-sets)))))
 
 (defn intersection
   "Return a set that is the intersection of the input sets"
   {:added "1.0"}
   ([s1] s1)
   ([s1 s2]
-     (if (< (count s2) (count s1))
-       (recur s2 s1)
-       (reduce (fn [result item]
-                   (if (contains? s2 item)
-		     result
-                     (disj result item)))
-	       s1 s1)))
-  ([s1 s2 & sets] 
-     (let [bubbled-sets (bubble-max-key #(- (count %)) (conj sets s2 s1))]
-       (reduce intersection (first bubbled-sets) (rest bubbled-sets)))))
+   (if (< (count s2) (count s1))
+     (recur s2 s1)
+     (reduce (fn [result item]
+               (if (contains? s2 item)
+                 result
+                 (disj result item)))
+             s1 s1)))
+  ([s1 s2 & sets]
+   (let [bubbled-sets (bubble-max-key #(- (count %)) (conj sets s2 s1))]
+     (reduce intersection (first bubbled-sets) (rest bubbled-sets)))))
 
 (defn difference
   "Return a set that is the first set without elements of the remaining sets"
   {:added "1.0"}
   ([s1] s1)
-  ([s1 s2] 
-     (if (< (count s1) (count s2))
-       (reduce (fn [result item] 
-                   (if (contains? s2 item) 
-                     (disj result item) 
-                     result))
-               s1 s1)
-       (reduce disj s1 s2)))
-  ([s1 s2 & sets] 
-     (reduce difference s1 (conj sets s2))))
-
+  ([s1 s2]
+   (if (< (count s1) (count s2))
+     (reduce (fn [result item]
+               (if (contains? s2 item)
+                 (disj result item)
+                 result))
+             s1 s1)
+     (reduce disj s1 s2)))
+  ([s1 s2 & sets]
+   (reduce difference s1 (conj sets s2))))
 
 (defn select
   "Returns a set of the elements for which pred is true"
   {:added "1.0"}
   [pred xset]
-    (reduce (fn [s k] (if (pred k) s (disj s k)))
-            xset xset))
+  (reduce (fn [s k] (if (pred k) s (disj s k)))
+          xset xset))
 
 (defn project
   "Returns a rel of the elements of xrel with only the keys in ks"
@@ -78,12 +77,12 @@
   "Returns the map with the keys in kmap renamed to the vals in kmap"
   {:added "1.0"}
   [map kmap]
-    (reduce 
-     (fn [m [old new]]
-       (if (contains? map old)
-         (assoc m new (get map old))
-         m)) 
-     (apply dissoc map (keys kmap)) kmap))
+  (reduce
+   (fn [m [old new]]
+     (if (contains? map old)
+       (assoc m new (get map old))
+       m))
+   (apply dissoc map (keys kmap)) kmap))
 
 (defn rename
   "Returns a rel of the maps in xrel with the keys in kmap renamed to the vals in kmap"
@@ -96,12 +95,12 @@
   set of the maps in xrel with the corresponding values of ks."
   {:added "1.0"}
   [xrel ks]
-    (reduce
-     (fn [m x]
-       (let [ik (select-keys x ks)]
-         (assoc m ik (conj (get m ik #{}) x))))
-     {} xrel))
-   
+  (reduce
+   (fn [m x]
+     (let [ik (select-keys x ks)]
+       (assoc m ik (conj (get m ik #{}) x))))
+   {} xrel))
+
 (defn map-invert
   "Returns the map with the vals mapped to the keys."
   {:added "1.0"}
@@ -138,7 +137,7 @@
                    ret)))
              #{} s))))
 
-(defn subset? 
+(defn subset?
   "Is set1 a subset of set2?"
   {:added "1.2",
    :tag Boolean}
@@ -146,7 +145,7 @@
   (and (<= (count set1) (count set2))
        (every? #(contains? set2 %) set1)))
 
-(defn superset? 
+(defn superset?
   "Is set1 a superset of set2?"
   {:added "1.2",
    :tag Boolean}
@@ -155,22 +154,20 @@
        (every? #(contains? set1 %) set2)))
 
 (comment
-(refer 'set)
-(def xs #{{:a 11 :b 1 :c 1 :d 4}
-         {:a 2 :b 12 :c 2 :d 6}
-         {:a 3 :b 3 :c 3 :d 8 :f 42}})
+  (refer 'set)
+  (def xs #{{:a 11 :b 1 :c 1 :d 4}
+            {:a 2 :b 12 :c 2 :d 6}
+            {:a 3 :b 3 :c 3 :d 8 :f 42}})
 
-(def ys #{{:a 11 :b 11 :c 11 :e 5}
-         {:a 12 :b 11 :c 12 :e 3}
-         {:a 3 :b 3 :c 3 :e 7 }})
+  (def ys #{{:a 11 :b 11 :c 11 :e 5}
+            {:a 12 :b 11 :c 12 :e 3}
+            {:a 3 :b 3 :c 3 :e 7}})
 
-(join xs ys)
-(join xs (rename ys {:b :yb :c :yc}) {:a :a})
+  (join xs ys)
+  (join xs (rename ys {:b :yb :c :yc}) {:a :a})
 
-(union #{:a :b :c} #{:c :d :e })
-(difference #{:a :b :c} #{:c :d :e})
-(intersection #{:a :b :c} #{:c :d :e})
+  (union #{:a :b :c} #{:c :d :e})
+  (difference #{:a :b :c} #{:c :d :e})
+  (intersection #{:a :b :c} #{:c :d :e})
 
-(index ys [:b])
-)
-
+  (index ys [:b]))

--- a/src/clj/clojure/stacktrace.clj
+++ b/src/clj/clojure/stacktrace.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;; stacktrace.clj: print Clojure-centric stack traces
 
@@ -12,8 +12,8 @@
 ;; January 6, 2009
 
 (ns ^{:doc "Print stack traces oriented towards Clojure, not Java."
-       :author "Stuart Sierra"}
-  clojure.stacktrace)
+      :author "Stuart Sierra"}
+ clojure.stacktrace)
 
 (defn root-cause
   "Returns the last 'cause' Throwable in a chain of Throwables."
@@ -28,11 +28,11 @@
   {:added "1.1"}
   [e]
   (let [class (.getClassName e)
-	method (.getMethodName e)] 
+        method (.getMethodName e)]
     (let [match (re-matches #"^([A-Za-z0-9_.-]+)\$(\w+)__\d+$" (str class))]
       (if (and match (= "invoke" method))
-	(apply printf "%s/%s" (rest match))
-	(printf "%s.%s" class method))))
+        (apply printf "%s/%s" (rest match))
+        (printf "%s.%s" class method))))
   (printf " (%s:%d)" (or (.getFileName e) "") (.getLineNumber e)))
 
 (defn print-throwable
@@ -48,30 +48,30 @@
   {:added "1.1"}
   ([tr] (print-stack-trace tr nil))
   ([^Throwable tr n]
-     (let [st (.getStackTrace tr)]
-       (print-throwable tr)
-       (newline)
-       (print " at ") 
-       (if-let [e (first st)]
-         (print-trace-element e)
-         (print "[empty stack trace]"))
-       (newline)
-       (doseq [e (if (nil? n)
-		   (rest st)
-		   (take (dec n) (rest st)))]
-	 (print "    ")
-	 (print-trace-element e)
-	 (newline)))))
+   (let [st (.getStackTrace tr)]
+     (print-throwable tr)
+     (newline)
+     (print " at ")
+     (if-let [e (first st)]
+       (print-trace-element e)
+       (print "[empty stack trace]"))
+     (newline)
+     (doseq [e (if (nil? n)
+                 (rest st)
+                 (take (dec n) (rest st)))]
+       (print "    ")
+       (print-trace-element e)
+       (newline)))))
 
 (defn print-cause-trace
   "Like print-stack-trace but prints chained exceptions (causes)."
   {:added "1.1"}
   ([tr] (print-cause-trace tr nil))
   ([tr n]
-     (print-stack-trace tr n)
-     (when-let [cause (.getCause tr)]
-       (print "Caused by: " )
-       (recur cause n))))
+   (print-stack-trace tr n)
+   (when-let [cause (.getCause tr)]
+     (print "Caused by: ")
+     (recur cause n))))
 
 (defn e
   "REPL utility.  Prints a brief stack trace for the root cause of the

--- a/src/clj/clojure/string.clj
+++ b/src/clj/clojure/string.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "Clojure String utilities
 
@@ -38,7 +38,7 @@ Design notes for clojure.string:
    e.g. passing a mutable implementation of CharSequence, then
    thread-safety is your responsibility."
       :author "Stuart Sierra, Stuart Halloway, David Liebke"}
-  clojure.string
+ clojure.string
   (:refer-clojure :exclude (replace reverse))
   (:import (java.util.regex Pattern Matcher)
            clojure.lang.LazilyPersistentVector))
@@ -99,14 +99,14 @@ Design notes for clojure.string:
   {:added "1.2"}
   [^CharSequence s match replacement]
   (let [s (.toString s)]
-    (cond 
-     (instance? Character match) (.replace s ^Character match ^Character replacement)
-     (instance? CharSequence match) (.replace s ^CharSequence match ^CharSequence replacement)
-     (instance? Pattern match) (if (instance? CharSequence replacement)
-                                 (.replaceAll (re-matcher ^Pattern match s)
-                                              (.toString ^CharSequence replacement))
-                                 (replace-by s match replacement))
-     :else (throw (IllegalArgumentException. (str "Invalid match arg: " match))))))
+    (cond
+      (instance? Character match) (.replace s ^Character match ^Character replacement)
+      (instance? CharSequence match) (.replace s ^CharSequence match ^CharSequence replacement)
+      (instance? Pattern match) (if (instance? CharSequence replacement)
+                                  (.replaceAll (re-matcher ^Pattern match s)
+                                               (.toString ^CharSequence replacement))
+                                  (replace-by s match replacement))
+      :else (throw (IllegalArgumentException. (str "Invalid match arg: " match))))))
 
 (defn- replace-first-by
   [^CharSequence s ^Pattern re f]
@@ -164,34 +164,33 @@ Design notes for clojure.string:
   [^CharSequence s match replacement]
   (let [s (.toString s)]
     (cond
-     (instance? Character match)
-     (replace-first-char s match replacement)
-     (instance? CharSequence match)
-     (replace-first-str s (.toString ^CharSequence match)
-                        (.toString ^CharSequence replacement))
-     (instance? Pattern match)
-     (if (instance? CharSequence replacement)
-       (.replaceFirst (re-matcher ^Pattern match s)
-                      (.toString ^CharSequence replacement))
-       (replace-first-by s match replacement))
-     :else (throw (IllegalArgumentException. (str "Invalid match arg: " match))))))
-
+      (instance? Character match)
+      (replace-first-char s match replacement)
+      (instance? CharSequence match)
+      (replace-first-str s (.toString ^CharSequence match)
+                         (.toString ^CharSequence replacement))
+      (instance? Pattern match)
+      (if (instance? CharSequence replacement)
+        (.replaceFirst (re-matcher ^Pattern match s)
+                       (.toString ^CharSequence replacement))
+        (replace-first-by s match replacement))
+      :else (throw (IllegalArgumentException. (str "Invalid match arg: " match))))))
 
 (defn ^String join
   "Returns a string of all elements in coll, as returned by (seq coll),
    separated by an optional separator."
   {:added "1.2"}
   ([coll]
-     (apply str coll))
+   (apply str coll))
   ([separator coll]
-     (loop [sb (StringBuilder. (str (first coll)))
-            more (next coll)
-            sep (str separator)]
-       (if more
-         (recur (-> sb (.append sep) (.append (str (first more))))
-                (next more)
-                sep)
-         (str sb)))))
+   (loop [sb (StringBuilder. (str (first coll)))
+          more (next coll)
+          sep (str separator)]
+     (if more
+       (recur (-> sb (.append sep) (.append (str (first more))))
+              (next more)
+              sep)
+       (str sb)))))
 
 (defn ^String capitalize
   "Converts first character of the string to upper-case, all other
@@ -221,9 +220,9 @@ Design notes for clojure.string:
   the maximum number of splits. Not lazy. Returns vector of the splits."
   {:added "1.2"}
   ([^CharSequence s ^Pattern re]
-     (LazilyPersistentVector/createOwning (.split re s)))
-  ([ ^CharSequence s ^Pattern re limit]
-     (LazilyPersistentVector/createOwning (.split re s limit))))
+   (LazilyPersistentVector/createOwning (.split re s)))
+  ([^CharSequence s ^Pattern re limit]
+   (LazilyPersistentVector/createOwning (.split re s limit))))
 
 (defn split-lines
   "Splits s on \\n or \\r\\n."
@@ -300,7 +299,7 @@ Design notes for clojure.string:
 (defn ^String escape
   "Return a new string, using cmap to escape each character ch
    from s as follows:
-   
+
    If (cmap ch) is nil, append ch to the new string.
    If (cmap ch) is non-nil, append (str (cmap ch)) instead."
   {:added "1.2"}
@@ -320,42 +319,42 @@ Design notes for clojure.string:
   forward from from-index or nil if not found."
   {:added "1.8"}
   ([^CharSequence s value]
-  (let [result ^long
-        (if (instance? Character value)
-          (.indexOf (.toString s) ^int (.charValue ^Character value))
-          (.indexOf (.toString s) ^String value))]
-    (if (= result -1)
-      nil
-      result)))
+   (let [result ^long
+         (if (instance? Character value)
+           (.indexOf (.toString s) ^int (.charValue ^Character value))
+           (.indexOf (.toString s) ^String value))]
+     (if (= result -1)
+       nil
+       result)))
   ([^CharSequence s value ^long from-index]
-  (let [result ^long
-        (if (instance? Character value)
-          (.indexOf (.toString s) ^int (.charValue ^Character value) (unchecked-int from-index))
-          (.indexOf (.toString s) ^String value (unchecked-int from-index)))]
-    (if (= result -1)
-      nil
-      result))))
+   (let [result ^long
+         (if (instance? Character value)
+           (.indexOf (.toString s) ^int (.charValue ^Character value) (unchecked-int from-index))
+           (.indexOf (.toString s) ^String value (unchecked-int from-index)))]
+     (if (= result -1)
+       nil
+       result))))
 
 (defn last-index-of
   "Return last index of value (string or char) in s, optionally
   searching backward from from-index or nil if not found."
   {:added "1.8"}
   ([^CharSequence s value]
-  (let [result ^long
-        (if (instance? Character value)
-          (.lastIndexOf (.toString s) ^int (.charValue ^Character value))
-          (.lastIndexOf (.toString s) ^String value))]
-    (if (= result -1)
-      nil
-      result)))
+   (let [result ^long
+         (if (instance? Character value)
+           (.lastIndexOf (.toString s) ^int (.charValue ^Character value))
+           (.lastIndexOf (.toString s) ^String value))]
+     (if (= result -1)
+       nil
+       result)))
   ([^CharSequence s value ^long from-index]
-  (let [result ^long
-        (if (instance? Character value)
-          (.lastIndexOf (.toString s) ^int (.charValue ^Character value) (unchecked-int from-index))
-          (.lastIndexOf (.toString s) ^String value (unchecked-int from-index)))]
-    (if (= result -1)
-      nil
-      result))))
+   (let [result ^long
+         (if (instance? Character value)
+           (.lastIndexOf (.toString s) ^int (.charValue ^Character value) (unchecked-int from-index))
+           (.lastIndexOf (.toString s) ^String value (unchecked-int from-index)))]
+     (if (= result -1)
+       nil
+       result))))
 
 (defn starts-with?
   "True if s starts with substr."

--- a/src/clj/clojure/template.clj
+++ b/src/clj/clojure/template.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;; template.clj - anonymous functions that pre-evaluate sub-expressions
 
@@ -23,8 +23,8 @@
 
 
 (ns ^{:doc "Macros that expand to repeated copies of a template expression."
-       :author "Stuart Sierra"}
-  clojure.template
+      :author "Stuart Sierra"}
+ clojure.template
   (:require [clojure.walk :as walk]))
 
 (defn apply-template
@@ -51,5 +51,5 @@
            ;=> (do (+ 4 2) (+ 5 3))"
   [argv expr & values]
   (let [c (count argv)]
-    `(do ~@(map (fn [a] (apply-template argv expr a)) 
+    `(do ~@(map (fn [a] (apply-template argv expr a))
                 (partition c values)))))

--- a/src/clj/clojure/test.clj
+++ b/src/clj/clojure/test.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;; test.clj: test framework for Clojure
 
@@ -14,10 +14,10 @@
 ;; Thanks to Chas Emerick, Allen Rohner, and Stuart Halloway for
 ;; contributions and suggestions.
 
-(ns 
-  ^{:author "Stuart Sierra, with contributions and suggestions by 
+(ns
+ ^{:author "Stuart Sierra, with contributions and suggestions by
   Chas Emerick, Allen Rohner, and Stuart Halloway",
-     :doc "A unit testing framework.
+   :doc "A unit testing framework.
 
    ASSERTIONS
 
@@ -49,7 +49,7 @@
    \"(is (thrown? c ...))\" form tests if an exception of class c is
    thrown:
 
-   (is (thrown? ArithmeticException (/ 1 0))) 
+   (is (thrown? ArithmeticException (/ 1 0)))
 
    \"(is (thrown-with-msg? c re ...))\" does the same thing and also
    tests that the message on the exception matches the regular
@@ -231,7 +231,7 @@
 
    For additional event types, see the examples in the code.
 "}
-  clojure.test
+ clojure.test
   (:require [clojure.template :as temp]
             [clojure.stacktrace :as stack]
             [clojure.string :as str]))
@@ -250,19 +250,18 @@
   *load-tests* true)
 
 (def ^:dynamic
- ^{:doc "The maximum depth of stack traces to print when an Exception
-  is thrown during a test.  Defaults to nil, which means print the 
+  ^{:doc "The maximum depth of stack traces to print when an Exception
+  is thrown during a test.  Defaults to nil, which means print the
   complete stack trace."
-   :added "1.1"}
- *stack-trace-depth* nil)
-
+    :added "1.1"}
+  *stack-trace-depth* nil)
 
 ;;; GLOBALS USED BY THE REPORTING FUNCTIONS
 
 (def ^:dynamic *report-counters* nil)	  ; bound to a ref of a map in test-ns
 
 (def ^:dynamic *initial-report-counters*  ; used to initialize *report-counters*
-     {:test 0, :pass 0, :fail 0, :error 0})
+  {:test 0, :pass 0, :fail 0, :error 0})
 
 (def ^:dynamic *testing-vars* (list))  ; bound to hierarchy of vars being tested
 
@@ -328,8 +327,8 @@
    'report' will be a map with a :type key.  See the documentation at
    the top of test_is.clj for more information on the types of
    arguments for 'report'."
-     :dynamic true
-     :added "1.1"}
+    :dynamic true
+    :added "1.1"}
   report :type)
 
 (defn- file-and-line
@@ -357,13 +356,13 @@
   (report
    (case
     (:type m)
-    :fail (merge (stacktrace-file-and-line (drop-while
+     :fail (merge (stacktrace-file-and-line (drop-while
                                              #(let [cl-name (.getClassName ^StackTraceElement %)]
                                                 (or (str/starts-with? cl-name "java.lang.")
                                                     (str/starts-with? cl-name "clojure.test$")))
                                              (.getStackTrace (Thread/currentThread)))) m)
-    :error (merge (stacktrace-file-and-line (.getStackTrace ^Throwable (:actual m))) m)
-    m)))
+     :error (merge (stacktrace-file-and-line (.getStackTrace ^Throwable (:actual m))) m)
+     m)))
 
 (defmethod report :default [m]
   (with-test-out (prn m)))
@@ -382,33 +381,31 @@
 
 (defmethod report :error [m]
   (with-test-out
-   (inc-report-counter :error)
-   (println "\nERROR in" (testing-vars-str m))
-   (when (seq *testing-contexts*) (println (testing-contexts-str)))
-   (when-let [message (:message m)] (println message))
-   (println "expected:" (pr-str (:expected m)))
-   (print "  actual: ")
-   (let [actual (:actual m)]
-     (if (instance? Throwable actual)
-       (stack/print-cause-trace actual *stack-trace-depth*)
-       (prn actual)))))
+    (inc-report-counter :error)
+    (println "\nERROR in" (testing-vars-str m))
+    (when (seq *testing-contexts*) (println (testing-contexts-str)))
+    (when-let [message (:message m)] (println message))
+    (println "expected:" (pr-str (:expected m)))
+    (print "  actual: ")
+    (let [actual (:actual m)]
+      (if (instance? Throwable actual)
+        (stack/print-cause-trace actual *stack-trace-depth*)
+        (prn actual)))))
 
 (defmethod report :summary [m]
   (with-test-out
-   (println "\nRan" (:test m) "tests containing"
-            (+ (:pass m) (:fail m) (:error m)) "assertions.")
-   (println (:fail m) "failures," (:error m) "errors.")))
+    (println "\nRan" (:test m) "tests containing"
+             (+ (:pass m) (:fail m) (:error m)) "assertions.")
+    (println (:fail m) "failures," (:error m) "errors.")))
 
 (defmethod report :begin-test-ns [m]
   (with-test-out
-   (println "\nTesting" (ns-name (:ns m)))))
+    (println "\nTesting" (ns-name (:ns m)))))
 
 ;; Ignore these message types:
 (defmethod report :end-test-ns [m])
 (defmethod report :begin-test-var [m])
 (defmethod report :end-test-var [m])
-
-
 
 ;;; UTILITIES FOR ASSERTIONS
 
@@ -446,9 +443,9 @@
            result# (apply ~pred values#)]
        (if result#
          (do-report {:type :pass, :message ~msg,
-                  :expected '~form, :actual (cons ~pred values#)})
+                     :expected '~form, :actual (cons ~pred values#)})
          (do-report {:type :fail, :message ~msg,
-                  :expected '~form, :actual (list '~'not (cons '~pred values#))}))
+                     :expected '~form, :actual (list '~'not (cons '~pred values#))}))
        result#)))
 
 (defn assert-any
@@ -459,12 +456,10 @@
   `(let [value# ~form]
      (if value#
        (do-report {:type :pass, :message ~msg,
-                :expected '~form, :actual value#})
+                   :expected '~form, :actual value#})
        (do-report {:type :fail, :message ~msg,
-                :expected '~form, :actual value#}))
+                   :expected '~form, :actual value#}))
      value#))
-
-
 
 ;;; ASSERTION METHODS
 
@@ -472,7 +467,7 @@
 ;; macro.  These define different kinds of tests, based on the first
 ;; symbol in the test expression.
 
-(defmulti assert-expr 
+(defmulti assert-expr
   (fn [msg form]
     (cond
       (nil? form) :always-fail
@@ -495,9 +490,9 @@
      (let [result# (instance? klass# object#)]
        (if result#
          (do-report {:type :pass, :message ~msg,
-                  :expected '~form, :actual (class object#)})
+                     :expected '~form, :actual (class object#)})
          (do-report {:type :fail, :message ~msg,
-                  :expected '~form, :actual (class object#)}))
+                     :expected '~form, :actual (class object#)}))
        result#)))
 
 (defmethod assert-expr 'thrown? [msg form]
@@ -508,10 +503,10 @@
         body (nthnext form 2)]
     `(try ~@body
           (do-report {:type :fail, :message ~msg,
-                   :expected '~form, :actual nil})
+                      :expected '~form, :actual nil})
           (catch ~klass e#
             (do-report {:type :pass, :message ~msg,
-                     :expected '~form, :actual e#})
+                        :expected '~form, :actual e#})
             e#))))
 
 (defmethod assert-expr 'thrown-with-msg? [msg form]
@@ -528,11 +523,10 @@
             (let [m# (.getMessage e#)]
               (if (re-find ~re m#)
                 (do-report {:type :pass, :message ~msg,
-                         :expected '~form, :actual e#})
+                            :expected '~form, :actual e#})
                 (do-report {:type :fail, :message ~msg,
-                         :expected '~form, :actual e#})))
+                            :expected '~form, :actual e#})))
             e#))))
-
 
 (defmacro try-expr
   "Used by the 'is' macro to catch unexpected exceptions.
@@ -544,8 +538,6 @@
           (do-report {:type :error, :message ~msg,
                       :expected '~form, :actual t#}))))
 
-
-
 ;;; ASSERTION MACROS
 
 ;; You use these in your tests.
@@ -553,7 +545,7 @@
 (defmacro is
   "Generic assertion macro.  'form' is any predicate test.
   'msg' is an optional message to attach to the assertion.
-  
+
   Example: (is (= 4 (+ 2 2)) \"Two plus two should be 4\")
 
   Special forms:
@@ -564,7 +556,7 @@
   (is (thrown-with-msg? c re body)) checks that an instance of c is
   thrown AND that the message on the exception matches (with
   re-find) the regular expression re."
-  {:added "1.1"} 
+  {:added "1.1"}
   ([form] `(is ~form nil))
   ([form msg] `(try-expr ~msg ~form)))
 
@@ -573,10 +565,10 @@
   See clojure.template/do-template for an explanation of
   templates.
 
-  Example: (are [x y] (= x y)  
+  Example: (are [x y] (= x y)
                 2 (+ 1 1)
                 4 (* 2 2))
-  Expands to: 
+  Expands to:
            (do (is (= 2 (+ 1 1)))
                (is (= 4 (* 2 2))))
 
@@ -601,8 +593,6 @@
   `(binding [*testing-contexts* (conj *testing-contexts* ~string)]
      ~@body))
 
-
-
 ;;; DEFINING TESTS
 
 (defmacro with-test
@@ -616,7 +606,6 @@
   (if *load-tests*
     `(doto ~definition (alter-meta! assoc :test (fn [] ~@body)))
     definition))
-
 
 (defmacro deftest
   "Defines a test function with no arguments.  Test functions may call
@@ -633,7 +622,7 @@
   [name & body]
   (when *load-tests*
     `(def ~(vary-meta name assoc :test `(fn [] ~@body))
-          (fn [] (test-var (var ~name))))))
+       (fn [] (test-var (var ~name))))))
 
 (defmacro deftest-
   "Like deftest but creates a private var."
@@ -641,8 +630,7 @@
   [name & body]
   (when *load-tests*
     `(def ~(vary-meta name assoc :test `(fn [] ~@body) :private true)
-          (fn [] (test-var (var ~name))))))
-
+       (fn [] (test-var (var ~name))))))
 
 (defmacro set-test
   "Experimental.
@@ -654,8 +642,6 @@
   [name & body]
   (when *load-tests*
     `(alter-meta! (var ~name) assoc :test (fn [] ~@body))))
-
-
 
 ;;; DEFINING FIXTURES
 
@@ -699,9 +685,6 @@
   [fixtures]
   (reduce compose-fixtures default-fixture fixtures))
 
-
-
-
 ;;; RUNNING TESTS: LOW-LEVEL FUNCTIONS
 
 (defn test-var
@@ -716,7 +699,7 @@
       (try (t)
            (catch Throwable e
              (do-report {:type :error, :message "Uncaught exception, not in assertion."
-                      :expected nil, :actual e})))
+                         :expected nil, :actual e})))
       (do-report {:type :end-test-var, :var v}))))
 
 (defn test-vars
@@ -754,13 +737,11 @@
       (do-report {:type :begin-test-ns, :ns ns-obj})
       ;; If the namespace has a test-ns-hook function, call that:
       (if-let [v (find-var (symbol (str (ns-name ns-obj)) "test-ns-hook"))]
-	((var-get v))
+        ((var-get v))
         ;; Otherwise, just test every var in the namespace.
         (test-all-vars ns-obj))
       (do-report {:type :end-test-ns, :ns ns-obj}))
     @*report-counters*))
-
-
 
 ;;; RUNNING TESTS: HIGH-LEVEL FUNCTIONS
 
@@ -771,10 +752,10 @@
   {:added "1.1"}
   ([] (run-tests *ns*))
   ([& namespaces]
-     (let [summary (assoc (apply merge-with + (map test-ns namespaces))
-                     :type :summary)]
-       (do-report summary)
-       summary)))
+   (let [summary (assoc (apply merge-with + (map test-ns namespaces))
+                        :type :summary)]
+     (do-report summary)
+     summary)))
 
 (defn run-all-tests
   "Runs all tests in all namespaces; prints results.

--- a/src/clj/clojure/test/junit.clj
+++ b/src/clj/clojure/test/junit.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; test/junit.clj: Extension to clojure.test for JUnit-compatible XML output
 
@@ -33,15 +33,15 @@
   To write the output to a file, rebind clojure.test/*test-out* to
   your own PrintWriter (perhaps opened using
   clojure.java.io/writer)."
-  :author "Jason Sankey"}
-  clojure.test.junit
+      :author "Jason Sankey"}
+ clojure.test.junit
   (:require [clojure.stacktrace :as stack]
             [clojure.test :as t]))
 
 ;; copied from clojure.contrib.lazy-xml
 (def ^{:private true}
-     escape-xml-map
-     (zipmap "'<>\"&" (map #(str \& % \;) '[apos lt gt quot amp])))
+  escape-xml-map
+  (zipmap "'<>\"&" (map #(str \& % \;) '[apos lt gt quot amp])))
 (defn- escape-xml [text]
   (apply str (map #(escape-xml-map % %) text)))
 
@@ -127,54 +127,54 @@
 (defn failure-el
   [m]
   (message-el (assoc m
-                :tag 'failure
-                :expected-str (pr-str (:expected m))
-                :actual-str (pr-str (:actual m)))))
+                     :tag 'failure
+                     :expected-str (pr-str (:expected m))
+                     :actual-str (pr-str (:actual m)))))
 
 (defn error-el
   [{:keys [expected actual] :as m}]
   (message-el (assoc m
-                :tag 'error
-                :expected-str (pr-str expected)
-                :actual-str (if (instance? Throwable actual)
-                              (with-out-str
-                                (stack/print-cause-trace actual t/*stack-trace-depth*))
-                              (pr-str actual)))))
+                     :tag 'error
+                     :expected-str (pr-str expected)
+                     :actual-str (if (instance? Throwable actual)
+                                   (with-out-str
+                                     (stack/print-cause-trace actual t/*stack-trace-depth*))
+                                   (pr-str actual)))))
 
 ;; This multimethod will override test-is/report
 (defmulti ^:dynamic junit-report :type)
 
 (defmethod junit-report :begin-test-ns [m]
   (t/with-test-out
-   (start-suite (name (ns-name (:ns m))))))
+    (start-suite (name (ns-name (:ns m))))))
 
 (defmethod junit-report :end-test-ns [_]
   (t/with-test-out
-   (finish-suite)))
+    (finish-suite)))
 
 (defmethod junit-report :begin-test-var [m]
   (t/with-test-out
-   (let [var (:var m)]
-     (binding [*var-context* (conj *var-context* var)]
-       (start-case (test-name *var-context*) (name (ns-name (:ns (meta var)))))))))
+    (let [var (:var m)]
+      (binding [*var-context* (conj *var-context* var)]
+        (start-case (test-name *var-context*) (name (ns-name (:ns (meta var)))))))))
 
 (defmethod junit-report :end-test-var [m]
   (t/with-test-out
-   (finish-case)))
+    (finish-case)))
 
 (defmethod junit-report :pass [m]
   (t/with-test-out
-   (t/inc-report-counter :pass)))
+    (t/inc-report-counter :pass)))
 
 (defmethod junit-report :fail [m]
   (t/with-test-out
-   (t/inc-report-counter :fail)
-   (failure-el m)))
+    (t/inc-report-counter :fail)
+    (failure-el m)))
 
 (defmethod junit-report :error [m]
   (t/with-test-out
-   (t/inc-report-counter :error)
-   (error-el m)))
+    (t/inc-report-counter :error)
+    (error-el m)))
 
 (defmethod junit-report :default [_])
 

--- a/src/clj/clojure/test/tap.clj
+++ b/src/clj/clojure/test/tap.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;; test_is/tap.clj: Extension to test for TAP output
 
@@ -37,8 +37,8 @@
 
     (with-tap-output
      (run-tests 'my.cool.library))"
-       :author "Stuart Sierra"}
-  clojure.test.tap
+      :author "Stuart Sierra"}
+ clojure.test.tap
   (:require [clojure.test :as t]
             [clojure.stacktrace :as stack]))
 
@@ -62,7 +62,7 @@
   [msg]
   (println "ok" msg))
 
-(defn print-tap-fail 
+(defn print-tap-fail
   "Prints a TAP 'not ok' line.  msg is a string, with no line breaks"
   {:added "1.1"}
   [msg]
@@ -73,7 +73,7 @@
 
 (defmethod tap-report :default [data]
   (t/with-test-out
-   (print-tap-diagnostic (pr-str data))))
+    (print-tap-diagnostic (pr-str data))))
 
 (defn print-diagnostics [data]
   (when (seq t/*testing-contexts*)
@@ -86,33 +86,32 @@
     (do
       (print-tap-diagnostic
        (str "  actual:"
-        (with-out-str
-          (if (instance? Throwable (:actual data))
-            (stack/print-cause-trace (:actual data) t/*stack-trace-depth*)
-            (prn (:actual data)))))))))
+            (with-out-str
+              (if (instance? Throwable (:actual data))
+                (stack/print-cause-trace (:actual data) t/*stack-trace-depth*)
+                (prn (:actual data)))))))))
 
 (defmethod tap-report :pass [data]
   (t/with-test-out
-   (t/inc-report-counter :pass)
-   (print-tap-pass (t/testing-vars-str data))
-   (print-diagnostics data)))
+    (t/inc-report-counter :pass)
+    (print-tap-pass (t/testing-vars-str data))
+    (print-diagnostics data)))
 
 (defmethod tap-report :error [data]
   (t/with-test-out
-   (t/inc-report-counter :error)
-   (print-tap-fail (t/testing-vars-str data))
-   (print-diagnostics data)))
+    (t/inc-report-counter :error)
+    (print-tap-fail (t/testing-vars-str data))
+    (print-diagnostics data)))
 
 (defmethod tap-report :fail [data]
   (t/with-test-out
-   (t/inc-report-counter :fail)
-   (print-tap-fail (t/testing-vars-str data))
-   (print-diagnostics data)))
+    (t/inc-report-counter :fail)
+    (print-tap-fail (t/testing-vars-str data))
+    (print-diagnostics data)))
 
 (defmethod tap-report :summary [data]
   (t/with-test-out
-   (print-tap-plan (+ (:pass data) (:fail data) (:error data)))))
-
+    (print-tap-plan (+ (:pass data) (:fail data) (:error data)))))
 
 (defmacro with-tap-output
   "Execute body with modified test reporting functions that produce

--- a/src/clj/clojure/uuid.clj
+++ b/src/clj/clojure/uuid.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.uuid)
 

--- a/src/clj/clojure/walk.clj
+++ b/src/clj/clojure/walk.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;; walk.clj - generic tree walker with replacement
 
@@ -18,9 +18,9 @@
 ;; * December 9, 2008: first version
 
 
-(ns 
-  ^{:author "Stuart Sierra",
-     :doc "This file defines a generic tree walker for Clojure data
+(ns
+ ^{:author "Stuart Sierra",
+   :doc "This file defines a generic tree walker for Clojure data
 structures.  It takes any data structure (list, vector, map, set,
 seq), calls a function on every element, and uses the return value
 of the function in place of the original.  This makes it fairly
@@ -30,7 +30,7 @@ the examples.
 Note: \"walk\" supports all Clojure data structures EXCEPT maps
 created with sorted-map-by.  There is no (obvious) way to retrieve
 the sorting function."}
-  clojure.walk)
+ clojure.walk)
 
 (defn walk
   "Traverses form, an arbitrary data structure.  inner and outer are
@@ -41,13 +41,13 @@ the sorting function."}
   {:added "1.1"}
   [inner outer form]
   (cond
-   (list? form) (outer (apply list (map inner form)))
-   (instance? clojure.lang.IMapEntry form) (outer (vec (map inner form)))
-   (seq? form) (outer (doall (map inner form)))
-   (instance? clojure.lang.IRecord form)
-     (outer (reduce (fn [r x] (conj r (inner x))) form form))
-   (coll? form) (outer (into (empty form) (map inner form)))
-   :else (outer form)))
+    (list? form) (outer (apply list (map inner form)))
+    (instance? clojure.lang.IMapEntry form) (outer (vec (map inner form)))
+    (seq? form) (outer (doall (map inner form)))
+    (instance? clojure.lang.IRecord form)
+    (outer (reduce (fn [r x] (conj r (inner x))) form form))
+    (coll? form) (outer (into (empty form) (map inner form)))
+    :else (outer form)))
 
 (defn postwalk
   "Performs a depth-first, post-order traversal of form.  Calls f on
@@ -62,7 +62,6 @@ the sorting function."}
   {:added "1.1"}
   [f form]
   (walk (partial prewalk f) identity (f form)))
-
 
 ;; Note: I wanted to write:
 ;;

--- a/src/clj/clojure/xml.clj
+++ b/src/clj/clojure/xml.clj
@@ -1,14 +1,14 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "XML reading/writing."
-       :author "Rich Hickey"}
-  clojure.xml
+      :author "Rich Hickey"}
+ clojure.xml
   (:import (org.xml.sax ContentHandler Attributes SAXException)
            (javax.xml.parsers SAXParser SAXParserFactory)))
 
@@ -69,8 +69,7 @@
            (endPrefixMapping [prefix])
            (ignorableWhitespace [ch start length])
            (processingInstruction [target data])
-           (skippedEntity [name])
-           ))))
+           (skippedEntity [name])))))
 
 (defn startparse-sax [s ch]
   (.. SAXParserFactory (newInstance) (newSAXParser) (parse s ch)))
@@ -85,12 +84,12 @@
   {:added "1.0"}
   ([s] (parse s startparse-sax))
   ([s startparse]
-    (binding [*stack* nil
-              *current* (struct element)
-              *state* :between
-              *sb* nil]
-      (startparse s content-handler)
-      ((:content *current*) 0)))) 
+   (binding [*stack* nil
+             *current* (struct element)
+             *state* :between
+             *sb* nil]
+     (startparse s content-handler)
+     ((:content *current*) 0))))
 
 (defn emit-element [e]
   (if (instance? String e)
@@ -98,15 +97,15 @@
     (do
       (print (str "<" (name (:tag e))))
       (when (:attrs e)
-	(doseq [attr (:attrs e)]
-	  (print (str " " (name (key attr)) "='" (val attr)"'"))))
+        (doseq [attr (:attrs e)]
+          (print (str " " (name (key attr)) "='" (val attr) "'"))))
       (if (:content e)
-	(do
-	  (println ">")
-	  (doseq [c (:content e)]
-	    (emit-element c))
-	  (println (str "</" (name (:tag e)) ">")))
-	(println "/>")))))
+        (do
+          (println ">")
+          (doseq [c (:content e)]
+            (emit-element c))
+          (println (str "</" (name (:tag e)) ">")))
+        (println "/>")))))
 
 (defn emit [x]
   (println "<?xml version='1.0' encoding='UTF-8'?>")

--- a/src/clj/clojure/zip.clj
+++ b/src/clj/clojure/zip.clj
@@ -1,22 +1,22 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;functional hierarchical zipper, with navigation, editing and enumeration
 ;see Huet
 
 (ns ^{:doc "Functional hierarchical zipper, with navigation, editing,
   and enumeration.  See Huet"
-       :author "Rich Hickey"}
-  clojure.zip
+      :author "Rich Hickey"}
+ clojure.zip
   (:refer-clojure :exclude (replace remove next)))
 
 (defn zipper
-  "Creates a new zipper structure. 
+  "Creates a new zipper structure.
 
   branch? is a fn that, given a node, returns true if can have
   children, even if it currently doesn't.
@@ -29,37 +29,37 @@
   root is the root node."
   {:added "1.0"}
   [branch? children make-node root]
-    ^{:zip/branch? branch? :zip/children children :zip/make-node make-node}
-    [root nil])
+  ^{:zip/branch? branch? :zip/children children :zip/make-node make-node}
+  [root nil])
 
 (defn seq-zip
   "Returns a zipper for nested sequences, given a root sequence"
   {:added "1.0"}
   [root]
-    (zipper seq?
-            identity
-            (fn [node children] (with-meta children (meta node)))
-            root))
+  (zipper seq?
+          identity
+          (fn [node children] (with-meta children (meta node)))
+          root))
 
 (defn vector-zip
   "Returns a zipper for nested vectors, given a root vector"
   {:added "1.0"}
   [root]
-    (zipper vector?
-            seq
-            (fn [node children] (with-meta (vec children) (meta node)))
-            root))
+  (zipper vector?
+          seq
+          (fn [node children] (with-meta (vec children) (meta node)))
+          root))
 
 (defn xml-zip
   "Returns a zipper for xml elements (as from xml/parse),
   given a root element"
   {:added "1.0"}
   [root]
-    (zipper (complement string?) 
-            (comp seq :content)
-            (fn [node children]
-              (assoc node :content (and children (apply vector children))))
-            root))
+  (zipper (complement string?)
+          (comp seq :content)
+          (fn [node children]
+            (assoc node :content (and children (apply vector children))))
+          root))
 
 (defn node
   "Returns the node at loc"
@@ -70,162 +70,161 @@
   "Returns true if the node at loc is a branch"
   {:added "1.0"}
   [loc]
-    ((:zip/branch? (meta loc)) (node loc)))
+  ((:zip/branch? (meta loc)) (node loc)))
 
 (defn children
   "Returns a seq of the children of node at loc, which must be a branch"
   {:added "1.0"}
   [loc]
-    (if (branch? loc)
-      ((:zip/children (meta loc)) (node loc))
-      (throw (Exception. "called children on a leaf node"))))
+  (if (branch? loc)
+    ((:zip/children (meta loc)) (node loc))
+    (throw (Exception. "called children on a leaf node"))))
 
 (defn make-node
   "Returns a new branch node, given an existing node and new
   children. The loc is only used to supply the constructor."
   {:added "1.0"}
   [loc node children]
-    ((:zip/make-node (meta loc)) node children))
+  ((:zip/make-node (meta loc)) node children))
 
 (defn path
   "Returns a seq of nodes leading to this loc"
   {:added "1.0"}
   [loc]
-    (:pnodes (loc 1)))
+  (:pnodes (loc 1)))
 
 (defn lefts
   "Returns a seq of the left siblings of this loc"
   {:added "1.0"}
   [loc]
-    (seq (:l (loc 1))))
+  (seq (:l (loc 1))))
 
 (defn rights
   "Returns a seq of the right siblings of this loc"
   {:added "1.0"}
   [loc]
-    (:r (loc 1)))
-
+  (:r (loc 1)))
 
 (defn down
   "Returns the loc of the leftmost child of the node at this loc, or
   nil if no children"
   {:added "1.0"}
   [loc]
-    (when (branch? loc)
-      (let [[node path] loc
-            [c & cnext :as cs] (children loc)]
-        (when cs
-          (with-meta [c {:l [] 
-                         :pnodes (if path (conj (:pnodes path) node) [node]) 
-                         :ppath path 
-                         :r cnext}] (meta loc))))))
+  (when (branch? loc)
+    (let [[node path] loc
+          [c & cnext :as cs] (children loc)]
+      (when cs
+        (with-meta [c {:l []
+                       :pnodes (if path (conj (:pnodes path) node) [node])
+                       :ppath path
+                       :r cnext}] (meta loc))))))
 
 (defn up
   "Returns the loc of the parent of the node at this loc, or nil if at
   the top"
   {:added "1.0"}
   [loc]
-    (let [[node {l :l, ppath :ppath, pnodes :pnodes r :r, changed? :changed?, :as path}] loc]
-      (when pnodes
-        (let [pnode (peek pnodes)]
-          (with-meta (if changed?
-                       [(make-node loc pnode (concat l (cons node r))) 
-                        (and ppath (assoc ppath :changed? true))]
-                       [pnode ppath])
-                     (meta loc))))))
+  (let [[node {l :l, ppath :ppath, pnodes :pnodes r :r, changed? :changed?, :as path}] loc]
+    (when pnodes
+      (let [pnode (peek pnodes)]
+        (with-meta (if changed?
+                     [(make-node loc pnode (concat l (cons node r)))
+                      (and ppath (assoc ppath :changed? true))]
+                     [pnode ppath])
+          (meta loc))))))
 
 (defn root
   "zips all the way up and returns the root node, reflecting any
  changes."
   {:added "1.0"}
   [loc]
-    (if (= :end (loc 1))
-      (node loc)
-      (let [p (up loc)]
-        (if p
-          (recur p)
-          (node loc)))))
+  (if (= :end (loc 1))
+    (node loc)
+    (let [p (up loc)]
+      (if p
+        (recur p)
+        (node loc)))))
 
 (defn right
   "Returns the loc of the right sibling of the node at this loc, or nil"
   {:added "1.0"}
   [loc]
-    (let [[node {l :l  [r & rnext :as rs] :r :as path}] loc]
-      (when (and path rs)
-        (with-meta [r (assoc path :l (conj l node) :r rnext)] (meta loc)))))
+  (let [[node {l :l  [r & rnext :as rs] :r :as path}] loc]
+    (when (and path rs)
+      (with-meta [r (assoc path :l (conj l node) :r rnext)] (meta loc)))))
 
 (defn rightmost
   "Returns the loc of the rightmost sibling of the node at this loc, or self"
   {:added "1.0"}
   [loc]
-    (let [[node {l :l r :r :as path}] loc]
-      (if (and path r)
-        (with-meta [(last r) (assoc path :l (apply conj l node (butlast r)) :r nil)] (meta loc))
-        loc)))
+  (let [[node {l :l r :r :as path}] loc]
+    (if (and path r)
+      (with-meta [(last r) (assoc path :l (apply conj l node (butlast r)) :r nil)] (meta loc))
+      loc)))
 
 (defn left
   "Returns the loc of the left sibling of the node at this loc, or nil"
   {:added "1.0"}
   [loc]
-    (let [[node {l :l r :r :as path}] loc]
-      (when (and path (seq l))
-        (with-meta [(peek l) (assoc path :l (pop l) :r (cons node r))] (meta loc)))))
+  (let [[node {l :l r :r :as path}] loc]
+    (when (and path (seq l))
+      (with-meta [(peek l) (assoc path :l (pop l) :r (cons node r))] (meta loc)))))
 
 (defn leftmost
   "Returns the loc of the leftmost sibling of the node at this loc, or self"
   {:added "1.0"}
   [loc]
-    (let [[node {l :l r :r :as path}] loc]
-      (if (and path (seq l))
-        (with-meta [(first l) (assoc path :l [] :r (concat (rest l) [node] r))] (meta loc))
-        loc)))
+  (let [[node {l :l r :r :as path}] loc]
+    (if (and path (seq l))
+      (with-meta [(first l) (assoc path :l [] :r (concat (rest l) [node] r))] (meta loc))
+      loc)))
 
 (defn insert-left
   "Inserts the item as the left sibling of the node at this loc,
  without moving"
   {:added "1.0"}
   [loc item]
-    (let [[node {l :l :as path}] loc]
-      (if (nil? path)
-        (throw (new Exception "Insert at top"))
-        (with-meta [node (assoc path :l (conj l item) :changed? true)] (meta loc)))))
+  (let [[node {l :l :as path}] loc]
+    (if (nil? path)
+      (throw (new Exception "Insert at top"))
+      (with-meta [node (assoc path :l (conj l item) :changed? true)] (meta loc)))))
 
 (defn insert-right
   "Inserts the item as the right sibling of the node at this loc,
   without moving"
   {:added "1.0"}
   [loc item]
-    (let [[node {r :r :as path}] loc]
-      (if (nil? path)
-        (throw (new Exception "Insert at top"))
-        (with-meta [node (assoc path :r (cons item r) :changed? true)] (meta loc)))))
+  (let [[node {r :r :as path}] loc]
+    (if (nil? path)
+      (throw (new Exception "Insert at top"))
+      (with-meta [node (assoc path :r (cons item r) :changed? true)] (meta loc)))))
 
 (defn replace
   "Replaces the node at this loc, without moving"
   {:added "1.0"}
   [loc node]
-    (let [[_ path] loc]
-      (with-meta [node (assoc path :changed? true)] (meta loc))))
+  (let [[_ path] loc]
+    (with-meta [node (assoc path :changed? true)] (meta loc))))
 
 (defn edit
   "Replaces the node at this loc with the value of (f node args)"
   {:added "1.0"}
   [loc f & args]
-    (replace loc (apply f (node loc) args)))
+  (replace loc (apply f (node loc) args)))
 
 (defn insert-child
   "Inserts the item as the leftmost child of the node at this loc,
   without moving"
   {:added "1.0"}
   [loc item]
-    (replace loc (make-node loc (node loc) (cons item (children loc)))))
+  (replace loc (make-node loc (node loc) (cons item (children loc)))))
 
 (defn append-child
   "Inserts the item as the rightmost child of the node at this loc,
   without moving"
   {:added "1.0"}
   [loc item]
-    (replace loc (make-node loc (node loc) (concat (children loc) [item]))))
+  (replace loc (make-node loc (node loc) (concat (children loc) [item]))))
 
 (defn next
   "Moves to the next loc in the hierarchy, depth-first. When reaching
@@ -233,86 +232,85 @@
   at the end, stays there."
   {:added "1.0"}
   [loc]
-    (if (= :end (loc 1))
-      loc
-      (or 
-       (and (branch? loc) (down loc))
-       (right loc)
-       (loop [p loc]
-         (if (up p)
-           (or (right (up p)) (recur (up p)))
-           [(node p) :end])))))
+  (if (= :end (loc 1))
+    loc
+    (or
+     (and (branch? loc) (down loc))
+     (right loc)
+     (loop [p loc]
+       (if (up p)
+         (or (right (up p)) (recur (up p)))
+         [(node p) :end])))))
 
 (defn prev
   "Moves to the previous loc in the hierarchy, depth-first. If already
   at the root, returns nil."
   {:added "1.0"}
   [loc]
-    (if-let [lloc (left loc)]
-      (loop [loc lloc]
-        (if-let [child (and (branch? loc) (down loc))]
-          (recur (rightmost child))
-          loc))
-      (up loc)))
+  (if-let [lloc (left loc)]
+    (loop [loc lloc]
+      (if-let [child (and (branch? loc) (down loc))]
+        (recur (rightmost child))
+        loc))
+    (up loc)))
 
 (defn end?
   "Returns true if loc represents the end of a depth-first walk"
   {:added "1.0"}
   [loc]
-    (= :end (loc 1)))
+  (= :end (loc 1)))
 
 (defn remove
   "Removes the node at loc, returning the loc that would have preceded
   it in a depth-first walk."
   {:added "1.0"}
   [loc]
-    (let [[node {l :l, ppath :ppath, pnodes :pnodes, rs :r, :as path}] loc]
-      (if (nil? path)
-        (throw (new Exception "Remove at top"))
-        (if (pos? (count l))
-          (loop [loc (with-meta [(peek l) (assoc path :l (pop l) :changed? true)] (meta loc))]
-            (if-let [child (and (branch? loc) (down loc))]
-              (recur (rightmost child))
-              loc))
-          (with-meta [(make-node loc (peek pnodes) rs) 
-                      (and ppath (assoc ppath :changed? true))]
-                     (meta loc))))))
-  
+  (let [[node {l :l, ppath :ppath, pnodes :pnodes, rs :r, :as path}] loc]
+    (if (nil? path)
+      (throw (new Exception "Remove at top"))
+      (if (pos? (count l))
+        (loop [loc (with-meta [(peek l) (assoc path :l (pop l) :changed? true)] (meta loc))]
+          (if-let [child (and (branch? loc) (down loc))]
+            (recur (rightmost child))
+            loc))
+        (with-meta [(make-node loc (peek pnodes) rs)
+                    (and ppath (assoc ppath :changed? true))]
+          (meta loc))))))
+
 (comment
 
-(load-file "/Users/rich/dev/clojure/src/zip.clj")
-(refer 'zip)
-(def data '[[a * b] + [c * d]])
-(def dz (vector-zip data))
+  (load-file "/Users/rich/dev/clojure/src/zip.clj")
+  (refer 'zip)
+  (def data '[[a * b] + [c * d]])
+  (def dz (vector-zip data))
 
-(right (down (right (right (down dz)))))
-(lefts (right (down (right (right (down dz))))))
-(rights (right (down (right (right (down dz))))))
-(up (up (right (down (right (right (down dz)))))))
-(path (right (down (right (right (down dz))))))
+  (right (down (right (right (down dz)))))
+  (lefts (right (down (right (right (down dz))))))
+  (rights (right (down (right (right (down dz))))))
+  (up (up (right (down (right (right (down dz)))))))
+  (path (right (down (right (right (down dz))))))
 
-(-> dz down right right down right)
-(-> dz down right right down right (replace '/) root)
-(-> dz next next (edit str) next next next (replace '/) root)
-(-> dz next next next next next next next next next remove root)
-(-> dz next next next next next next next next next remove (insert-right 'e) root)
-(-> dz next next next next next next next next next remove up (append-child 'e) root)
+  (-> dz down right right down right)
+  (-> dz down right right down right (replace '/) root)
+  (-> dz next next (edit str) next next next (replace '/) root)
+  (-> dz next next next next next next next next next remove root)
+  (-> dz next next next next next next next next next remove (insert-right 'e) root)
+  (-> dz next next next next next next next next next remove up (append-child 'e) root)
 
-(end? (-> dz next next next next next next next next next remove next))
+  (end? (-> dz next next next next next next next next next remove next))
 
-(-> dz next remove next remove root)
+  (-> dz next remove next remove root)
 
-(loop [loc dz]
-  (if (end? loc)
-    (root loc)
-    (recur (next (if (= '* (node loc)) 
-                   (replace loc '/)
-                   loc)))))
+  (loop [loc dz]
+    (if (end? loc)
+      (root loc)
+      (recur (next (if (= '* (node loc))
+                     (replace loc '/)
+                     loc)))))
 
-(loop [loc dz]
-  (if (end? loc)
-    (root loc)
-    (recur (next (if (= '* (node loc)) 
-                   (remove loc)
-                   loc)))))
-)
+  (loop [loc dz]
+    (if (end? loc)
+      (root loc)
+      (recur (next (if (= '* (node loc))
+                     (remove loc)
+                     loc))))))

--- a/test/clojure/test_clojure/agents.clj
+++ b/test/clojure/test_clojure/agents.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Shawn Hoover
 
@@ -23,8 +23,8 @@
     (send agt (fn [state] (throw (Throwable. "just testing Throwables"))))
     (try
      ;; Let the action finish; eat the "agent has errors" error that bubbles up
-     (await-for fragile-wait agt)
-     (catch RuntimeException _))
+      (await-for fragile-wait agt)
+      (catch RuntimeException _))
     (is (instance? Throwable (agent-error agt)))
 
     ;; And now send an action that should work
@@ -46,21 +46,20 @@
     (is (= 0 @agt))
     (is (nil? (agent-error agt)))
     (is (= agt (first @err)))
-  (is (true? (instance? ArithmeticException (second @err))))))
-
+    (is (true? (instance? ArithmeticException (second @err))))))
 
 ;; TODO: make these tests deterministic (i.e. not sleep and hope)
 
 #_(deftest fail-handler
-  (let [err (atom nil)
-        agt (agent 0 :error-mode :fail :error-handler #(reset! err %&))]
-    (send agt /)
-    (Thread/sleep 100)
-    (is (true? (instance? ArithmeticException (agent-error agt))))
-    (is (= 0 @agt))
-    (is (= agt (first @err)))
-    (is (true? (instance? ArithmeticException (second @err))))
-    (is (thrown? RuntimeException (send agt inc)))))
+    (let [err (atom nil)
+          agt (agent 0 :error-mode :fail :error-handler #(reset! err %&))]
+      (send agt /)
+      (Thread/sleep 100)
+      (is (true? (instance? ArithmeticException (agent-error agt))))
+      (is (= 0 @agt))
+      (is (= agt (first @err)))
+      (is (true? (instance? ArithmeticException (second @err))))
+      (is (thrown? RuntimeException (send agt inc)))))
 
 (deftest can-send-from-error-handler-before-popping-action-that-caused-error
   (let [latch (CountDownLatch. 1)
@@ -82,57 +81,57 @@
     (is (.await latch 10 TimeUnit/SECONDS))))
 
 #_(deftest restart-no-clear
-  (let [p (promise)
-        agt (agent 1 :error-mode :fail)]
-    (send agt (fn [v] @p))
-    (send agt /)
-    (send agt inc)
-    (send agt inc)
-    (deliver p 0)
-    (Thread/sleep 100)
-    (is (= 0 @agt))
-    (is (= ArithmeticException (class (agent-error agt))))
-    (restart-agent agt 10)
-    (is (true? (await-for fragile-wait agt)))
-    (is (= 12 @agt))
-    (is (nil? (agent-error agt)))))
+    (let [p (promise)
+          agt (agent 1 :error-mode :fail)]
+      (send agt (fn [v] @p))
+      (send agt /)
+      (send agt inc)
+      (send agt inc)
+      (deliver p 0)
+      (Thread/sleep 100)
+      (is (= 0 @agt))
+      (is (= ArithmeticException (class (agent-error agt))))
+      (restart-agent agt 10)
+      (is (true? (await-for fragile-wait agt)))
+      (is (= 12 @agt))
+      (is (nil? (agent-error agt)))))
 
 #_(deftest restart-clear
-  (let [p (promise)
-        agt (agent 1 :error-mode :fail)]
-    (send agt (fn [v] @p))
-    (send agt /)
-    (send agt inc)
-    (send agt inc)
-    (deliver p 0)
-    (Thread/sleep 100)
-    (is (= 0 @agt))
-    (is (= ArithmeticException (class (agent-error agt))))
-    (restart-agent agt 10 :clear-actions true)
-    (is (true? (await-for fragile-wait agt)))
-    (is (= 10 @agt))
-    (is (nil? (agent-error agt)))
-    (send agt inc)
-    (is (true? (await-for fragile-wait agt)))
-    (is (= 11 @agt))
-    (is (nil? (agent-error agt)))))
+    (let [p (promise)
+          agt (agent 1 :error-mode :fail)]
+      (send agt (fn [v] @p))
+      (send agt /)
+      (send agt inc)
+      (send agt inc)
+      (deliver p 0)
+      (Thread/sleep 100)
+      (is (= 0 @agt))
+      (is (= ArithmeticException (class (agent-error agt))))
+      (restart-agent agt 10 :clear-actions true)
+      (is (true? (await-for fragile-wait agt)))
+      (is (= 10 @agt))
+      (is (nil? (agent-error agt)))
+      (send agt inc)
+      (is (true? (await-for fragile-wait agt)))
+      (is (= 11 @agt))
+      (is (nil? (agent-error agt)))))
 
 #_(deftest invalid-restart
-  (let [p (promise)
-        agt (agent 2 :error-mode :fail :validator even?)]
-    (is (thrown? RuntimeException (restart-agent agt 4)))
-    (send agt (fn [v] @p))
-    (send agt (partial + 2))
-    (send agt (partial + 2))
-    (deliver p 3)
-    (Thread/sleep 100)
-    (is (= 2 @agt))
-    (is (= IllegalStateException (class (agent-error agt))))
-    (is (thrown? RuntimeException (restart-agent agt 5)))
-    (restart-agent agt 6)
-    (is (true? (await-for fragile-wait agt)))
-    (is (= 10 @agt))
-    (is (nil? (agent-error agt)))))
+    (let [p (promise)
+          agt (agent 2 :error-mode :fail :validator even?)]
+      (is (thrown? RuntimeException (restart-agent agt 4)))
+      (send agt (fn [v] @p))
+      (send agt (partial + 2))
+      (send agt (partial + 2))
+      (deliver p 3)
+      (Thread/sleep 100)
+      (is (= 2 @agt))
+      (is (= IllegalStateException (class (agent-error agt))))
+      (is (thrown? RuntimeException (restart-agent agt 5)))
+      (restart-agent agt 6)
+      (is (true? (await-for fragile-wait agt)))
+      (is (= 10 @agt))
+      (is (nil? (agent-error agt)))))
 
 (deftest earmuff-agent-bound
   (let [a (agent 1)]
@@ -182,13 +181,13 @@
 (deftest seque-into-seque-deadlock
   (is (= (range 10) (seque 3 (seque 3 (range 10))))))
 
-; http://clojure.org/agents
+;; http://clojure.org/agents
 
-; agent
-; deref, @-reader-macro, agent-errors
-; send send-off clear-agent-errors
-; await await-for
-; set-validator get-validator
-; add-watch remove-watch
-; shutdown-agents
+;; agent
+;; deref, @-reader-macro, agent-errors
+;; send send-off clear-agent-errors
+;; await await-for
+;; set-validator get-validator
+;; add-watch remove-watch
+;; shutdown-agents
 

--- a/test/clojure/test_clojure/annotations.clj
+++ b/test/clojure/test_clojure/annotations.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Authors: Stuart Halloway, Rich Hickey
 
@@ -12,6 +12,6 @@
   (:use clojure.test))
 
 (case (System/getProperty "java.specification.version")
-      "1.6" (load "annotations/java_6")
-      nil)
+  "1.6" (load "annotations/java_6")
+  nil)
 

--- a/test/clojure/test_clojure/annotations/java_5.clj
+++ b/test/clojure/test_clojure/annotations/java_5.clj
@@ -6,13 +6,13 @@
 
 (deftype #^{Deprecated true
             Retention RetentionPolicy/RUNTIME}
-  Bar [#^int a
-       #^{:tag int
-          Deprecated true
-          Retention RetentionPolicy/RUNTIME} b]
+           Bar [#^int a
+                #^{:tag int
+                   Deprecated true
+                   Retention RetentionPolicy/RUNTIME} b]
   Foo (#^{Deprecated true
           Retention RetentionPolicy/RUNTIME}
-       foo [this] 42))
+         foo [this] 42))
 
 (defn annotation->map
   "Converts a Java annotation (which conceals data)
@@ -20,18 +20,18 @@
    Works recursively. Returns non-annotations unscathed."
   [#^java.lang.annotation.Annotation o]
   (cond
-   (instance? Annotation o)
-   (let [type (.annotationType o)
-         itfs (-> (into #{type} (supers type)) (disj java.lang.annotation.Annotation))
-         data-methods (into #{} (mapcat #(.getDeclaredMethods %) itfs))]
-     (into
-      {:annotationType (.annotationType o)}
-      (map
-       (fn [m] [(keyword (.getName m)) (annotation->map (.invoke m o nil))])
-       data-methods)))
-   (or (sequential? o) (.isArray (class o)))
-   (map annotation->map o)
-     :else o))
+    (instance? Annotation o)
+    (let [type (.annotationType o)
+          itfs (-> (into #{type} (supers type)) (disj java.lang.annotation.Annotation))
+          data-methods (into #{} (mapcat #(.getDeclaredMethods %) itfs))]
+      (into
+       {:annotationType (.annotationType o)}
+       (map
+        (fn [m] [(keyword (.getName m)) (annotation->map (.invoke m o nil))])
+        data-methods)))
+    (or (sequential? o) (.isArray (class o)))
+    (map annotation->map o)
+    :else o))
 
 (def expected-annotations
   #{{:annotationType java.lang.annotation.Retention, :value RetentionPolicy/RUNTIME}

--- a/test/clojure/test_clojure/annotations/java_6.clj
+++ b/test/clojure/test_clojure/annotations/java_6.clj
@@ -11,22 +11,22 @@
             javax.xml.ws.soap.Addressing {:enabled false :required true}
             WebServiceRefs [(WebServiceRef {:name "fred" :type String})
                             (WebServiceRef {:name "ethel" :mappedName "lucy"})]}
-  Bar [#^int a
-       #^{:tag int
-          Deprecated true
-          Retention RetentionPolicy/RUNTIME
-          javax.annotation.processing.SupportedOptions ["foo" "bar" "baz"]
-            javax.xml.ws.soap.Addressing {:enabled false :required true}
-          WebServiceRefs [(WebServiceRef {:name "fred" :type String})
-                            (WebServiceRef {:name "ethel" :mappedName "lucy"})]}
-       b]
+           Bar [#^int a
+                #^{:tag int
+                   Deprecated true
+                   Retention RetentionPolicy/RUNTIME
+                   javax.annotation.processing.SupportedOptions ["foo" "bar" "baz"]
+                   javax.xml.ws.soap.Addressing {:enabled false :required true}
+                   WebServiceRefs [(WebServiceRef {:name "fred" :type String})
+                                   (WebServiceRef {:name "ethel" :mappedName "lucy"})]}
+                  b]
   Foo (#^{Deprecated true
           Retention RetentionPolicy/RUNTIME
           javax.annotation.processing.SupportedOptions ["foo" "bar" "baz"]
           javax.xml.ws.soap.Addressing {:enabled false :required true}
           WebServiceRefs [(WebServiceRef {:name "fred" :type String})
                           (WebServiceRef {:name "ethel" :mappedName "lucy"})]}
-       foo [this] 42))
+         foo [this] 42))
 
 (defn annotation->map
   "Converts a Java annotation (which conceals data)
@@ -34,18 +34,18 @@
    Works recursively. Returns non-annotations unscathed."
   [#^java.lang.annotation.Annotation o]
   (cond
-   (instance? Annotation o)
-   (let [type (.annotationType o)
-         itfs (-> (into #{type} (supers type)) (disj java.lang.annotation.Annotation))
-         data-methods (into #{} (mapcat #(.getDeclaredMethods %) itfs))]
-     (into
-      {:annotationType (.annotationType o)}
-      (map
-       (fn [m] [(keyword (.getName m)) (annotation->map (.invoke m o nil))])
-       data-methods)))
-   (or (sequential? o) (.isArray (class o)))
-   (map annotation->map o)
-     :else o))
+    (instance? Annotation o)
+    (let [type (.annotationType o)
+          itfs (-> (into #{type} (supers type)) (disj java.lang.annotation.Annotation))
+          data-methods (into #{} (mapcat #(.getDeclaredMethods %) itfs))]
+      (into
+       {:annotationType (.annotationType o)}
+       (map
+        (fn [m] [(keyword (.getName m)) (annotation->map (.invoke m o nil))])
+        data-methods)))
+    (or (sequential? o) (.isArray (class o)))
+    (map annotation->map o)
+    :else o))
 
 (def expected-annotations
   #{{:annotationType java.lang.annotation.Retention, :value RetentionPolicy/RUNTIME}

--- a/test/clojure/test_clojure/api.clj
+++ b/test/clojure/test_clojure/api.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.api
   (:require [clojure.test.generative :refer (defspec)]
@@ -50,5 +50,4 @@
   [^{:tag cgen/var} v]
   (when-not (= v %)
     (throw (ex-info "Var cannot roundtrip strings through Clojure/var" {:from v :to %}))))
-
 

--- a/test/clojure/test_clojure/atoms.clj
+++ b/test/clojure/test_clojure/atoms.clj
@@ -1,20 +1,20 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;Author: Frantisek Sodomka
 
 (ns clojure.test-clojure.atoms
   (:use clojure.test))
 
-; http://clojure.org/atoms
+;; http://clojure.org/atoms
 
-; atom
-; deref, @-reader-macro
-; swap! reset!
-; compare-and-set!
+;; atom
+;; deref, @-reader-macro
+;; swap! reset!
+;; compare-and-set!
 

--- a/test/clojure/test_clojure/clojure_set.clj
+++ b/test/clojure/test_clojure/clojure_set.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Frantisek Sodomka
 
@@ -15,121 +15,121 @@
 
 (deftest test-union
   (are [x y] (= x y)
-      (set/union) #{}
+    (set/union) #{}
 
       ; identity
-      (set/union #{}) #{}
-      (set/union #{1}) #{1}
-      (set/union #{1 2 3}) #{1 2 3}
+    (set/union #{}) #{}
+    (set/union #{1}) #{1}
+    (set/union #{1 2 3}) #{1 2 3}
 
       ; 2 sets, at least one is empty
-      (set/union #{} #{}) #{}
-      (set/union #{} #{1}) #{1}
-      (set/union #{} #{1 2 3}) #{1 2 3}
-      (set/union #{1} #{}) #{1}
-      (set/union #{1 2 3} #{}) #{1 2 3}
+    (set/union #{} #{}) #{}
+    (set/union #{} #{1}) #{1}
+    (set/union #{} #{1 2 3}) #{1 2 3}
+    (set/union #{1} #{}) #{1}
+    (set/union #{1 2 3} #{}) #{1 2 3}
 
       ; 2 sets
-      (set/union #{1} #{2}) #{1 2}
-      (set/union #{1} #{1 2}) #{1 2}
-      (set/union #{2} #{1 2}) #{1 2}
-      (set/union #{1 2} #{3}) #{1 2 3}
-      (set/union #{1 2} #{2 3}) #{1 2 3}
+    (set/union #{1} #{2}) #{1 2}
+    (set/union #{1} #{1 2}) #{1 2}
+    (set/union #{2} #{1 2}) #{1 2}
+    (set/union #{1 2} #{3}) #{1 2 3}
+    (set/union #{1 2} #{2 3}) #{1 2 3}
 
       ; 3 sets, some are empty
-      (set/union #{} #{} #{}) #{}
-      (set/union #{1} #{} #{}) #{1}
-      (set/union #{} #{1} #{}) #{1}
-      (set/union #{} #{} #{1}) #{1}
-      (set/union #{1 2} #{2 3} #{}) #{1 2 3}
+    (set/union #{} #{} #{}) #{}
+    (set/union #{1} #{} #{}) #{1}
+    (set/union #{} #{1} #{}) #{1}
+    (set/union #{} #{} #{1}) #{1}
+    (set/union #{1 2} #{2 3} #{}) #{1 2 3}
 
       ; 3 sets
-      (set/union #{1 2} #{3 4} #{5 6}) #{1 2 3 4 5 6}
-      (set/union #{1 2} #{2 3} #{1 3 4}) #{1 2 3 4}
+    (set/union #{1 2} #{3 4} #{5 6}) #{1 2 3 4 5 6}
+    (set/union #{1 2} #{2 3} #{1 3 4}) #{1 2 3 4}
 
       ; different data types
-      (set/union #{1 2} #{:a :b} #{nil} #{false true} #{\c "abc"} #{[] [1 2]}
-        #{{} {:a 1}} #{#{} #{1 2}})
-          #{1 2 :a :b nil false true \c "abc" [] [1 2] {} {:a 1} #{} #{1 2}}
+    (set/union #{1 2} #{:a :b} #{nil} #{false true} #{\c "abc"} #{[] [1 2]}
+               #{{} {:a 1}} #{#{} #{1 2}})
+    #{1 2 :a :b nil false true \c "abc" [] [1 2] {} {:a 1} #{} #{1 2}}
 
       ; different types of sets
-      (set/union (hash-set) (hash-set 1 2) (hash-set 2 3))
-          (hash-set 1 2 3)
-      (set/union (sorted-set) (sorted-set 1 2) (sorted-set 2 3))
-          (sorted-set 1 2 3)
-      (set/union (hash-set) (hash-set 1 2) (hash-set 2 3)
-        (sorted-set) (sorted-set 4 5) (sorted-set 5 6))
-          (hash-set 1 2 3 4 5 6)  ; also equals (sorted-set 1 2 3 4 5 6)
+    (set/union (hash-set) (hash-set 1 2) (hash-set 2 3))
+    (hash-set 1 2 3)
+    (set/union (sorted-set) (sorted-set 1 2) (sorted-set 2 3))
+    (sorted-set 1 2 3)
+    (set/union (hash-set) (hash-set 1 2) (hash-set 2 3)
+               (sorted-set) (sorted-set 4 5) (sorted-set 5 6))
+    (hash-set 1 2 3 4 5 6)  ; also equals (sorted-set 1 2 3 4 5 6)
 ))
 
 (deftest test-intersection
   ; at least one argument is needed
   (is (thrown? IllegalArgumentException (set/intersection)))
-  
+
   (are [x y] (= x y)
       ; identity
-      (set/intersection #{}) #{}
-      (set/intersection #{1}) #{1}
-      (set/intersection #{1 2 3}) #{1 2 3}
-      
+    (set/intersection #{}) #{}
+    (set/intersection #{1}) #{1}
+    (set/intersection #{1 2 3}) #{1 2 3}
+
       ; 2 sets, at least one is empty
-      (set/intersection #{} #{}) #{}
-      (set/intersection #{} #{1}) #{}
-      (set/intersection #{} #{1 2 3}) #{}
-      (set/intersection #{1} #{}) #{}
-      (set/intersection #{1 2 3} #{}) #{}
+    (set/intersection #{} #{}) #{}
+    (set/intersection #{} #{1}) #{}
+    (set/intersection #{} #{1 2 3}) #{}
+    (set/intersection #{1} #{}) #{}
+    (set/intersection #{1 2 3} #{}) #{}
 
       ; 2 sets
-      (set/intersection #{1 2} #{1 2}) #{1 2}
-      (set/intersection #{1 2} #{3 4}) #{}
-      (set/intersection #{1 2} #{1}) #{1}
-      (set/intersection #{1 2} #{2}) #{2}
-      (set/intersection #{1 2 4} #{2 3 4 5}) #{2 4}
+    (set/intersection #{1 2} #{1 2}) #{1 2}
+    (set/intersection #{1 2} #{3 4}) #{}
+    (set/intersection #{1 2} #{1}) #{1}
+    (set/intersection #{1 2} #{2}) #{2}
+    (set/intersection #{1 2 4} #{2 3 4 5}) #{2 4}
 
       ; 3 sets, some are empty
-      (set/intersection #{} #{} #{}) #{}
-      (set/intersection #{1} #{} #{}) #{}
-      (set/intersection #{1} #{1} #{}) #{}
-      (set/intersection #{1} #{} #{1}) #{}
-      (set/intersection #{1 2} #{2 3} #{}) #{}
+    (set/intersection #{} #{} #{}) #{}
+    (set/intersection #{1} #{} #{}) #{}
+    (set/intersection #{1} #{1} #{}) #{}
+    (set/intersection #{1} #{} #{1}) #{}
+    (set/intersection #{1 2} #{2 3} #{}) #{}
 
       ; 3 sets
-      (set/intersection #{1 2} #{2 3} #{5 2}) #{2}
-      (set/intersection #{1 2 3} #{1 3 4} #{1 3}) #{1 3}
-      (set/intersection #{1 2 3} #{3 4 5} #{8 2 3}) #{3}
+    (set/intersection #{1 2} #{2 3} #{5 2}) #{2}
+    (set/intersection #{1 2 3} #{1 3 4} #{1 3}) #{1 3}
+    (set/intersection #{1 2 3} #{3 4 5} #{8 2 3}) #{3}
 
       ; different types of sets
-      (set/intersection (hash-set 1 2) (hash-set 2 3)) #{2}
-      (set/intersection (sorted-set 1 2) (sorted-set 2 3)) #{2}
-      (set/intersection
-        (hash-set 1 2) (hash-set 2 3)
-        (sorted-set 1 2) (sorted-set 2 3)) #{2} ))
+    (set/intersection (hash-set 1 2) (hash-set 2 3)) #{2}
+    (set/intersection (sorted-set 1 2) (sorted-set 2 3)) #{2}
+    (set/intersection
+     (hash-set 1 2) (hash-set 2 3)
+     (sorted-set 1 2) (sorted-set 2 3)) #{2}))
 
 (deftest test-difference
   (are [x y] (= x y)
       ; identity
-      (set/difference #{}) #{}
-      (set/difference #{1}) #{1}
-      (set/difference #{1 2 3}) #{1 2 3}
+    (set/difference #{}) #{}
+    (set/difference #{1}) #{1}
+    (set/difference #{1 2 3}) #{1 2 3}
 
       ; 2 sets
-      (set/difference #{1 2} #{1 2}) #{}
-      (set/difference #{1 2} #{3 4}) #{1 2}
-      (set/difference #{1 2} #{1}) #{2}
-      (set/difference #{1 2} #{2}) #{1}
-      (set/difference #{1 2 4} #{2 3 4 5}) #{1}
+    (set/difference #{1 2} #{1 2}) #{}
+    (set/difference #{1 2} #{3 4}) #{1 2}
+    (set/difference #{1 2} #{1}) #{2}
+    (set/difference #{1 2} #{2}) #{1}
+    (set/difference #{1 2 4} #{2 3 4 5}) #{1}
 
        ; 3 sets
-      (set/difference #{1 2} #{2 3} #{5 2}) #{1}
-      (set/difference #{1 2 3} #{1 3 4} #{1 3}) #{2}
-      (set/difference #{1 2 3} #{3 4 5} #{8 2 3}) #{1} ))
+    (set/difference #{1 2} #{2 3} #{5 2}) #{1}
+    (set/difference #{1 2 3} #{1 3 4} #{1 3}) #{2}
+    (set/difference #{1 2 3} #{3 4 5} #{8 2 3}) #{1}))
 
 (deftest test-select
   (are [x y] (= x y)
     (set/select integer? #{}) #{}
     (set/select integer? #{1 2}) #{1 2}
     (set/select integer? #{1 2 :a :b :c}) #{1 2}
-    (set/select integer? #{:a :b :c}) #{}) )
+    (set/select integer? #{:a :b :c}) #{}))
 
 (def compositions
   #{{:name "Art of the Fugue" :composer "J. S. Bach"}
@@ -146,7 +146,7 @@
                                              {:composer "Giuseppe Verdi"}
                                              {:composer "J. S. Bach"}}
     (set/project compositions [:year]) #{{}}
-    (set/project #{{}} [:name]) #{{}} ))
+    (set/project #{{}} [:name]) #{{}}))
 
 (deftest test-rename
   (are [x y] (= x y)
@@ -162,63 +162,61 @@
 
 (deftest test-rename-keys
   (are [x y] (= x y)
-       (set/rename-keys {:a "one" :b "two"} {:a :z}) {:z "one" :b "two"}
-       (set/rename-keys {:a "one" :b "two"} {:a :z :c :y}) {:z "one" :b "two"}
-       (set/rename-keys {:a "one" :b "two" :c "three"} {:a :b :b :a}) {:a "two" :b "one" :c "three"}))
+    (set/rename-keys {:a "one" :b "two"} {:a :z}) {:z "one" :b "two"}
+    (set/rename-keys {:a "one" :b "two"} {:a :z :c :y}) {:z "one" :b "two"}
+    (set/rename-keys {:a "one" :b "two" :c "three"} {:a :b :b :a}) {:a "two" :b "one" :c "three"}))
 
 (deftest test-index
   (are [x y] (= x y)
-    (set/index  #{{:c 2} {:b 1} {:a 1 :b 2}} [:b]) {{:b 2} #{{:a 1 :b 2}}, {:b 1} #{{:b 1}} {} #{{:c 2}}}
-  ))
+    (set/index  #{{:c 2} {:b 1} {:a 1 :b 2}} [:b]) {{:b 2} #{{:a 1 :b 2}}, {:b 1} #{{:b 1}} {} #{{:c 2}}}))
 
 (deftest test-join
   (are [x y] (= x y)
     (set/join compositions compositions) compositions
     (set/join compositions #{{:name "Art of the Fugue" :genre "Classical"}})
-                           #{{:name "Art of the Fugue" :composer "J. S. Bach" :genre "Classical"}}
-    ))
+    #{{:name "Art of the Fugue" :composer "J. S. Bach" :genre "Classical"}}))
 
 (deftest test-map-invert
   (are [x y] (= x y)
-       (set/map-invert {:a "one" :b "two"}) {"one" :a "two" :b}))
+    (set/map-invert {:a "one" :b "two"}) {"one" :a "two" :b}))
 
 (deftest test-subset?
   (are [sub super] (set/subset? sub super)
-       #{} #{}
-       #{} #{1}
-       #{1} #{1}
-       #{1 2} #{1 2}
-       #{1 2} #{1 2 42}
-       #{false} #{false}
-       #{nil}   #{nil}
-       #{nil}   #{nil false}
-       #{1 2 nil} #{1 2 nil 4})
+    #{} #{}
+    #{} #{1}
+    #{1} #{1}
+    #{1 2} #{1 2}
+    #{1 2} #{1 2 42}
+    #{false} #{false}
+    #{nil}   #{nil}
+    #{nil}   #{nil false}
+    #{1 2 nil} #{1 2 nil 4})
   (are [notsub super] (not (set/subset? notsub super))
-       #{1} #{}
-       #{2} #{1}
-       #{1 3} #{1}
-       #{nil} #{false}
-       #{false} #{nil}
-       #{false nil} #{nil}
-       #{1 2 nil}   #{1 2}))
+    #{1} #{}
+    #{2} #{1}
+    #{1 3} #{1}
+    #{nil} #{false}
+    #{false} #{nil}
+    #{false nil} #{nil}
+    #{1 2 nil}   #{1 2}))
 
 (deftest test-superset?
   (are [super sub] (set/superset? super sub)
-       #{} #{}
-       #{1} #{}
-       #{1} #{1}
-       #{1 2} #{1 2}
-       #{1 2 42} #{1 2}
-       #{false}  #{false}
-       #{nil}    #{nil}
-       #{false nil} #{false}
-       #{1 2 4 nil false} #{1 2 nil})
+    #{} #{}
+    #{1} #{}
+    #{1} #{1}
+    #{1 2} #{1 2}
+    #{1 2 42} #{1 2}
+    #{false}  #{false}
+    #{nil}    #{nil}
+    #{false nil} #{false}
+    #{1 2 4 nil false} #{1 2 nil})
   (are [notsuper sub] (not (set/superset? notsuper sub))
-       #{} #{1}
-       #{2} #{1}
-       #{1} #{1 3}
-       #{nil} #{false}
-       #{false} #{nil}
-       #{nil}   #{false nil}
-       #{nil 2 3} #{false nil 2 3}))
+    #{} #{1}
+    #{2} #{1}
+    #{1} #{1 3}
+    #{nil} #{false}
+    #{false} #{nil}
+    #{nil}   #{false nil}
+    #{nil 2 3} #{false nil 2 3}))
 

--- a/test/clojure/test_clojure/clojure_walk.clj
+++ b/test/clojure/test_clojure/clojure_walk.clj
@@ -6,7 +6,7 @@
   (is (= (w/prewalk-replace {:a :b} [:a {:a :a} (list 3 :c :a)])
          [:b {:b :b} (list 3 :c :b)])))
 
-(deftest t-postwalk-replace 
+(deftest t-postwalk-replace
   (is (= (w/postwalk-replace {:a :b} [:a {:a :a} (list 3 :c :a)])
          [:b {:b :b} (list 3 :c :b)])))
 
@@ -26,7 +26,7 @@
 (deftest t-postwalk-order
   (is (= (let [a (atom [])]
            (w/postwalk (fn [form] (swap! a conj form) form)
-                      [1 2 {:a 3} (list 4 [5])])
+                       [1 2 {:a 3} (list 4 [5])])
            @a)
          [1 2
           :a 3 [:a 3] {:a 3}
@@ -36,25 +36,25 @@
 (defrecord Foo [a b c])
 
 (deftest walk
-         "Checks that walk returns the correct result and type of collection"
-         (let [colls ['(1 2 3)
-                      [1 2 3]
-                      #{1 2 3}
-                      (sorted-set-by > 1 2 3)
-                      {:a 1, :b 2, :c 3}
-                      (sorted-map-by > 1 10, 2 20, 3 30)
-                      (->Foo 1 2 3)
-                      (map->Foo {:a 1 :b 2 :c 3 :extra 4})]]
-           (doseq [c colls]
-             (let [walked (w/walk identity identity c)]
-               (is (= c walked))
+  "Checks that walk returns the correct result and type of collection"
+  (let [colls ['(1 2 3)
+               [1 2 3]
+               #{1 2 3}
+               (sorted-set-by > 1 2 3)
+               {:a 1, :b 2, :c 3}
+               (sorted-map-by > 1 10, 2 20, 3 30)
+               (->Foo 1 2 3)
+               (map->Foo {:a 1 :b 2 :c 3 :extra 4})]]
+    (doseq [c colls]
+      (let [walked (w/walk identity identity c)]
+        (is (= c walked))
 									;;(is (= (type c) (type walked)))
-               (if (map? c)
-                 (is (= (w/walk #(update-in % [1] inc) #(reduce + (vals %)) c)
-                        (reduce + (map (comp inc val) c))))
-                 (is (= (w/walk inc #(reduce + %) c)
-                        (reduce + (map inc c)))))
-               (when (or (instance? clojure.lang.PersistentTreeMap c)
-                         (instance? clojure.lang.PersistentTreeSet c))
-                 (is (= (.comparator c) (.comparator walked))))))))
+        (if (map? c)
+          (is (= (w/walk #(update-in % [1] inc) #(reduce + (vals %)) c)
+                 (reduce + (map (comp inc val) c))))
+          (is (= (w/walk inc #(reduce + %) c)
+                 (reduce + (map inc c)))))
+        (when (or (instance? clojure.lang.PersistentTreeMap c)
+                  (instance? clojure.lang.PersistentTreeSet c))
+          (is (= (.comparator c) (.comparator walked))))))))
 

--- a/test/clojure/test_clojure/clojure_xml.clj
+++ b/test/clojure/test_clojure/clojure_xml.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;Author: Frantisek Sodomka
 
@@ -13,9 +13,8 @@
   (:use clojure.test)
   (:require [clojure.xml :as xml]))
 
+;; parse
 
-; parse
-
-; emit-element
-; emit
+;; emit-element
+;; emit
 

--- a/test/clojure/test_clojure/clojure_zip.clj
+++ b/test/clojure/test_clojure/clojure_zip.clj
@@ -1,48 +1,47 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 
 (ns clojure.test-clojure.clojure-zip
   (:use clojure.test)
   (:require [clojure.zip :as zip]))
 
-
-; zipper
+;; zipper
 ;
-; seq-zip
-; vector-zip
-; xml-zip
+;; seq-zip
+;; vector-zip
+;; xml-zip
 ;
-; node
-; branch?
-; children
-; make-node
-; path
-; lefts
-; rights
-; down
-; up
-; root
-; right
-; rightmost
-; left
-; leftmost
+;; node
+;; branch?
+;; children
+;; make-node
+;; path
+;; lefts
+;; rights
+;; down
+;; up
+;; root
+;; right
+;; rightmost
+;; left
+;; leftmost
 ;
-; insert-left
-; insert-right
-; replace
-; edit
-; insert-child
-; append-child
-; next
-; prev
-; end?
-; remove
+;; insert-left
+;; insert-right
+;; replace
+;; edit
+;; insert-child
+;; append-child
+;; next
+;; prev
+;; end?
+;; remove
 

--- a/test/clojure/test_clojure/compilation.clj
+++ b/test/clojure/test_clojure/compilation.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 
 (ns clojure.test-clojure.compilation
@@ -17,32 +17,32 @@
   (:use clojure.test
         [clojure.test-helper :only (should-not-reflect should-print-err-message)]))
 
-; http://clojure.org/compilation
+;; http://clojure.org/compilation
 
-; compile
-; gen-class, gen-interface
+;; compile
+;; gen-class, gen-interface
 
 
 (deftest test-compiler-metadata
   (let [m (meta #'when)]
     (are [x y]  (= x y)
-        (list? (:arglists m)) true
-        (> (count (:arglists m)) 0) true
+      (list? (:arglists m)) true
+      (> (count (:arglists m)) 0) true
 
-        (string? (:doc m)) true
-        (> (.length (:doc m)) 0) true
+      (string? (:doc m)) true
+      (> (.length (:doc m)) 0) true
 
-        (string? (:file m)) true
-        (> (.length (:file m)) 0) true
+      (string? (:file m)) true
+      (> (.length (:file m)) 0) true
 
-        (integer? (:line m)) true
-        (> (:line m) 0) true
+      (integer? (:line m)) true
+      (> (:line m) 0) true
 
-        (integer? (:column m)) true
-        (> (:column m) 0) true
+      (integer? (:column m)) true
+      (> (:column m) 0) true
 
-        (:macro m) true
-        (:name m) 'when )))
+      (:macro m) true
+      (:name m) 'when)))
 
 (deftest test-embedded-constants
   (testing "Embedded constants"
@@ -113,9 +113,9 @@
 
 ;; disabled until build box can call java from mvn
 #_(deftest test-numeric-dispatch
-  (is (= "(int, int)" (TestDispatch/someMethod (int 1) (int 1))))
-  (is (= "(int, long)" (TestDispatch/someMethod (int 1) (long 1))))
-  (is (= "(long, long)" (TestDispatch/someMethod (long 1) (long 1)))))
+    (is (= "(int, int)" (TestDispatch/someMethod (int 1) (int 1))))
+    (is (= "(int, long)" (TestDispatch/someMethod (int 1) (long 1))))
+    (is (= "(long, long)" (TestDispatch/someMethod (long 1) (long 1)))))
 
 (deftest test-CLJ-671-regression
   (testing "that the presence of hints does not cause the compiler to infinitely loop"
@@ -123,7 +123,7 @@
               (loop [x (long x) y (long y)]
                 (if (== y 0)
                   x
-                  (recur y ^Long(rem x y)))))]
+                  (recur y ^Long (rem x y)))))]
       (is (= 4 (gcd 8 100))))))
 
 ;; ensure proper use of hints / type decls
@@ -156,12 +156,12 @@
 (deftest calls-use-arg-vector-hint
   (should-not-reflect #(.floatValue (clojure.test-clojure.compilation/hinting-conflict)))
   (should-print-err-message #"(?s)Reflection warning.*"
-    #(.substring (clojure.test-clojure.compilation/hinting-conflict) 0)))
+                            #(.substring (clojure.test-clojure.compilation/hinting-conflict) 0)))
 
 (deftest deref-uses-var-tag
   (should-not-reflect #(.substring clojure.test-clojure.compilation/hinting-conflict 0))
   (should-print-err-message #"(?s)Reflection warning.*"
-    #(.floatValue clojure.test-clojure.compilation/hinting-conflict)))
+                            #(.floatValue clojure.test-clojure.compilation/hinting-conflict)))
 
 (defn ^String legacy-hinting [])
 
@@ -170,7 +170,7 @@
 
 (defprotocol HintedProtocol
   (hintedp ^String [a]
-           ^Integer [a b]))
+    ^Integer [a b]))
 
 (deftest hinted-protocol-arg-vector
   (should-not-reflect #(.substring (clojure.test-clojure.compilation/hintedp "") 0))
@@ -185,34 +185,34 @@
   (should-not-reflect #(loop [k 5.0] (recur (clojure.test-clojure.compilation/primfn 0))))
 
   (should-print-err-message #"(?s).*k is not matching primitive.*"
-    #(loop [k (clojure.test-clojure.compilation/primfn)] (recur :foo))))
+                            #(loop [k (clojure.test-clojure.compilation/primfn)] (recur :foo))))
 
 #_(deftest CLJ-1154-use-out-after-compile
   ;; This test creates a dummy file to compile, sets up a dummy
   ;; compiled output directory, and a dummy output stream, and
   ;; verifies the stream is still usable after compiling.
-  (spit "test/dummy.clj" "(ns dummy)")
-  (try
-    (let [compile-path (System/getProperty "clojure.compile.path")
-          tmp (java.io.File. "tmp")
-          new-out (java.io.OutputStreamWriter. (java.io.ByteArrayOutputStream.))]
-      (binding [clojure.core/*out* new-out]
-        (try
-          (.mkdir tmp)
-          (System/setProperty "clojure.compile.path" "tmp")
-          (clojure.lang.Compile/main (into-array ["dummy"]))
-          (println "this should still work without throwing an exception" )
-          (finally
-            (if compile-path
-              (System/setProperty "clojure.compile.path" compile-path)
-              (System/clearProperty "clojure.compile.path"))
-            (doseq [f (.listFiles tmp)]
-              (.delete f))
-            (.delete tmp)))))
-    (finally
-      (doseq [f (.listFiles (java.io.File. "test"))
-              :when (re-find #"dummy.clj" (str f))]
-        (.delete f)))))
+    (spit "test/dummy.clj" "(ns dummy)")
+    (try
+      (let [compile-path (System/getProperty "clojure.compile.path")
+            tmp (java.io.File. "tmp")
+            new-out (java.io.OutputStreamWriter. (java.io.ByteArrayOutputStream.))]
+        (binding [clojure.core/*out* new-out]
+          (try
+            (.mkdir tmp)
+            (System/setProperty "clojure.compile.path" "tmp")
+            (clojure.lang.Compile/main (into-array ["dummy"]))
+            (println "this should still work without throwing an exception")
+            (finally
+              (if compile-path
+                (System/setProperty "clojure.compile.path" compile-path)
+                (System/clearProperty "clojure.compile.path"))
+              (doseq [f (.listFiles tmp)]
+                (.delete f))
+              (.delete tmp)))))
+      (finally
+        (doseq [f (.listFiles (java.io.File. "test"))
+                :when (re-find #"dummy.clj" (str f))]
+          (.delete f)))))
 
 (deftest CLJ-1184-do-in-non-list-test
   (testing "do in a vector throws an exception"
@@ -227,12 +227,12 @@
   (letfn [(compile [s]
             (spit "test/clojure/bad_def_test.clj" (str "(ns clojure.bad-def-test)\n" s))
             (try
-             (binding [*compile-path* "test"]
-               (clojure.core/compile 'clojure.bad-def-test))
-             (finally
-               (doseq [f (.listFiles (java.io.File. "test/clojure"))
-                       :when (re-find #"bad_def_test" (str f))]
-                 (.delete f)))))]
+              (binding [*compile-path* "test"]
+                (clojure.core/compile 'clojure.bad-def-test))
+              (finally
+                (doseq [f (.listFiles (java.io.File. "test/clojure"))
+                        :when (re-find #"bad_def_test" (str f))]
+                  (.delete f)))))]
     (testing "do in a vector throws an exception in compilation"
       (is (thrown? Compiler$CompilerException (compile "[do 1 2 3]"))))
     (testing "do in a set throws an exception in compilation"
@@ -268,28 +268,25 @@
   (should-not-reflect #(Math/abs (clojure.test-clojure.compilation/hinted-primfn 1)))
   (should-not-reflect #(Math/abs ^long (clojure.test-clojure.compilation/unhinted-primfn 1))))
 
-
 (defrecord Y [a])
-#clojure.test_clojure.compilation.Y[1]
+#clojure.test_clojure.compilation.Y [1]
 (defrecord Y [b])
 
 (binding [*compile-path* "target/test-classes"]
   (compile 'clojure.test-clojure.compilation.examples))
 
-
 (deftest test-compiler-line-numbers
   (let [fails-on-line-number? (fn [expected function]
-                                 (try
-                                   (function)
-                                   nil
-                                   (catch Throwable t
-                                     (let [frames (filter #(= "line_number_examples.clj" (.getFileName %))
-                                                          (.getStackTrace t))
-                                           _ (if (zero? (count frames))
-                                               (.printStackTrace t)
-                                               )
-                                           actual (.getLineNumber ^StackTraceElement (first frames))]
-                                       (= expected actual)))))]
+                                (try
+                                  (function)
+                                  nil
+                                  (catch Throwable t
+                                    (let [frames (filter #(= "line_number_examples.clj" (.getFileName %))
+                                                         (.getStackTrace t))
+                                          _ (if (zero? (count frames))
+                                              (.printStackTrace t))
+                                          actual (.getLineNumber ^StackTraceElement (first frames))]
+                                      (= expected actual)))))]
     (is (fails-on-line-number?  13 line/instance-field))
     (is (fails-on-line-number?  19 line/instance-field-reflected))
     (is (fails-on-line-number?  25 line/instance-field-unboxed))
@@ -324,26 +321,26 @@
 
 (deftest clj-1568
   (let [compiler-fails-at?
-          (fn [row col source]
-            (try
-              (Compiler/load (java.io.StringReader. source) (name (gensym "clj-1568.example-")) "clj-1568.example")
-              nil
-              (catch Compiler$CompilerException e
-                (re-find (re-pattern (str "^.*:" row ":" col "\\)$"))
-                         (.getMessage e)))))]
+        (fn [row col source]
+          (try
+            (Compiler/load (java.io.StringReader. source) (name (gensym "clj-1568.example-")) "clj-1568.example")
+            nil
+            (catch Compiler$CompilerException e
+              (re-find (re-pattern (str "^.*:" row ":" col "\\)$"))
+                       (.getMessage e)))))]
     (testing "with error in the initial form"
       (are [row col source] (compiler-fails-at? row col source)
            ;; note that the spacing of the following string is important
-           1  4 "   (.foo nil)"
-           2 18 "
+        1  4 "   (.foo nil)"
+        2 18 "
                  (/ 1 0)"))
     (testing "with error in an non-initial form"
       (are [row col source] (compiler-fails-at? row col source)
            ;; note that the spacing of the following string is important
-           3 18 "(:foo {})
+        3 18 "(:foo {})
 
                  (.foo nil)"
-           4 20 "(ns clj-1568.example)
+        4 20 "(ns clj-1568.example)
 
 
                    (/ 1 0)"))))
@@ -373,7 +370,7 @@
 (deftest incorrect-primitive-type-hint-throws
   ;; invalid primitive type hint
   (is (thrown-with-msg? Compiler$CompilerException #"Cannot coerce long to int"
-        (load-string "(defn returns-long ^long [] 1) (Integer/bitCount ^int (returns-long))")))
+                        (load-string "(defn returns-long ^long [] 1) (Integer/bitCount ^int (returns-long))")))
   ;; correct casting instead
   (is (= 1 (load-string "(defn returns-long ^long [] 1) (Integer/bitCount (int (returns-long)))"))))
 
@@ -382,7 +379,6 @@
 (deftest test-anon-recursive-fn
   (is (= [0 0] (take 2 ((fn rf [x] (lazy-seq (cons x (rf x)))) 0))))
   (is (= [0 0] (take 2 (zf 0)))))
-
 
 ;; See CLJ-1845
 (deftest direct-linking-for-load

--- a/test/clojure/test_clojure/compilation/line_number_examples.clj
+++ b/test/clojure/test_clojure/compilation/line_number_examples.clj
@@ -116,6 +116,5 @@
   "I throw an exception casting to IFn in an invoke form."
   []
   ;; This code formatting is intentional.
-  (
-   (identity 1)
+  ((identity 1)
    (identity nil)))

--- a/test/clojure/test_clojure/control.clj
+++ b/test/clojure/test_clojure/control.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka, Mike Hinchey, Stuart Halloway
+;; Author: Frantisek Sodomka, Mike Hinchey, Stuart Halloway
 
 ;;
 ;;  Test "flow control" constructs.
@@ -20,230 +20,213 @@
 
 (defn maintains-identity [f]
   (are [x] (= (f x) x)
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      () '(1 2)
-      [] [1 2]
-      {} {:a 1 :b 2}
-      #{} #{1 2} ))
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2}))
 
-
-; http://clojure.org/special_forms
-; http://clojure.org/macros
+;; http://clojure.org/special_forms
+;; http://clojure.org/macros
 
 (deftest test-do
   (are [x y] (= x y)
       ; no params => nil
-      (do) nil
-      
+    (do) nil
+
       ; return last
-      (do 1) 1
-      (do 1 2) 2
-      (do 1 2 3 4 5) 5
-      
+    (do 1) 1
+    (do 1 2) 2
+    (do 1 2 3 4 5) 5
+
       ; evaluate and return last
-      (let [a (atom 0)]
-        (do (reset! a (+ @a 1))   ; 1
-            (reset! a (+ @a 1))   ; 2
-            (reset! a (+ @a 1))   ; 3
-            @a))  3 )
+    (let [a (atom 0)]
+      (do (reset! a (+ @a 1))   ; 1
+          (reset! a (+ @a 1))   ; 2
+          (reset! a (+ @a 1))   ; 3
+          @a))  3)
 
   ; identity (= (do x) x)
-  (maintains-identity (fn [_] (do _))) )
-
+  (maintains-identity (fn [_] (do _))))
 
 ;; loop/recur
 (deftest test-loop
   (are [x y] (= x y)
-       1 (loop []
-           1)
-       3 (loop [a 1]
-           (if (< a 3)
-             (recur (inc a))
-             a))
-       [2 4 6] (loop [a []
-                      b [1 2 3]]
-                 (if (seq b)
-                   (recur (conj a (* 2 (first b)))
-                          (next b))
-                   a))
-       [6 4 2] (loop [a ()
-                      b [1 2 3]]
-                 (if (seq b)
-                   (recur (conj a (* 2 (first b)))
-                          (next b))
-                   a))
-       )
-  )
-
+    1 (loop []
+        1)
+    3 (loop [a 1]
+        (if (< a 3)
+          (recur (inc a))
+          a))
+    [2 4 6] (loop [a []
+                   b [1 2 3]]
+              (if (seq b)
+                (recur (conj a (* 2 (first b)))
+                       (next b))
+                a))
+    [6 4 2] (loop [a ()
+                   b [1 2 3]]
+              (if (seq b)
+                (recur (conj a (* 2 (first b)))
+                       (next b))
+                a))))
 
 ;; throw, try
 
-; if: see logic.clj
+;; if: see logic.clj
 
 (deftest test-when
   (are [x y] (= x y)
-       1 (when true 1)
-       nil (when true)
-       nil (when false)
-       nil (when false (exception))
-       ))
+    1 (when true 1)
+    nil (when true)
+    nil (when false)
+    nil (when false (exception))))
 
 (deftest test-when-not
   (are [x y] (= x y)
-       1 (when-not false 1)
-       nil (when-not true)
-       nil (when-not false)
-       nil (when-not true (exception))
-       ))
+    1 (when-not false 1)
+    nil (when-not true)
+    nil (when-not false)
+    nil (when-not true (exception))))
 
 (deftest test-if-not
   (are [x y] (= x y)
-       1 (if-not false 1)
-       1 (if-not false 1 (exception))
-       nil (if-not true 1)
-       2 (if-not true 1 2)
-       nil (if-not true (exception))
-       1 (if-not true (exception) 1)
-       ))
+    1 (if-not false 1)
+    1 (if-not false 1 (exception))
+    nil (if-not true 1)
+    2 (if-not true 1 2)
+    nil (if-not true (exception))
+    1 (if-not true (exception) 1)))
 
 (deftest test-when-let
   (are [x y] (= x y)
-       1 (when-let [a 1]
-           a)
-       2 (when-let [[a b] '(1 2)]
-           b)
-       nil (when-let [a false]
-             (exception))
-       ))
+    1 (when-let [a 1]
+        a)
+    2 (when-let [[a b] '(1 2)]
+        b)
+    nil (when-let [a false]
+          (exception))))
 
 (deftest test-if-let
   (are [x y] (= x y)
-       1 (if-let [a 1]
-           a)
-       2 (if-let [[a b] '(1 2)]
-           b)
-       nil (if-let [a false]
-             (exception))
-       1 (if-let [a false]
-           a 1)
-       1 (if-let [[a b] nil]
-             b 1)
-       1 (if-let [a false]
-           (exception)
-           1)
-       ))
+    1 (if-let [a 1]
+        a)
+    2 (if-let [[a b] '(1 2)]
+        b)
+    nil (if-let [a false]
+          (exception))
+    1 (if-let [a false]
+        a 1)
+    1 (if-let [[a b] nil]
+        b 1)
+    1 (if-let [a false]
+        (exception)
+        1)))
 
 (deftest test-when-first
   (are [x y] (= x y)
-       1 (when-first [a [1 2]]
-           a)
-       2 (when-first [[a b] '((1 2) 3)]
-           b)
-       nil (when-first [a nil]
-             (exception))
-       ))
+    1 (when-first [a [1 2]]
+        a)
+    2 (when-first [[a b] '((1 2) 3)]
+        b)
+    nil (when-first [a nil]
+          (exception))))
 
 (deftest test-if-some
   (are [x y] (= x y)
-       1 (if-some [a 1] a)
-       false (if-some [a false] a)
-       nil (if-some [a nil] (exception))
-       3 (if-some [[a b] [1 2]] (+ a b))
-       1 (if-some [[a b] nil] b 1)
-       1 (if-some [a nil] (exception) 1)))
+    1 (if-some [a 1] a)
+    false (if-some [a false] a)
+    nil (if-some [a nil] (exception))
+    3 (if-some [[a b] [1 2]] (+ a b))
+    1 (if-some [[a b] nil] b 1)
+    1 (if-some [a nil] (exception) 1)))
 
 (deftest test-when-some
   (are [x y] (= x y)
-       1 (when-some [a 1] a)
-       2 (when-some [[a b] [1 2]] b)
-       false (when-some [a false] a)
-       nil (when-some [a nil] (exception))))
+    1 (when-some [a 1] a)
+    2 (when-some [[a b] [1 2]] b)
+    false (when-some [a false] a)
+    nil (when-some [a nil] (exception))))
 
 (deftest test-cond
   (are [x y] (= x y)
-      (cond) nil
+    (cond) nil
 
-      (cond nil true) nil
-      (cond false true) nil
-      
-      (cond true 1 true (exception)) 1
-      (cond nil 1 false 2 true 3 true 4) 3
-      (cond nil 1 false 2 true 3 true (exception)) 3 )
+    (cond nil true) nil
+    (cond false true) nil
+
+    (cond true 1 true (exception)) 1
+    (cond nil 1 false 2 true 3 true 4) 3
+    (cond nil 1 false 2 true 3 true (exception)) 3)
 
   ; false
   (are [x]  (= (cond x :a true :b) :b)
-      nil false )
+    nil false)
 
   ; true
   (are [x]  (= (cond x :a true :b) :a)
-      true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      () '(1 2)
-      [] [1 2]
-      {} {:a 1 :b 2}
-      #{} #{1 2} )
+    true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2})
 
   ; evaluation
   (are [x y] (= x y)
-      (cond (> 3 2) (+ 1 2) true :result true (exception)) 3
-      (cond (< 3 2) (+ 1 2) true :result true (exception)) :result )
+    (cond (> 3 2) (+ 1 2) true :result true (exception)) 3
+    (cond (< 3 2) (+ 1 2) true :result true (exception)) :result)
 
   ; identity (= (cond true x) x)
-  (maintains-identity (fn [_] (cond true _))) )
-
+  (maintains-identity (fn [_] (cond true _))))
 
 (deftest test-condp
   (are [x] (= :pass x)
-       (condp = 1
-         1 :pass
-         2 :fail)
-       (condp = 1
-         2 :fail
-         1 :pass)
-       (condp = 1
-         2 :fail
-         :pass)
-       (condp = 1
-         :pass)
-       (condp = 1
-         2 :fail
+    (condp = 1
+      1 :pass
+      2 :fail)
+    (condp = 1
+      2 :fail
+      1 :pass)
+    (condp = 1
+      2 :fail
+      :pass)
+    (condp = 1
+      :pass)
+    (condp = 1
+      2 :fail
          ;; doc of condp says result-expr is returned
          ;; shouldn't it say similar to cond: "evaluates and returns
          ;; the value of the corresponding expr and doesn't evaluate any of the
          ;; other tests or exprs."
-         (identity :pass))
-       (condp + 1
-         1 :>> #(if (= % 2) :pass :fail))
-       (condp + 1
-         1 :>> #(if (= % 3) :fail :pass))
-       )
+      (identity :pass))
+    (condp + 1
+      1 :>> #(if (= % 2) :pass :fail))
+    (condp + 1
+      1 :>> #(if (= % 3) :fail :pass)))
   (is (thrown? IllegalArgumentException
-               (condp = 1)
-               ))
+               (condp = 1)))
   (is (thrown? IllegalArgumentException
                (condp = 1
-                 2 :fail)
-               ))
-  )
+                 2 :fail))))
 
-
-; [for, doseq (for.clj)]
+;; [for, doseq (for.clj)]
 
 (deftest test-dotimes
   ;; dotimes always returns nil
@@ -254,8 +237,7 @@
          (let [a (atom 0)]
            (dotimes [n 3]
              (swap! a inc))
-           @a)
-         ))
+           @a)))
   ;; test all values of n
   (is (= [0 1 2]
          (let [a (atom [])]
@@ -266,8 +248,7 @@
          (let [a (atom [])]
            (dotimes [n 0]
              (swap! a conj n))
-           @a)))
-  )
+           @a))))
 
 (deftest test-while
   (is (= nil (while nil (throw (Exception. "never")))))
@@ -278,87 +259,86 @@
                w (while (pos? @a)
                    (swap! a dec))]
            [@a w])))
-  (is (thrown? Exception (while true (throw (Exception. "expected to throw")))))
-  )
+  (is (thrown? Exception (while true (throw (Exception. "expected to throw"))))))
 
-; locking, monitor-enter, monitor-exit
+;; locking, monitor-enter, monitor-exit
 
-; case 
+;; case
 (deftest test-case
   (testing "can match many kinds of things"
     (let [two 2
           test-fn
           #(case %
-                 1 :number
-                 "foo" :string
-                 \a :char
-                 pow :symbol
-                 :zap :keyword
-                 (2 \b "bar") :one-of-many
-                 [1 2] :sequential-thing
-                 {:a 2} :map
-                 {:r 2 :d 2} :droid
-                 #{2 3 4 5} :set
-                 [1 [[[2]]]] :deeply-nested
-                 nil :nil
-                 :default)]
+             1 :number
+             "foo" :string
+             \a :char
+             pow :symbol
+             :zap :keyword
+             (2 \b "bar") :one-of-many
+             [1 2] :sequential-thing
+             {:a 2} :map
+             {:r 2 :d 2} :droid
+             #{2 3 4 5} :set
+             [1 [[[2]]]] :deeply-nested
+             nil :nil
+             :default)]
       (are [result input] (= result (test-fn input))
-           :number 1
-           :string "foo"
-           :char \a
-           :keyword :zap
-           :symbol 'pow
-           :one-of-many 2
-           :one-of-many \b
-           :one-of-many "bar"
-           :sequential-thing [1 2]
-           :sequential-thing (list 1 2)
-           :sequential-thing [1 two]
-           :map {:a 2}
-           :map {:a two}
-           :set #{2 3 4 5}
-           :set #{two 3 4 5}
-           :default #{2 3 4 5 6}
-           :droid {:r 2 :d 2}
-           :deeply-nested [1 [[[two]]]]
-           :nil nil
-           :default :anything-not-appearing-above)))
+        :number 1
+        :string "foo"
+        :char \a
+        :keyword :zap
+        :symbol 'pow
+        :one-of-many 2
+        :one-of-many \b
+        :one-of-many "bar"
+        :sequential-thing [1 2]
+        :sequential-thing (list 1 2)
+        :sequential-thing [1 two]
+        :map {:a 2}
+        :map {:a two}
+        :set #{2 3 4 5}
+        :set #{two 3 4 5}
+        :default #{2 3 4 5 6}
+        :droid {:r 2 :d 2}
+        :deeply-nested [1 [[[two]]]]
+        :nil nil
+        :default :anything-not-appearing-above)))
   (testing "throws IllegalArgumentException if no match"
     (is (thrown-with-msg?
-          IllegalArgumentException #"No matching clause: 2"
-          (case 2 1 :ok))))
+         IllegalArgumentException #"No matching clause: 2"
+         (case 2 1 :ok))))
   (testing "sorting doesn't matter"
     (let [test-fn
           #(case %
-                {:b 2 :a 1} :map
-                #{3 2 1} :set
-                :default)]
+             {:b 2 :a 1} :map
+             #{3 2 1} :set
+             :default)]
       (are [result input] (= result (test-fn input))
-           :map {:a 1 :b 2}
-           :map (sorted-map :a 1 :b 2)
-           :set #{3 2 1}
-           :set (sorted-set 2 1 3))))
+        :map {:a 1 :b 2}
+        :map (sorted-map :a 1 :b 2)
+        :set #{3 2 1}
+        :set (sorted-set 2 1 3))))
   (testing "test number equivalence"
     (is (= :1 (case 1N 1 :1 :else))))
   (testing "test warn when boxing/hashing expr for all-ints case"
     (should-print-err-message
-      #"Performance warning, .*:\d+ - case has int tests, but tested expression is not primitive..*\r?\n"
-      (let [x (Object.)] (case x 1 1 2))))
+     #"Performance warning, .*:\d+ - case has int tests, but tested expression is not primitive..*\r?\n"
+     (let [x (Object.)] (case x 1 1 2))))
   (testing "test correct behavior on sparse ints"
     (are [result input] (= result (case input
                                     2r1000000000000000000000000000000 :big
                                     1 :small
                                     :else))
-         :small 1
-         :big 1073741824
-         :else 2)
+      :small 1
+      :big 1073741824
+      :else 2)
     (are [result input] (= result (case input
                                     1 :small
                                     2r1000000000000000000000000000000 :big
                                     :else))
-         :small 1
-         :big 1073741824
-         :else 2))
+      :small 1
+      :big 1073741824
+      :else 2))
   (testing "test emits return types"
     (should-not-reflect (Long. (case 1 1 1))) ; new Long(long)
     (should-not-reflect (Long. (case 1 1 "1")))) ; new Long(String)
@@ -373,9 +353,9 @@
       :a (char 97)))
   (testing "test error on duplicate test constants"
     (is (thrown-with-msg?
-          IllegalArgumentException
-          #"Duplicate case test constant: 1"
-          (eval `(case 0 1 :x 1 :y)))))
+         IllegalArgumentException
+         #"Duplicate case test constant: 1"
+         (eval `(case 0 1 :x 1 :y)))))
   (testing "test correct behaviour on Number truncation"
     (let [^Object x (Long. 8589934591)  ; force bindings to not be emitted as a primitive long
           ^Object y (Long. -1)]
@@ -388,37 +368,37 @@
                                     1 :long
                                     9223372039002259457N :big
                                     :else))
-         :long 1
-         :big 9223372039002259457N
-         :else 4294967296
-         :else 2)
+      :long 1
+      :big 9223372039002259457N
+      :else 4294967296
+      :else 2)
     (are [result input] (= result (case input
                                     9223372039002259457N :big
                                     1 :long
                                     :else))
-         :long 1
-         :big 9223372039002259457N
-         :else 4294967296
-         :else 2)
+      :long 1
+      :big 9223372039002259457N
+      :else 4294967296
+      :else 2)
     (are [result input] (= result (case input
                                     0 :zero
                                     -1 :neg1
                                     2 :two
                                     :oops :OOPS))
-         :zero 0
-         :neg1 -1
-         :two 2
-         :OOPS :oops)
+      :zero 0
+      :neg1 -1
+      :two 2
+      :OOPS :oops)
     (are [result input] (= result (case input
                                     1204766517646190306 :a
                                     1 :b
                                     -2 :c
                                     :d))
-         :a 1204766517646190306
-         :b 1
-         :c -2
-         :d 4294967296
-         :d 3))
+      :a 1204766517646190306
+      :b 1
+      :c -2
+      :d 4294967296
+      :d 3))
   (testing "test warn for hash collision"
     (should-print-err-message
      #"Performance warning, .*:\d+ - hash collision of some case test constants; if selected, those entries will be tested sequentially..*\r?\n"
@@ -427,9 +407,9 @@
     (let [test-fn
           ;; never write code like this...
           #(case %
-                 (throw (RuntimeException. "boom")) :piece-of-throw-expr
-                 :no-match)]
+             (throw (RuntimeException. "boom")) :piece-of-throw-expr
+             :no-match)]
       (are [result input] (= result (test-fn input))
-           :piece-of-throw-expr 'throw
-           :piece-of-throw-expr '[RuntimeException. "boom"]
-           :no-match nil))))
+        :piece-of-throw-expr 'throw
+        :piece-of-throw-expr '[RuntimeException. "boom"]
+        :no-match nil))))

--- a/test/clojure/test_clojure/data.clj
+++ b/test/clojure/test_clojure/data.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.data
   (:use clojure.data clojure.test)
@@ -12,21 +12,21 @@
 
 (deftest diff-test
   (are [d x y] (= d (diff x y))
-       [nil nil nil] nil nil
-       [1 2 nil] 1 2
-       [nil nil [1 2 3]] [1 2 3] '(1 2 3)
-       [1 [:a :b] nil] 1 [:a :b]
-       [{:a 1} :b nil] {:a 1} :b
-       [:team #{:p1 :p2} nil] :team #{:p1 :p2}
-       [{0 :a} [:a] nil] {0 :a} [:a]
-       [nil [nil 2] [1]] [1] [1 2]
-       [nil nil [1 2]] [1 2] (into-array [1 2])
-       [#{:a} #{:b} #{:c :d}] #{:a :c :d} #{:b :c :d}
-       [nil nil {:a 1}] {:a 1} {:a 1}
-       [{:a #{2}} {:a #{4}} {:a #{3}}] {:a #{2 3}} {:a #{3 4}}
-       [#{1} #{3} #{2}] (HashSet. [1 2]) (HashSet. [2 3])
-       [nil nil [1 2]] [1 2] (into-array [1 2])
-       [nil nil [1 2]] (into-array [1 2]) [1 2]
-       [{:a {:c [1]}} {:a {:c [0]}} {:a {:c [nil 2] :b 1}}] {:a {:b 1 :c [1 2]}} {:a {:b 1 :c [0 2]}}
-       [{:a nil} {:a false} {:b nil :c false}] {:a nil :b nil :c false} {:a false :b nil :c false}))
+    [nil nil nil] nil nil
+    [1 2 nil] 1 2
+    [nil nil [1 2 3]] [1 2 3] '(1 2 3)
+    [1 [:a :b] nil] 1 [:a :b]
+    [{:a 1} :b nil] {:a 1} :b
+    [:team #{:p1 :p2} nil] :team #{:p1 :p2}
+    [{0 :a} [:a] nil] {0 :a} [:a]
+    [nil [nil 2] [1]] [1] [1 2]
+    [nil nil [1 2]] [1 2] (into-array [1 2])
+    [#{:a} #{:b} #{:c :d}] #{:a :c :d} #{:b :c :d}
+    [nil nil {:a 1}] {:a 1} {:a 1}
+    [{:a #{2}} {:a #{4}} {:a #{3}}] {:a #{2 3}} {:a #{3 4}}
+    [#{1} #{3} #{2}] (HashSet. [1 2]) (HashSet. [2 3])
+    [nil nil [1 2]] [1 2] (into-array [1 2])
+    [nil nil [1 2]] (into-array [1 2]) [1 2]
+    [{:a {:c [1]}} {:a {:c [0]}} {:a {:c [nil 2] :b 1}}] {:a {:b 1 :c [1 2]}} {:a {:b 1 :c [0 2]}}
+    [{:a nil} {:a false} {:b nil :c false}] {:a nil :b nil :c false} {:a false :b nil :c false}))
 

--- a/test/clojure/test_clojure/data_structures.clj
+++ b/test/clojure/test_clojure/data_structures.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 
 (ns clojure.test-clojure.data-structures
@@ -16,12 +16,10 @@
             [clojure.data.generators :as gen]
             [clojure.string :as string]))
 
-
 ;; *** Helper functions ***
 
 (defn diff [s1 s2]
   (seq (reduce disj (set s1) (set s2))))
-
 
 ;; *** Generative ***
 (defspec subcollection-counts-are-consistent
@@ -128,568 +126,557 @@
 (defstruct equality-struct :a :b)
 
 (deftest test-equality
-  ; nil is not equal to any other value
+                                        ; nil is not equal to any other value
   (are [x] (not (= nil x))
-      true false
-      0 0.0
-      \space
-      "" #""
-      () [] #{} {}
-      (lazy-seq nil)  ; SVN 1292: fixed (= (lazy-seq nil) nil)
-      (lazy-seq ())
-      (lazy-seq [])
-      (lazy-seq {})
-      (lazy-seq #{})
-      (lazy-seq "")
-      (lazy-seq (into-array []))
-      (new Object) )
+    true false
+    0 0.0
+    \space
+    "" #""
+    () [] #{} {}
+    (lazy-seq nil)  ; SVN 1292: fixed (= (lazy-seq nil) nil)
+    (lazy-seq ())
+    (lazy-seq [])
+    (lazy-seq {})
+    (lazy-seq #{})
+    (lazy-seq "")
+    (lazy-seq (into-array []))
+    (new Object))
 
-  ; numbers equality across types (see tests below - NOT IMPLEMENTED YET)
+                                        ; numbers equality across types (see tests below - NOT IMPLEMENTED YET)
 
-  ; ratios
+                                        ; ratios
   (is (== 1/2 0.5))
   (is (== 1/1000 0.001))
   (is (not= 2/3 0.6666666666666666))
 
-  ; vectors equal other seqs by items equality
+                                        ; vectors equal other seqs by items equality
   (are [x y] (= x y)
-      '() []        ; regression fixed in r1208; was not equal
-      '(1) [1]
-      '(1 2) [1 2]
+    '() []        ; regression fixed in r1208; was not equal
+    '(1) [1]
+    '(1 2) [1 2]
 
-      [] '()        ; same again, but vectors first
-      [1] '(1)
-      [1 2] '(1 2) )
+    [] '()        ; same again, but vectors first
+    [1] '(1)
+    [1 2] '(1 2))
   (is (not= [1 2] '(2 1)))  ; order of items matters
 
-  ; list and vector vs. set and map
+                                        ; list and vector vs. set and map
   (are [x y] (not= x y)
-      ; only () equals []
-      () #{}
-      () {}
-      [] #{}
-      [] {}
-      #{} {}
-      ; only '(1) equals [1]
-      '(1) #{1}
-      [1] #{1} )
+                                        ; only () equals []
+    () #{}
+    () {}
+    [] #{}
+    [] {}
+    #{} {}
+                                        ; only '(1) equals [1]
+    '(1) #{1}
+    [1] #{1})
 
-  ; sorted-map, hash-map and array-map - classes differ, but content is equal
-  
-;; TODO: reimplement all-are with new do-template?  
-;;   (all-are (not= (class _1) (class _2))
-;;       (sorted-map :a 1)
-;;       (hash-map   :a 1)
-;;       (array-map  :a 1))
-;;   (all-are (= _1 _2)
-;;       (sorted-map)
-;;       (hash-map)
-;;       (array-map))
-;;   (all-are (= _1 _2)
-;;       (sorted-map :a 1)
-;;       (hash-map   :a 1)
-;;       (array-map  :a 1))
-;;   (all-are (= _1 _2)
-;;       (sorted-map :a 1 :z 3 :c 2)
-;;       (hash-map   :a 1 :z 3 :c 2)
-;;       (array-map  :a 1 :z 3 :c 2))
+                                        ; sorted-map, hash-map and array-map - classes differ, but content is equal
 
-  ; struct-map vs. sorted-map, hash-map and array-map
+  ;; TODO: reimplement all-are with new do-template?
+  ;;   (all-are (not= (class _1) (class _2))
+  ;;       (sorted-map :a 1)
+  ;;       (hash-map   :a 1)
+  ;;       (array-map  :a 1))
+  ;;   (all-are (= _1 _2)
+  ;;       (sorted-map)
+  ;;       (hash-map)
+  ;;       (array-map))
+  ;;   (all-are (= _1 _2)
+  ;;       (sorted-map :a 1)
+  ;;       (hash-map   :a 1)
+  ;;       (array-map  :a 1))
+  ;;   (all-are (= _1 _2)
+  ;;       (sorted-map :a 1 :z 3 :c 2)
+  ;;       (hash-map   :a 1 :z 3 :c 2)
+  ;;       (array-map  :a 1 :z 3 :c 2))
+
+                                        ; struct-map vs. sorted-map, hash-map and array-map
   (are [x] (and (not= (class (struct equality-struct 1 2)) (class x))
                 (= (struct equality-struct 1 2) x))
-      (sorted-map-by compare :a 1 :b 2)
-      (sorted-map :a 1 :b 2)
-      (hash-map   :a 1 :b 2)
-      (array-map  :a 1 :b 2))
+    (sorted-map-by compare :a 1 :b 2)
+    (sorted-map :a 1 :b 2)
+    (hash-map   :a 1 :b 2)
+    (array-map  :a 1 :b 2))
 
-  ; sorted-set vs. hash-set
+                                        ; sorted-set vs. hash-set
   (is (not= (class (sorted-set 1)) (class (hash-set 1))))
   (are [x y] (= x y)
-      (sorted-set-by <) (hash-set)
-      (sorted-set-by < 1) (hash-set 1)
-      (sorted-set-by < 3 2 1) (hash-set 3 2 1)
-      (sorted-set) (hash-set)
-      (sorted-set 1) (hash-set 1)
-      (sorted-set 3 2 1) (hash-set 3 2 1) ))
-
+    (sorted-set-by <) (hash-set)
+    (sorted-set-by < 1) (hash-set 1)
+    (sorted-set-by < 3 2 1) (hash-set 3 2 1)
+    (sorted-set) (hash-set)
+    (sorted-set 1) (hash-set 1)
+    (sorted-set 3 2 1) (hash-set 3 2 1)))
 
 ;; *** Collections ***
 
 (deftest test-count
   (let [EMPTY clojure.lang.PersistentQueue/EMPTY]
     (are [x y] (= (count x) y)
-         EMPTY 0 
-         (into EMPTY [:a :b]) 2
-         (-> (into EMPTY [:a :b]) pop pop) 0
-         
-         nil 0
+      EMPTY 0
+      (into EMPTY [:a :b]) 2
+      (-> (into EMPTY [:a :b]) pop pop) 0
 
-         () 0
-         '(1) 1
-         '(1 2 3) 3
+      nil 0
 
-         [] 0
-         [1] 1
-         [1 2 3] 3
+      () 0
+      '(1) 1
+      '(1 2 3) 3
 
-         #{} 0
-         #{1} 1
-         #{1 2 3} 3
+      [] 0
+      [1] 1
+      [1 2 3] 3
 
-         {} 0
-         {:a 1} 1
-         {:a 1 :b 2 :c 3} 3
+      #{} 0
+      #{1} 1
+      #{1 2 3} 3
 
-         "" 0
-         "a" 1
-         "abc" 3
+      {} 0
+      {:a 1} 1
+      {:a 1 :b 2 :c 3} 3
 
-         (into-array []) 0
-         (into-array [1]) 1
-         (into-array [1 2 3]) 3
+      "" 0
+      "a" 1
+      "abc" 3
 
-         (java.util.ArrayList. []) 0
-         (java.util.ArrayList. [1]) 1
-         (java.util.ArrayList. [1 2 3]) 3
+      (into-array []) 0
+      (into-array [1]) 1
+      (into-array [1 2 3]) 3
 
-         (java.util.HashMap. {}) 0
-         (java.util.HashMap. {:a 1}) 1
-         (java.util.HashMap. {:a 1 :b 2 :c 3}) 3 ))
+      (java.util.ArrayList. []) 0
+      (java.util.ArrayList. [1]) 1
+      (java.util.ArrayList. [1 2 3]) 3
 
-  ; different types
+      (java.util.HashMap. {}) 0
+      (java.util.HashMap. {:a 1}) 1
+      (java.util.HashMap. {:a 1 :b 2 :c 3}) 3))
+
+                                        ; different types
   (are [x]  (= (count [x]) 1)
-      nil true false
-      0 0.0 "" \space
-      () [] #{} {}  ))
-
+    nil true false
+    0 0.0 "" \space
+    () [] #{} {}))
 
 (deftest test-conj
-  ; doesn't work on strings or arrays
+  ;; doesn't work on strings or arrays
   (is (thrown? ClassCastException (conj "" \a)))
   (is (thrown? ClassCastException (conj (into-array []) 1)))
 
   (are [x y] (= x y)
-      (conj nil 1) '(1)
-      (conj nil 3 2 1) '(1 2 3)
+    (conj nil 1) '(1)
+    (conj nil 3 2 1) '(1 2 3)
 
-      (conj nil nil) '(nil)
-      (conj nil nil nil) '(nil nil)
-      (conj nil nil nil 1) '(1 nil nil)
+    (conj nil nil) '(nil)
+    (conj nil nil nil) '(nil nil)
+    (conj nil nil nil 1) '(1 nil nil)
 
-      ; list -> conj puts the item at the front of the list
-      (conj () 1) '(1)
-      (conj () 1 2) '(2 1)
+    ;; list -> conj puts the item at the front of the list
+    (conj () 1) '(1)
+    (conj () 1 2) '(2 1)
 
-      (conj '(2 3) 1) '(1 2 3)
-      (conj '(2 3) 1 4 3) '(3 4 1 2 3)
+    (conj '(2 3) 1) '(1 2 3)
+    (conj '(2 3) 1 4 3) '(3 4 1 2 3)
 
-      (conj () nil) '(nil)
-      (conj () ()) '(())
+    (conj () nil) '(nil)
+    (conj () ()) '(())
 
-      ; vector -> conj puts the item at the end of the vector
-      (conj [] 1) [1]
-      (conj [] 1 2) [1 2]
+    ;; vector -> conj puts the item at the end of the vector
+    (conj [] 1) [1]
+    (conj [] 1 2) [1 2]
 
-      (conj [2 3] 1) [2 3 1]
-      (conj [2 3] 1 4 3) [2 3 1 4 3]
+    (conj [2 3] 1) [2 3 1]
+    (conj [2 3] 1 4 3) [2 3 1 4 3]
 
-      (conj [] nil) [nil]
-      (conj [] []) [[]]
+    (conj [] nil) [nil]
+    (conj [] []) [[]]
 
-      ; map -> conj expects another (possibly single entry) map as the item,
-      ;   and returns a new map which is the old map plus the entries
-      ;   from the new, which may overwrite entries of the old.
-      ;   conj also accepts a MapEntry or a vector of two items (key and value).
-      (conj {} {}) {}
-      (conj {} {:a 1}) {:a 1}
-      (conj {} {:a 1 :b 2}) {:a 1 :b 2}
-      (conj {} {:a 1 :b 2} {:c 3}) {:a 1 :b 2 :c 3}
-      (conj {} {:a 1 :b 2} {:a 3 :c 4}) {:a 3 :b 2 :c 4}
+    ;; map -> conj expects another (possibly single entry) map as the item,
+    ;;   and returns a new map which is the old map plus the entries
+    ;;   from the new, which may overwrite entries of the old.
+    ;;   conj also accepts a MapEntry or a vector of two items (key and value).
+    (conj {} {}) {}
+    (conj {} {:a 1}) {:a 1}
+    (conj {} {:a 1 :b 2}) {:a 1 :b 2}
+    (conj {} {:a 1 :b 2} {:c 3}) {:a 1 :b 2 :c 3}
+    (conj {} {:a 1 :b 2} {:a 3 :c 4}) {:a 3 :b 2 :c 4}
 
-      (conj {:a 1} {:a 7}) {:a 7}
-      (conj {:a 1} {:b 2}) {:a 1 :b 2}
-      (conj {:a 1} {:a 7 :b 2}) {:a 7 :b 2}
-      (conj {:a 1} {:a 7 :b 2} {:c 3}) {:a 7 :b 2 :c 3}
-      (conj {:a 1} {:a 7 :b 2} {:b 4 :c 5}) {:a 7 :b 4 :c 5}
+    (conj {:a 1} {:a 7}) {:a 7}
+    (conj {:a 1} {:b 2}) {:a 1 :b 2}
+    (conj {:a 1} {:a 7 :b 2}) {:a 7 :b 2}
+    (conj {:a 1} {:a 7 :b 2} {:c 3}) {:a 7 :b 2 :c 3}
+    (conj {:a 1} {:a 7 :b 2} {:b 4 :c 5}) {:a 7 :b 4 :c 5}
 
-      (conj {} (first {:a 1})) {:a 1}           ; MapEntry
-      (conj {:a 1} (first {:b 2})) {:a 1 :b 2}
-      (conj {:a 1} (first {:a 7})) {:a 7}
-      (conj {:a 1} (first {:b 2}) (first {:a 5})) {:a 5 :b 2}
+    (conj {} (first {:a 1})) {:a 1}           ; MapEntry
+    (conj {:a 1} (first {:b 2})) {:a 1 :b 2}
+    (conj {:a 1} (first {:a 7})) {:a 7}
+    (conj {:a 1} (first {:b 2}) (first {:a 5})) {:a 5 :b 2}
 
-      (conj {} [:a 1]) {:a 1}                   ; vector
-      (conj {:a 1} [:b 2]) {:a 1 :b 2}
-      (conj {:a 1} [:a 7]) {:a 7}
-      (conj {:a 1} [:b 2] [:a 5]) {:a 5 :b 2}
+    (conj {} [:a 1]) {:a 1}                   ; vector
+    (conj {:a 1} [:b 2]) {:a 1 :b 2}
+    (conj {:a 1} [:a 7]) {:a 7}
+    (conj {:a 1} [:b 2] [:a 5]) {:a 5 :b 2}
 
-      (conj {} {nil {}}) {nil {}}
-      (conj {} {{} nil}) {{} nil}
-      (conj {} {{} {}}) {{} {}}
+    (conj {} {nil {}}) {nil {}}
+    (conj {} {{} nil}) {{} nil}
+    (conj {} {{} {}}) {{} {}}
 
-      ; set
-      (conj #{} 1) #{1}
-      (conj #{} 1 2 3) #{1 2 3}
+    ;; set
+    (conj #{} 1) #{1}
+    (conj #{} 1 2 3) #{1 2 3}
 
-      (conj #{2 3} 1) #{3 1 2}
-      (conj #{3 2} 1) #{1 2 3}
+    (conj #{2 3} 1) #{3 1 2}
+    (conj #{3 2} 1) #{1 2 3}
 
-      (conj #{2 3} 2) #{2 3}
-      (conj #{2 3} 2 3) #{2 3}
-      (conj #{2 3} 4 1 2 3) #{1 2 3 4}
+    (conj #{2 3} 2) #{2 3}
+    (conj #{2 3} 2 3) #{2 3}
+    (conj #{2 3} 4 1 2 3) #{1 2 3 4}
 
-      (conj #{} nil) #{nil}
-      (conj #{} #{}) #{#{}} ))
-
+    (conj #{} nil) #{nil}
+    (conj #{} #{}) #{#{}}))
 
 ;; *** Lists and Vectors ***
 
 (deftest test-peek
-  ; doesn't work for sets and maps
+  ;; doesn't work for sets and maps
   (is (thrown? ClassCastException (peek #{1})))
   (is (thrown? ClassCastException (peek {:a 1})))
 
   (are [x y] (= x y)
-      (peek nil) nil
+    (peek nil) nil
 
-      ; list = first
-      (peek ()) nil
-      (peek '(1)) 1
-      (peek '(1 2 3)) 1
+    ;; list = first
+    (peek ()) nil
+    (peek '(1)) 1
+    (peek '(1 2 3)) 1
 
-      (peek '(nil)) nil     ; special cases
-      (peek '(1 nil)) 1
-      (peek '(nil 2)) nil
-      (peek '(())) ()
-      (peek '(() nil)) ()
-      (peek '(() 2 nil)) ()
+    (peek '(nil)) nil     ; special cases
+    (peek '(1 nil)) 1
+    (peek '(nil 2)) nil
+    (peek '(())) ()
+    (peek '(() nil)) ()
+    (peek '(() 2 nil)) ()
 
-      ; vector = last
-      (peek []) nil
-      (peek [1]) 1
-      (peek [1 2 3]) 3
+    ;; vector = last
+    (peek []) nil
+    (peek [1]) 1
+    (peek [1 2 3]) 3
 
-      (peek [nil]) nil      ; special cases
-      (peek [1 nil]) nil
-      (peek [nil 2]) 2
-      (peek [[]]) []
-      (peek [[] nil]) nil
-      (peek [[] 2 nil]) nil ))
-
+    (peek [nil]) nil      ; special cases
+    (peek [1 nil]) nil
+    (peek [nil 2]) 2
+    (peek [[]]) []
+    (peek [[] nil]) nil
+    (peek [[] 2 nil]) nil))
 
 (deftest test-pop
-  ; doesn't work for sets and maps
+  ;; doesn't work for sets and maps
   (is (thrown? ClassCastException (pop #{1})))
   (is (thrown? ClassCastException (pop #{:a 1})))
 
-  ; collection cannot be empty
+  ;; collection cannot be empty
   (is (thrown? IllegalStateException (pop ())))
   (is (thrown? IllegalStateException (pop [])))
 
   (are [x y] (= x y)
-      (pop nil) nil
+    (pop nil) nil
 
-      ; list - pop first
-      (pop '(1)) ()
-      (pop '(1 2 3)) '(2 3)
+    ;; list - pop first
+    (pop '(1)) ()
+    (pop '(1 2 3)) '(2 3)
 
-      (pop '(nil)) ()
-      (pop '(1 nil)) '(nil)
-      (pop '(nil 2)) '(2)
-      (pop '(())) ()
-      (pop '(() nil)) '(nil)
-      (pop '(() 2 nil)) '(2 nil)
+    (pop '(nil)) ()
+    (pop '(1 nil)) '(nil)
+    (pop '(nil 2)) '(2)
+    (pop '(())) ()
+    (pop '(() nil)) '(nil)
+    (pop '(() 2 nil)) '(2 nil)
 
-      ; vector - pop last
-      (pop [1]) []
-      (pop [1 2 3]) [1 2]
+    ;; vector - pop last
+    (pop [1]) []
+    (pop [1 2 3]) [1 2]
 
-      (pop [nil]) []
-      (pop [1 nil]) [1]
-      (pop [nil 2]) [nil]
-      (pop [[]]) []
-      (pop [[] nil]) [[]]
-      (pop [[] 2 nil]) [[] 2] ))
-
+    (pop [nil]) []
+    (pop [1 nil]) [1]
+    (pop [nil 2]) [nil]
+    (pop [[]]) []
+    (pop [[] nil]) [[]]
+    (pop [[] 2 nil]) [[] 2]))
 
 ;; *** Lists (IPersistentList) ***
 
 (deftest test-list
   (are [x]  (list? x)
-      ()
-      '()
-      (list)
-      (list 1 2 3) )
+    ()
+    '()
+    (list)
+    (list 1 2 3))
 
-  ; order is important
+  ;; order is important
   (are [x y] (not (= x y))
-      (list 1 2) (list 2 1)
-      (list 3 1 2) (list 1 2 3) )
+    (list 1 2) (list 2 1)
+    (list 3 1 2) (list 1 2 3))
 
   (are [x y] (= x y)
-      '() ()
-      (list) '()
-      (list 1) '(1)
-      (list 1 2) '(1 2)
+    '() ()
+    (list) '()
+    (list 1) '(1)
+    (list 1 2) '(1 2)
 
-      ; nesting
-      (list 1 (list 2 3) (list 3 (list 4 5 (list 6 (list 7)))))
-        '(1 (2 3) (3 (4 5 (6 (7)))))
+    ;; nesting
+    (list 1 (list 2 3) (list 3 (list 4 5 (list 6 (list 7)))))
+    '(1 (2 3) (3 (4 5 (6 (7)))))
 
-      ; different data structures
-      (list true false nil)
-        '(true false nil)
-      (list 1 2.5 2/3 "ab" \x 'cd :kw)
-        '(1 2.5 2/3 "ab" \x cd :kw)
-      (list (list 1 2) [3 4] {:a 1 :b 2} #{:c :d})
-        '((1 2) [3 4] {:a 1 :b 2} #{:c :d})
+    ;; different data structures
+    (list true false nil)
+    '(true false nil)
+    (list 1 2.5 2/3 "ab" \x 'cd :kw)
+    '(1 2.5 2/3 "ab" \x cd :kw)
+    (list (list 1 2) [3 4] {:a 1 :b 2} #{:c :d})
+    '((1 2) [3 4] {:a 1 :b 2} #{:c :d})
 
-      ; evaluation
-      (list (+ 1 2) [(+ 2 3) 'a] (list (* 2 3) 8))
-        '(3 [5 a] (6 8))
+    ;; evaluation
+    (list (+ 1 2) [(+ 2 3) 'a] (list (* 2 3) 8))
+    '(3 [5 a] (6 8))
 
-      ; special cases
-      (list nil) '(nil)
-      (list 1 nil) '(1 nil)
-      (list nil 2) '(nil 2)
-      (list ()) '(())
-      (list 1 ()) '(1 ())
-      (list () 2) '(() 2) ))
-
+    ;; special cases
+    (list nil) '(nil)
+    (list 1 nil) '(1 nil)
+    (list nil 2) '(nil 2)
+    (list ()) '(())
+    (list 1 ()) '(1 ())
+    (list () 2) '(() 2)))
 
 ;; *** Maps (IPersistentMap) ***
 
 (deftest test-find
   (are [x y] (= x y)
-      (find {} :a) nil
+    (find {} :a) nil
 
-      (find {:a 1} :a) [:a 1]
-      (find {:a 1} :b) nil
-      (find {nil 1} nil) [nil 1]
+    (find {:a 1} :a) [:a 1]
+    (find {:a 1} :b) nil
+    (find {nil 1} nil) [nil 1]
 
-      (find {:a 1 :b 2} :a) [:a 1]
-      (find {:a 1 :b 2} :b) [:b 2]
-      (find {:a 1 :b 2} :c) nil
+    (find {:a 1 :b 2} :a) [:a 1]
+    (find {:a 1 :b 2} :b) [:b 2]
+    (find {:a 1 :b 2} :c) nil
 
-      (find {} nil) nil
-      (find {:a 1} nil) nil
-      (find {:a 1 :b 2} nil) nil ))
-
+    (find {} nil) nil
+    (find {:a 1} nil) nil
+    (find {:a 1 :b 2} nil) nil))
 
 (deftest test-contains?
-  ; contains? is designed to work preferably on maps and sets
+  ;; contains? is designed to work preferably on maps and sets
   (are [x y] (= x y)
-      (contains? {} :a) false
-      (contains? {} nil) false
+    (contains? {} :a) false
+    (contains? {} nil) false
 
-      (contains? {:a 1} :a) true
-      (contains? {:a 1} :b) false
-      (contains? {:a 1} nil) false
-      (contains? {nil 1} nil) true
+    (contains? {:a 1} :a) true
+    (contains? {:a 1} :b) false
+    (contains? {:a 1} nil) false
+    (contains? {nil 1} nil) true
 
-      (contains? {:a 1 :b 2} :a) true
-      (contains? {:a 1 :b 2} :b) true
-      (contains? {:a 1 :b 2} :c) false
-      (contains? {:a 1 :b 2} nil) false
+    (contains? {:a 1 :b 2} :a) true
+    (contains? {:a 1 :b 2} :b) true
+    (contains? {:a 1 :b 2} :c) false
+    (contains? {:a 1 :b 2} nil) false
 
-      ; sets
-      (contains? #{} 1) false
-      (contains? #{} nil) false
+    ;; sets
+    (contains? #{} 1) false
+    (contains? #{} nil) false
 
-      (contains? #{1} 1) true
-      (contains? #{1} 2) false
-      (contains? #{1} nil) false
+    (contains? #{1} 1) true
+    (contains? #{1} 2) false
+    (contains? #{1} nil) false
 
-      (contains? #{1 2 3} 1) true
-      (contains? #{1 2 3} 3) true
-      (contains? #{1 2 3} 10) false
-      (contains? #{1 2 3} nil) false)
+    (contains? #{1 2 3} 1) true
+    (contains? #{1 2 3} 3) true
+    (contains? #{1 2 3} 10) false
+    (contains? #{1 2 3} nil) false)
 
-  ; contains? also works on java.util.Map and java.util.Set.
+  ;; contains? also works on java.util.Map and java.util.Set.
   (are [x y] (= x y)
-      (contains? (java.util.HashMap. {}) :a) false
-      (contains? (java.util.HashMap. {}) nil) false
+    (contains? (java.util.HashMap. {}) :a) false
+    (contains? (java.util.HashMap. {}) nil) false
 
-      (contains? (java.util.HashMap. {:a 1}) :a) true
-      (contains? (java.util.HashMap. {:a 1}) :b) false
-      (contains? (java.util.HashMap. {:a 1}) nil) false
+    (contains? (java.util.HashMap. {:a 1}) :a) true
+    (contains? (java.util.HashMap. {:a 1}) :b) false
+    (contains? (java.util.HashMap. {:a 1}) nil) false
 
-      (contains? (java.util.HashMap. {:a 1 :b 2}) :a) true
-      (contains? (java.util.HashMap. {:a 1 :b 2}) :b) true
-      (contains? (java.util.HashMap. {:a 1 :b 2}) :c) false
-      (contains? (java.util.HashMap. {:a 1 :b 2}) nil) false
+    (contains? (java.util.HashMap. {:a 1 :b 2}) :a) true
+    (contains? (java.util.HashMap. {:a 1 :b 2}) :b) true
+    (contains? (java.util.HashMap. {:a 1 :b 2}) :c) false
+    (contains? (java.util.HashMap. {:a 1 :b 2}) nil) false
 
-      ; sets
-      (contains? (java.util.HashSet. #{}) 1) false
-      (contains? (java.util.HashSet. #{}) nil) false
+                                        ; sets
+    (contains? (java.util.HashSet. #{}) 1) false
+    (contains? (java.util.HashSet. #{}) nil) false
 
-      (contains? (java.util.HashSet. #{1}) 1) true
-      (contains? (java.util.HashSet. #{1}) 2) false
-      (contains? (java.util.HashSet. #{1}) nil) false
+    (contains? (java.util.HashSet. #{1}) 1) true
+    (contains? (java.util.HashSet. #{1}) 2) false
+    (contains? (java.util.HashSet. #{1}) nil) false
 
-      (contains? (java.util.HashSet. #{1 2 3}) 1) true
-      (contains? (java.util.HashSet. #{1 2 3}) 3) true
-      (contains? (java.util.HashSet. #{1 2 3}) 10) false
-      (contains? (java.util.HashSet. #{1 2 3}) nil) false)
+    (contains? (java.util.HashSet. #{1 2 3}) 1) true
+    (contains? (java.util.HashSet. #{1 2 3}) 3) true
+    (contains? (java.util.HashSet. #{1 2 3}) 10) false
+    (contains? (java.util.HashSet. #{1 2 3}) nil) false)
 
-  ; numerically indexed collections (e.g. vectors and Java arrays)
-  ; => test if the numeric key is WITHIN THE RANGE OF INDEXES
+  ;; numerically indexed collections (e.g. vectors and Java arrays)
+  ;; => test if the numeric key is WITHIN THE RANGE OF INDEXES
   (are [x y] (= x y)
-      (contains? [] 0) false
-      (contains? [] -1) false
-      (contains? [] 1) false
+    (contains? [] 0) false
+    (contains? [] -1) false
+    (contains? [] 1) false
 
-      (contains? [1] 0) true
-      (contains? [1] -1) false
-      (contains? [1] 1) false
+    (contains? [1] 0) true
+    (contains? [1] -1) false
+    (contains? [1] 1) false
 
-      (contains? [1 2 3] 0) true
-      (contains? [1 2 3] 2) true
-      (contains? [1 2 3] 3) false
-      (contains? [1 2 3] -1) false
+    (contains? [1 2 3] 0) true
+    (contains? [1 2 3] 2) true
+    (contains? [1 2 3] 3) false
+    (contains? [1 2 3] -1) false
 
-      ; arrays
-      (contains? (into-array []) 0) false
-      (contains? (into-array []) -1) false
-      (contains? (into-array []) 1) false
+                                        ; arrays
+    (contains? (into-array []) 0) false
+    (contains? (into-array []) -1) false
+    (contains? (into-array []) 1) false
 
-      (contains? (into-array [1]) 0) true
-      (contains? (into-array [1]) -1) false
-      (contains? (into-array [1]) 1) false
+    (contains? (into-array [1]) 0) true
+    (contains? (into-array [1]) -1) false
+    (contains? (into-array [1]) 1) false
 
-      (contains? (into-array [1 2 3]) 0) true
-      (contains? (into-array [1 2 3]) 2) true
-      (contains? (into-array [1 2 3]) 3) false
-      (contains? (into-array [1 2 3]) -1) false)
+    (contains? (into-array [1 2 3]) 0) true
+    (contains? (into-array [1 2 3]) 2) true
+    (contains? (into-array [1 2 3]) 3) false
+    (contains? (into-array [1 2 3]) -1) false)
 
-  ; 'contains?' will not operate on non-associative things
+  ;; 'contains?' will not operate on non-associative things
   (are [x]  (is (thrown? Exception (contains? x 1)))
-       '(1 2 3)
-       3))
-
+    '(1 2 3)
+    3))
 
 (deftest test-keys
   (are [x y] (= x y)      ; other than map data structures
-      (keys ()) nil
-      (keys []) nil
-      (keys #{}) nil
-      (keys "") nil )
+    (keys ()) nil
+    (keys []) nil
+    (keys #{}) nil
+    (keys "") nil)
 
   (are [x y] (= x y)
-      ; (class {:a 1}) => clojure.lang.PersistentArrayMap
-      (keys {}) nil
-      (keys {:a 1}) '(:a)
-      (keys {nil 1}) '(nil)
-      (diff (keys {:a 1 :b 2}) '(:a :b)) nil              ; (keys {:a 1 :b 2}) '(:a :b)
+                                        ; (class {:a 1}) => clojure.lang.PersistentArrayMap
+    (keys {}) nil
+    (keys {:a 1}) '(:a)
+    (keys {nil 1}) '(nil)
+    (diff (keys {:a 1 :b 2}) '(:a :b)) nil              ; (keys {:a 1 :b 2}) '(:a :b)
 
-      ; (class (sorted-map :a 1)) => clojure.lang.PersistentTreeMap
-      (keys (sorted-map)) nil
-      (keys (sorted-map :a 1)) '(:a)
-      (diff (keys (sorted-map :a 1 :b 2)) '(:a :b)) nil   ; (keys (sorted-map :a 1 :b 2)) '(:a :b)
+                                        ; (class (sorted-map :a 1)) => clojure.lang.PersistentTreeMap
+    (keys (sorted-map)) nil
+    (keys (sorted-map :a 1)) '(:a)
+    (diff (keys (sorted-map :a 1 :b 2)) '(:a :b)) nil   ; (keys (sorted-map :a 1 :b 2)) '(:a :b)
 
-      ; (class (hash-map :a 1)) => clojure.lang.PersistentHashMap
-      (keys (hash-map)) nil
-      (keys (hash-map :a 1)) '(:a)
-      (diff (keys (hash-map :a 1 :b 2)) '(:a :b)) nil )   ; (keys (hash-map :a 1 :b 2)) '(:a :b)
+                                        ; (class (hash-map :a 1)) => clojure.lang.PersistentHashMap
+    (keys (hash-map)) nil
+    (keys (hash-map :a 1)) '(:a)
+    (diff (keys (hash-map :a 1 :b 2)) '(:a :b)) nil)   ; (keys (hash-map :a 1 :b 2)) '(:a :b)
 
   (let [m {:a 1 :b 2}
         k (keys m)]
     (is (= {:hi :there} (meta (with-meta k {:hi :there}))))))
 
-
 (deftest test-vals
   (are [x y] (= x y)      ; other than map data structures
-      (vals ()) nil
-      (vals []) nil
-      (vals #{}) nil
-      (vals "") nil )
+    (vals ()) nil
+    (vals []) nil
+    (vals #{}) nil
+    (vals "") nil)
 
   (are [x y] (= x y)
-      ; (class {:a 1}) => clojure.lang.PersistentArrayMap
-      (vals {}) nil
-      (vals {:a 1}) '(1)
-      (vals {nil 1}) '(1)
-      (diff (vals {:a 1 :b 2}) '(1 2)) nil              ; (vals {:a 1 :b 2}) '(1 2)
+                                        ; (class {:a 1}) => clojure.lang.PersistentArrayMap
+    (vals {}) nil
+    (vals {:a 1}) '(1)
+    (vals {nil 1}) '(1)
+    (diff (vals {:a 1 :b 2}) '(1 2)) nil              ; (vals {:a 1 :b 2}) '(1 2)
 
-      ; (class (sorted-map :a 1)) => clojure.lang.PersistentTreeMap
-      (vals (sorted-map)) nil
-      (vals (sorted-map :a 1)) '(1)
-      (diff (vals (sorted-map :a 1 :b 2)) '(1 2)) nil   ; (vals (sorted-map :a 1 :b 2)) '(1 2)
+                                        ; (class (sorted-map :a 1)) => clojure.lang.PersistentTreeMap
+    (vals (sorted-map)) nil
+    (vals (sorted-map :a 1)) '(1)
+    (diff (vals (sorted-map :a 1 :b 2)) '(1 2)) nil   ; (vals (sorted-map :a 1 :b 2)) '(1 2)
 
-      ; (class (hash-map :a 1)) => clojure.lang.PersistentHashMap
-      (vals (hash-map)) nil
-      (vals (hash-map :a 1)) '(1)
-      (diff (vals (hash-map :a 1 :b 2)) '(1 2)) nil )   ; (vals (hash-map :a 1 :b 2)) '(1 2)
+                                        ; (class (hash-map :a 1)) => clojure.lang.PersistentHashMap
+    (vals (hash-map)) nil
+    (vals (hash-map :a 1)) '(1)
+    (diff (vals (hash-map :a 1 :b 2)) '(1 2)) nil)   ; (vals (hash-map :a 1 :b 2)) '(1 2)
 
   (let [m {:a 1 :b 2}
         v (vals m)]
     (is (= {:hi :there} (meta (with-meta v {:hi :there}))))))
 
-
 (deftest test-key
   (are [x]  (= (key (first (hash-map x :value))) x)
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      () '(1 2)
-      [] [1 2]
-      {} {:a 1 :b 2}
-      #{} #{1 2} ))
-
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2}))
 
 (deftest test-val
   (are [x]  (= (val (first (hash-map :key x))) x)
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      () '(1 2)
-      [] [1 2]
-      {} {:a 1 :b 2}
-      #{} #{1 2} ))
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2}))
 
 (deftest test-get
   (let [m {:a 1, :b 2, :c {:d 3, :e 4}, :f nil, :g false, nil {:h 5}}]
     (is (thrown? IllegalArgumentException (get-in {:a 1} 5)))
     (are [x y] (= x y)
-         (get m :a) 1
-         (get m :e) nil
-         (get m :e 0) 0
-         (get m nil) {:h 5}
-         (get m :b 0) 2
-         (get m :f 0) nil
+      (get m :a) 1
+      (get m :e) nil
+      (get m :e 0) 0
+      (get m nil) {:h 5}
+      (get m :b 0) 2
+      (get m :f 0) nil
 
-         (get-in m [:c :e]) 4
-         (get-in m '(:c :e)) 4
-         (get-in m [:c :x]) nil
-         (get-in m [:f]) nil
-         (get-in m [:g]) false
-         (get-in m [:h]) nil
-         (get-in m []) m
-         (get-in m nil) m
+      (get-in m [:c :e]) 4
+      (get-in m '(:c :e)) 4
+      (get-in m [:c :x]) nil
+      (get-in m [:f]) nil
+      (get-in m [:g]) false
+      (get-in m [:h]) nil
+      (get-in m []) m
+      (get-in m nil) m
 
-         (get-in m [:c :e] 0) 4
-         (get-in m '(:c :e) 0) 4
-         (get-in m [:c :x] 0) 0
-         (get-in m [:b] 0) 2
-         (get-in m [:f] 0) nil
-         (get-in m [:g] 0) false
-         (get-in m [:h] 0) 0
-         (get-in m [:x :y] {:y 1}) {:y 1}
-         (get-in m [] 0) m
-         (get-in m nil 0) m)))
+      (get-in m [:c :e] 0) 4
+      (get-in m '(:c :e) 0) 4
+      (get-in m [:c :x] 0) 0
+      (get-in m [:b] 0) 2
+      (get-in m [:f] 0) nil
+      (get-in m [:g] 0) false
+      (get-in m [:h] 0) 0
+      (get-in m [:x :y] {:y 1}) {:y 1}
+      (get-in m [] 0) m
+      (get-in m nil 0) m)))
 
 (deftest test-nested-map-destructuring
   (let [sample-map {:a 1 :b {:a 2}}
@@ -699,189 +686,231 @@
         {{ai4 :a :as m} :b ao4 :a :as m} sample-map]
     (are [i o] (and (= i 2)
                     (= o 1))
-         ai1 ao1
-         ai2 ao2
-         ai3 ao3
-         ai4 ao4)))
+      ai1 ao1
+      ai2 ao2
+      ai3 ao3
+      ai4 ao4)))
 
 (deftest test-map-entry?
   (testing "map-entry? = false"
     (are [entry]
-      (false? (map-entry? entry))
+         (false? (map-entry? entry))
       nil 5 #{1 2} '(1 2) {:a 1} [] [0] [1 2 3]))
   (testing "map-entry? = true"
     (are [entry]
-      (true? (map-entry? entry))
+         (true? (map-entry? entry))
       (first (doto (java.util.HashMap.) (.put "x" 1))))))
 
 ;; *** Sets ***
 
 (deftest test-hash-set
   (are [x] (set? x)
-      #{}
-      #{1 2}
-      (hash-set)
-      (hash-set 1 2) )
+    #{}
+    #{1 2}
+    (hash-set)
+    (hash-set 1 2))
 
-  ; order isn't important
+  ;; order isn't important
   (are [x y] (= x y)
-      #{1 2} #{2 1}
-      #{3 1 2} #{1 2 3}
-      (hash-set 1 2) (hash-set 2 1)
-      (hash-set 3 1 2) (hash-set 1 2 3) )
+    #{1 2} #{2 1}
+    #{3 1 2} #{1 2 3}
+    (hash-set 1 2) (hash-set 2 1)
+    (hash-set 3 1 2) (hash-set 1 2 3)
 
+    ;; equal classes
+    (class #{}) (class (hash-set))
+    (class #{1 2}) (class (hash-set 1 2))
 
-  (are [x y] (= x y)
-      ; equal classes
-      (class #{}) (class (hash-set))
-      (class #{1 2}) (class (hash-set 1 2))
+    ;; creating
+    (hash-set) #{}
+    (hash-set 1) #{1}
+    (hash-set 1 2) #{1 2}
 
-      ; creating
-      (hash-set) #{}
-      (hash-set 1) #{1}
-      (hash-set 1 2) #{1 2}
+    ;; nesting
+    (hash-set 1 (hash-set 2 3) (hash-set 3 (hash-set 4 5 (hash-set 6 (hash-set 7)))))
+    #{1 #{2 3} #{3 #{4 5 #{6 #{7}}}}}
 
-      ; nesting
-      (hash-set 1 (hash-set 2 3) (hash-set 3 (hash-set 4 5 (hash-set 6 (hash-set 7)))))
-        #{1 #{2 3} #{3 #{4 5 #{6 #{7}}}}}
+    ;; different data structures
+    (hash-set true false nil)
+    #{true false nil}
+    (hash-set 1 2.5 2/3 "ab" \x 'cd :kw)
+    #{1 2.5 2/3 "ab" \x 'cd :kw}
+    (hash-set (list 1 2) [3 4] {:a 1 :b 2} #{:c :d})
+    #{'(1 2) [3 4] {:a 1 :b 2} #{:c :d}}
 
-      ; different data structures
-      (hash-set true false nil)
-        #{true false nil}
-      (hash-set 1 2.5 2/3 "ab" \x 'cd :kw)
-        #{1 2.5 2/3 "ab" \x 'cd :kw}
-      (hash-set (list 1 2) [3 4] {:a 1 :b 2} #{:c :d})
-        #{'(1 2) [3 4] {:a 1 :b 2} #{:c :d}}
+    ;; evaluation
+    (hash-set (+ 1 2) [(+ 2 3) :a] (hash-set (* 2 3) 8))
+    #{3 [5 :a] #{6 8}}
 
-      ; evaluation
-      (hash-set (+ 1 2) [(+ 2 3) :a] (hash-set (* 2 3) 8))
-        #{3 [5 :a] #{6 8}}
-
-      ; special cases
-      (hash-set nil) #{nil}
-      (hash-set 1 nil) #{1 nil}
-      (hash-set nil 2) #{nil 2}
-      (hash-set #{}) #{#{}}
-      (hash-set 1 #{}) #{1 #{}}
-      (hash-set #{} 2) #{#{} 2}
-      (hash-set (Integer. -1)) (hash-set (Long. -1))))
-
+    ;; special cases
+    (hash-set nil) #{nil}
+    (hash-set 1 nil) #{1 nil}
+    (hash-set nil 2) #{nil 2}
+    (hash-set #{}) #{#{}}
+    (hash-set 1 #{}) #{1 #{}}
+    (hash-set #{} 2) #{#{} 2}
+    (hash-set (Integer. -1)) (hash-set (Long. -1))))
 
 (deftest test-sorted-set
-  ; only compatible types can be used
+  ;; only compatible types can be used
   (is (thrown? ClassCastException (sorted-set 1 "a")))
   (is (thrown? ClassCastException (sorted-set '(1 2) [3 4])))
 
-  ; creates set?
+  ;; creates set?
   (are [x] (set? x)
-       (sorted-set)
-       (sorted-set 1 2) )
+    (sorted-set)
+    (sorted-set 1 2))
 
-  ; equal and unique
+  ;; equal and unique
   (are [x] (and (= (sorted-set x) #{x})
                 (= (sorted-set x x) (sorted-set x)))
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      ()  ; '(1 2)
-      [] [1 2]
-      {}  ; {:a 1 :b 2}
-      #{} ; #{1 2}
-  )
-  ; cannot be cast to java.lang.Comparable
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    ()  ; '(1 2)
+    [] [1 2]
+    {}  ; {:a 1 :b 2}
+    #{} ; #{1 2}
+)
+  ;; cannot be cast to java.lang.Comparable
   (is (thrown? ClassCastException (sorted-set '(1 2) '(1 2))))
   (is (thrown? ClassCastException (sorted-set {:a 1 :b 2} {:a 1 :b 2})))
   (is (thrown? ClassCastException (sorted-set #{1 2} #{1 2})))
 
   (are [x y] (= x y)
-      ; generating
-      (sorted-set) #{}
-      (sorted-set 1) #{1}
-      (sorted-set 1 2) #{1 2}
+    ;; generating
+    (sorted-set) #{}
+    (sorted-set 1) #{1}
+    (sorted-set 1 2) #{1 2}
 
-      ; sorting
-      (seq (sorted-set 5 4 3 2 1)) '(1 2 3 4 5)
+    ;; sorting
+    (seq (sorted-set 5 4 3 2 1)) '(1 2 3 4 5)
 
-      ; special cases
-      (sorted-set nil) #{nil}
-      (sorted-set 1 nil) #{nil 1}
-      (sorted-set nil 2) #{nil 2}
-      (sorted-set #{}) #{#{}} ))
-
+    ;; special cases
+    (sorted-set nil) #{nil}
+    (sorted-set 1 nil) #{nil 1}
+    (sorted-set nil 2) #{nil 2}
+    (sorted-set #{}) #{#{}}))
 
 (deftest test-sorted-set-by
-  ; only compatible types can be used
-  ; NB: not a ClassCastException, but a RuntimeException is thrown,
-  ; requires discussion on whether this should be symmetric with test-sorted-set
+  ;; only compatible types can be used
+  ;; NB: not a ClassCastException, but a RuntimeException is thrown,
+  ;; requires discussion on whether this should be symmetric with test-sorted-set
   (is (thrown? Exception (sorted-set-by < 1 "a")))
   (is (thrown? Exception (sorted-set-by < '(1 2) [3 4])))
 
-  ; creates set?
+  ;; creates set?
   (are [x] (set? x)
-       (sorted-set-by <)
-       (sorted-set-by < 1 2) )
+    (sorted-set-by <)
+    (sorted-set-by < 1 2))
 
-  ; equal and unique
+  ;; equal and unique
   (are [x] (and (= (sorted-set-by compare x) #{x})
                 (= (sorted-set-by compare x x) (sorted-set-by compare x)))
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      ()  ; '(1 2)
-      [] [1 2]
-      {}  ; {:a 1 :b 2}
-      #{} ; #{1 2}
-  )
-  ; cannot be cast to java.lang.Comparable
-  ; NB: not a ClassCastException, but a RuntimeException is thrown,
-  ; requires discussion on whether this should be symmetric with test-sorted-set
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    ()  ; '(1 2)
+    [] [1 2]
+    {}  ; {:a 1 :b 2}
+    #{} ; #{1 2}
+)
+  ;; cannot be cast to java.lang.Comparable
+  ;; NB: not a ClassCastException, but a RuntimeException is thrown,
+  ;; requires discussion on whether this should be symmetric with test-sorted-set
   (is (thrown? Exception (sorted-set-by compare '(1 2) '(1 2))))
   (is (thrown? Exception (sorted-set-by compare {:a 1 :b 2} {:a 1 :b 2})))
   (is (thrown? Exception (sorted-set-by compare #{1 2} #{1 2})))
 
   (are [x y] (= x y)
-      ; generating
-      (sorted-set-by >) #{}
-      (sorted-set-by > 1) #{1}
-      (sorted-set-by > 1 2) #{1 2}
+    ;; generating
+    (sorted-set-by >) #{}
+    (sorted-set-by > 1) #{1}
+    (sorted-set-by > 1 2) #{1 2}
 
-      ; sorting
-      (seq (sorted-set-by < 5 4 3 2 1)) '(1 2 3 4 5)
+    ;; sorting
+    (seq (sorted-set-by < 5 4 3 2 1)) '(1 2 3 4 5)
 
-      ; special cases
-      (sorted-set-by compare nil) #{nil}
-      (sorted-set-by compare 1 nil) #{nil 1}
-      (sorted-set-by compare nil 2) #{nil 2}
-      (sorted-set-by compare #{}) #{#{}} ))
-
+    ;; special cases
+    (sorted-set-by compare nil) #{nil}
+    (sorted-set-by compare 1 nil) #{nil 1}
+    (sorted-set-by compare nil 2) #{nil 2}
+    (sorted-set-by compare #{}) #{#{}}))
 
 (deftest test-set
-  ; set?
+  ;; set?
   (are [x] (set? (set x))
-      () '(1 2)
-      [] [1 2]
-      #{} #{1 2}
-      {} {:a 1 :b 2}
-      (into-array []) (into-array [1 2])
-      "" "abc" )
+    () '(1 2)
+    [] [1 2]
+    #{} #{1 2}
+    {} {:a 1 :b 2}
+    (into-array []) (into-array [1 2])
+    "" "abc")
 
-  ; unique
+  ;; unique
   (are [x] (= (set [x x]) #{x})
-      nil
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2})
+
+  ;; conversion
+  (are [x y] (= (set x) y)
+    () #{}
+    '(1 2) #{1 2}
+
+    [] #{}
+    [1 2] #{1 2}
+
+    #{} #{}         ; identity
+    #{1 2} #{1 2}   ; identity
+
+    {} #{}
+    {:a 1 :b 2} #{[:a 1] [:b 2]}
+
+    (into-array []) #{}
+    (into-array [1 2]) #{1 2}
+
+    "" #{}
+    "abc" #{\a \b \c}))
+
+(deftest test-disj
+  ;; doesn't work on lists, vectors or maps
+  (is (thrown? ClassCastException (disj '(1 2) 1)))
+  (is (thrown? ClassCastException (disj [1 2] 1)))
+  (is (thrown? ClassCastException (disj {:a 1} :a)))
+
+  ;; identity
+  (are [x] (= (disj x) x)
+    nil
+    #{}
+    #{1 2 3}
+    ;; different data types
+    #{nil
       false true
       0 42
       0.0 3.14
@@ -891,89 +920,40 @@
       "" "abc"
       'sym
       :kw
-      () '(1 2)
       [] [1 2]
       {} {:a 1 :b 2}
-      #{} #{1 2} )
+      #{} #{1 2}})
 
-  ; conversion
-  (are [x y] (= (set x) y)
-      () #{}
-      '(1 2) #{1 2}
-
-      [] #{}
-      [1 2] #{1 2}
-
-      #{} #{}         ; identity
-      #{1 2} #{1 2}   ; identity
-
-      {} #{}
-      {:a 1 :b 2} #{[:a 1] [:b 2]}
-
-      (into-array []) #{}
-      (into-array [1 2]) #{1 2}
-
-      "" #{}
-      "abc" #{\a \b \c} ))
-
-
-(deftest test-disj
-  ; doesn't work on lists, vectors or maps
-  (is (thrown? ClassCastException (disj '(1 2) 1)))
-  (is (thrown? ClassCastException (disj [1 2] 1)))
-  (is (thrown? ClassCastException (disj {:a 1} :a)))
-
-  ; identity
-  (are [x] (= (disj x) x)
-      nil
-      #{}
-      #{1 2 3}
-      ; different data types
-      #{nil
-        false true
-        0 42
-        0.0 3.14
-        2/3
-        0M 1M
-        \c
-        "" "abc"
-        'sym
-        :kw
-        [] [1 2]
-        {} {:a 1 :b 2}
-        #{} #{1 2}} )
-
-  ; type identity
+  ;; type identity
   (are [x] (= (class (disj x)) (class x))
-      (hash-set)
-      (hash-set 1 2)
-      (sorted-set)
-      (sorted-set 1 2) )
+    (hash-set)
+    (hash-set 1 2)
+    (sorted-set)
+    (sorted-set 1 2))
 
   (are [x y] (= x y)
-      (disj nil :a) nil
-      (disj nil :a :b) nil
+    (disj nil :a) nil
+    (disj nil :a :b) nil
 
-      (disj #{} :a) #{}
-      (disj #{} :a :b) #{}
+    (disj #{} :a) #{}
+    (disj #{} :a :b) #{}
 
-      (disj #{:a} :a) #{}
-      (disj #{:a} :a :b) #{}
-      (disj #{:a} :c) #{:a}
+    (disj #{:a} :a) #{}
+    (disj #{:a} :a :b) #{}
+    (disj #{:a} :c) #{:a}
 
-      (disj #{:a :b :c :d} :a) #{:b :c :d}
-      (disj #{:a :b :c :d} :a :d) #{:b :c}
-      (disj #{:a :b :c :d} :a :b :c) #{:d}
-      (disj #{:a :b :c :d} :d :a :c :b) #{}
+    (disj #{:a :b :c :d} :a) #{:b :c :d}
+    (disj #{:a :b :c :d} :a :d) #{:b :c}
+    (disj #{:a :b :c :d} :a :b :c) #{:d}
+    (disj #{:a :b :c :d} :d :a :c :b) #{}
 
-      (disj #{nil} :a) #{nil}
-      (disj #{nil} #{}) #{nil}
-      (disj #{nil} nil) #{}
+    (disj #{nil} :a) #{nil}
+    (disj #{nil} #{}) #{nil}
+    (disj #{nil} nil) #{}
 
-      (disj #{#{}} nil) #{#{}}
-      (disj #{#{}} #{}) #{}
-      (disj #{#{nil}} #{nil}) #{} ))
-
+    (disj #{#{}} nil) #{#{}}
+    (disj #{#{}} #{}) #{}
+    (disj #{#{nil}} #{nil}) #{}))
 
 ;; *** Queues ***
 
@@ -987,18 +967,17 @@
       (hash [1 2 3]) (hash (conj EMPTY 1 2 3))
       (range 5) (into EMPTY (range 5))
       (range 1 6) (-> EMPTY
-                    (into (range 6))
-                    pop))
+                      (into (range 6))
+                      pop))
     (are [x y] (not= x y)
       (range 5) (into EMPTY (range 6))
       (range 6) (into EMPTY (range 5))
       (range 0 6) (-> EMPTY
-                    (into (range 6))
-                    pop)
+                      (into (range 6))
+                      pop)
       (range 1 6) (-> EMPTY
-                    (into (range 7))
-                    pop))))
-
+                      (into (range 7))
+                      pop))))
 
 (deftest test-duplicates
   (let [equal-sets-incl-meta (fn [s1 s2]
@@ -1078,11 +1057,11 @@
 
 (deftest test-assoc
   (are [x y] (= x y)
-       [4] (assoc [] 0 4)
-       [5 -7] (assoc [] 0 5 1 -7)
-       {:a 1} (assoc {} :a 1)
-       {nil 1} (assoc {} nil 1)
-       {:a 2 :b -2} (assoc {} :b -2 :a 2))
+    [4] (assoc [] 0 4)
+    [5 -7] (assoc [] 0 5 1 -7)
+    {:a 1} (assoc {} :a 1)
+    {nil 1} (assoc {} nil 1)
+    {:a 2 :b -2} (assoc {} :b -2 :a 2))
   (is (thrown? IllegalArgumentException (assoc [] 0 5 1)))
   (is (thrown? IllegalArgumentException (assoc {} :b -2 :a))))
 
@@ -1098,21 +1077,21 @@
     (is (= (.hashCode ^Object a) (.hashCode ^Object b)) msg)))
 
 (deftest ordered-collection-equality-test
-  (let [empty-colls [ []
-                      '()
-                      (lazy-seq)
-                      clojure.lang.PersistentQueue/EMPTY
-                      (vector-of :long) ]]
+  (let [empty-colls [[]
+                     '()
+                     (lazy-seq)
+                     clojure.lang.PersistentQueue/EMPTY
+                     (vector-of :long)]]
     (doseq [c1 empty-colls, c2 empty-colls]
       (is-same-collection c1 c2)))
-  (let [colls1 [ [-3 :a "7th"]
-                 '(-3 :a "7th")
-                 (lazy-seq (cons -3
-                   (lazy-seq (cons :a
-                     (lazy-seq (cons "7th" nil))))))
-                 (into clojure.lang.PersistentQueue/EMPTY
-                       [-3 :a "7th"])
-                 (sequence (map identity) [-3 :a "7th"]) ]]
+  (let [colls1 [[-3 :a "7th"]
+                '(-3 :a "7th")
+                (lazy-seq (cons -3
+                                (lazy-seq (cons :a
+                                                (lazy-seq (cons "7th" nil))))))
+                (into clojure.lang.PersistentQueue/EMPTY
+                      [-3 :a "7th"])
+                (sequence (map identity) [-3 :a "7th"])]]
     (doseq [c1 colls1, c2 colls1]
       (is-same-collection c1 c2)))
   (is-same-collection [-3 1 7] (vector-of :long -3 1 7)))
@@ -1121,33 +1100,33 @@
   (compare (string/lower-case s1) (string/lower-case s2)))
 
 (deftest set-equality-test
-  (let [empty-sets [ #{}
-                     (hash-set)
-                     (sorted-set)
-                     (sorted-set-by case-indendent-string-cmp) ]]
+  (let [empty-sets [#{}
+                    (hash-set)
+                    (sorted-set)
+                    (sorted-set-by case-indendent-string-cmp)]]
     (doseq [s1 empty-sets, s2 empty-sets]
       (is-same-collection s1 s2)))
-  (let [sets1 [ #{"Banana" "apple" "7th"}
-                (hash-set "Banana" "apple" "7th")
-                (sorted-set "Banana" "apple" "7th")
-                (sorted-set-by case-indendent-string-cmp "Banana" "apple" "7th") ]]
+  (let [sets1 [#{"Banana" "apple" "7th"}
+               (hash-set "Banana" "apple" "7th")
+               (sorted-set "Banana" "apple" "7th")
+               (sorted-set-by case-indendent-string-cmp "Banana" "apple" "7th")]]
     (doseq [s1 sets1, s2 sets1]
       (is-same-collection s1 s2))))
 
 (deftest map-equality-test
-  (let [empty-maps [ {}
-                     (hash-map)
-                     (array-map)
-                     (sorted-map)
-                     (sorted-map-by case-indendent-string-cmp) ]]
+  (let [empty-maps [{}
+                    (hash-map)
+                    (array-map)
+                    (sorted-map)
+                    (sorted-map-by case-indendent-string-cmp)]]
     (doseq [m1 empty-maps, m2 empty-maps]
       (is-same-collection m1 m2)))
-  (let [maps1 [ {"Banana" "like", "apple" "love", "7th" "indifferent"}
-                (hash-map "Banana" "like", "apple" "love", "7th" "indifferent")
-                (array-map "Banana" "like", "apple" "love", "7th" "indifferent")
-                (sorted-map "Banana" "like", "apple" "love", "7th" "indifferent")
-                (sorted-map-by case-indendent-string-cmp
-                               "Banana" "like", "apple" "love", "7th" "indifferent") ]]
+  (let [maps1 [{"Banana" "like", "apple" "love", "7th" "indifferent"}
+               (hash-map "Banana" "like", "apple" "love", "7th" "indifferent")
+               (array-map "Banana" "like", "apple" "love", "7th" "indifferent")
+               (sorted-map "Banana" "like", "apple" "love", "7th" "indifferent")
+               (sorted-map-by case-indendent-string-cmp
+                              "Banana" "like", "apple" "love", "7th" "indifferent")]]
     (doseq [m1 maps1, m2 maps1]
       (is-same-collection m1 m2))))
 
@@ -1205,10 +1184,10 @@
             (when-not (.hasNext i)
               (throw (ex-info "Iterator exhausted before seq"
                               {:pos n :seqable seqable :iterable iterable})))
-              (when-not (= (.next i) (first s))
-                (throw (ex-info "Iterator and seq did not match"
-                                {:pos n :seqable seqable :iterable iterable})))
-                (recur (rest s) (inc n)))
+            (when-not (= (.next i) (first s))
+              (throw (ex-info "Iterator and seq did not match"
+                              {:pos n :seqable seqable :iterable iterable})))
+            (recur (rest s) (inc n)))
           (when (.hasNext i)
             (throw (ex-info "Seq exhausted before iterator"
                             {:pos n :seqable seqable :iterable iterable}))))))))
@@ -1258,23 +1237,23 @@
 (defn gen-record
   []
   (let [r (->Rec (gen/int) (gen/int))]
-       (gen/one-of r
-                   (merge r (gen-map)))))
+    (gen/one-of r
+                (merge r (gen-map)))))
 
 (defspec seq-and-iter-match-for-records
-         identity
-         [^{:tag clojure.test-clojure.data-structures/gen-record} r]
-         (seq-iter-match r r))
+  identity
+  [^{:tag clojure.test-clojure.data-structures/gen-record} r]
+  (seq-iter-match r r))
 
 (defspec seq-and-iter-match-for-keys
-         identity
-         [^{:tag clojure.test-clojure.data-structures/gen-map} m]
-         (seq-iter-match (keys m) (keys m)))
+  identity
+  [^{:tag clojure.test-clojure.data-structures/gen-map} m]
+  (seq-iter-match (keys m) (keys m)))
 
 (defspec seq-and-iter-match-for-vals
-         identity
-         [^{:tag clojure.test-clojure.data-structures/gen-map} m]
-         (seq-iter-match (vals m) (vals m)))
+  identity
+  [^{:tag clojure.test-clojure.data-structures/gen-map} m]
+  (seq-iter-match (vals m) (vals m)))
 
 (defstruct test-struct :a :b)
 
@@ -1285,6 +1264,6 @@
                 (assoc s (rand-nth cgen/ednable-scalars) (rand-nth cgen/ednable-scalars)))))
 
 (defspec seq-and-iter-match-for-structs
-         identity
-         [^{:tag clojure.test-clojure.data-structures/gen-struct} s]
-         (seq-iter-match s s))
+  identity
+  [^{:tag clojure.test-clojure.data-structures/gen-struct} s]
+  (seq-iter-match s s))

--- a/test/clojure/test_clojure/data_structures_interop.clj
+++ b/test/clojure/test_clojure/data_structures_interop.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.data-structures-interop
   (:require [clojure.test :refer :all]
@@ -81,51 +81,51 @@
                                                 ['array-map  (gen-array-map gen/symbol gen/int)]
                                                 ['sorted-map (gen-sorted-map gen/symbol gen/int)]])
                                  (fn [[s g]] (gen/tuple (gen/return s) g)))]
-    (instance? java.util.NoSuchElementException (exaust-iterator-forward (.iterator x)))))
+                (instance? java.util.NoSuchElementException (exaust-iterator-forward (.iterator x)))))
 
 (defspec array-iterator-throws-exception-on-exaustion 100
   (prop/for-all [arr (gen-array)]
-    (let [iter (clojure.lang.ArrayIter/createFromObject arr)]
-      (instance? java.util.NoSuchElementException (exaust-iterator-forward iter)))))
+                (let [iter (clojure.lang.ArrayIter/createFromObject arr)]
+                  (instance? java.util.NoSuchElementException (exaust-iterator-forward iter)))))
 
 (defspec list-iterator-throws-exception-on-forward-exaustion 50
   (prop/for-all [[_ x] (gen/bind (gen/elements [['vector    (gen/vector gen/int)]
                                                 ['subvec    (gen-subvec (gen/vector gen/int))]
                                                 ['vector-of (gen-gvec)]])
                                  (fn [[s g]] (gen/tuple (gen/return s) g)))]
-    (instance? java.util.NoSuchElementException (exaust-iterator-forward (.listIterator x)))))
+                (instance? java.util.NoSuchElementException (exaust-iterator-forward (.listIterator x)))))
 
 (defspec list-iterator-throws-exception-on-backward-exaustion 50
   (prop/for-all [[_ x] (gen/bind (gen/elements [['vector    (gen/vector gen/int)]
                                                 ['subvec    (gen-subvec (gen/vector gen/int))]
                                                 ['vector-of (gen-gvec)]])
                                  (fn [[s g]] (gen/tuple (gen/return s) g)))]
-    (instance? java.util.NoSuchElementException (exaust-iterator-backward (.listIterator x)))))
+                (instance? java.util.NoSuchElementException (exaust-iterator-backward (.listIterator x)))))
 
 (defspec map-keyset-iterator-throws-exception-on-exaustion 50
   (prop/for-all [[_ m] (gen/bind (gen/elements [['hash-map   (gen/hash-map gen/symbol gen/int)
                                                  'array-map  (gen-array-map gen/symbol gen/int)
                                                  'sorted-map (gen-sorted-map gen/symbol gen/int)]])
                                  (fn [[s g]] (gen/tuple (gen/return s) g)))]
-    (let [iter (.iterator (.keySet m))]
-      (instance? java.util.NoSuchElementException (exaust-iterator-forward iter)))))
+                (let [iter (.iterator (.keySet m))]
+                  (instance? java.util.NoSuchElementException (exaust-iterator-forward iter)))))
 
 (defspec map-values-iterator-throws-exception-on-exaustion 50
   (prop/for-all [[_ m] (gen/bind (gen/elements [['hash-map   (gen/hash-map gen/symbol gen/int)
                                                  'array-map  (gen-array-map gen/symbol gen/int)
                                                  'sorted-map (gen-sorted-map gen/symbol gen/int)]])
                                  (fn [[s g]] (gen/tuple (gen/return s) g)))]
-    (let [iter (.iterator (.values m))]
-      (instance? java.util.NoSuchElementException (exaust-iterator-forward iter)))))
+                (let [iter (.iterator (.values m))]
+                  (instance? java.util.NoSuchElementException (exaust-iterator-forward iter)))))
 
 (defspec map-keys-iterator-throws-exception-on-exaustion 50
   (prop/for-all [m (gen-sorted-map gen/symbol gen/int)]
-    (instance? java.util.NoSuchElementException (exaust-iterator-forward (.keys m)))))
+                (instance? java.util.NoSuchElementException (exaust-iterator-forward (.keys m)))))
 
 (defspec map-vals-iterator-throws-exception-on-exaustion 50
   (prop/for-all [m (gen-sorted-map gen/symbol gen/int)]
-    (instance? java.util.NoSuchElementException (exaust-iterator-forward (.vals m)))))
+                (instance? java.util.NoSuchElementException (exaust-iterator-forward (.vals m)))))
 
 (defspec map-reverse-iterator-throws-exception-on-exaustion 50
   (prop/for-all [m (gen-sorted-map gen/symbol gen/int)]
-    (instance? java.util.NoSuchElementException (exaust-iterator-forward (.reverseIterator m)))))
+                (instance? java.util.NoSuchElementException (exaust-iterator-forward (.reverseIterator m)))))

--- a/test/clojure/test_clojure/def.clj
+++ b/test/clojure/test_clojure/def.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.def
   (:use clojure.test clojure.test-helper
@@ -12,45 +12,45 @@
 
 (deftest defn-error-messages
   (testing "multiarity syntax invalid parameter declaration"
-    (is (fails-with-cause? 
-          IllegalArgumentException 
-          #"Parameter declaration \"arg1\" should be a vector"
-          (eval-in-temp-ns (defn foo (arg1 arg2))))))
+    (is (fails-with-cause?
+         IllegalArgumentException
+         #"Parameter declaration \"arg1\" should be a vector"
+         (eval-in-temp-ns (defn foo (arg1 arg2))))))
 
   (testing "multiarity syntax invalid signature"
-    (is (fails-with-cause? 
-          IllegalArgumentException 
-          #"Invalid signature \"\[a b\]\" should be a list"
-          (eval-in-temp-ns (defn foo 
-                             ([a] 1)
-                             [a b])))))
+    (is (fails-with-cause?
+         IllegalArgumentException
+         #"Invalid signature \"\[a b\]\" should be a list"
+         (eval-in-temp-ns (defn foo
+                            ([a] 1)
+                            [a b])))))
 
   (testing "assume single arity syntax"
-    (is (fails-with-cause? 
-          IllegalArgumentException 
-          #"Parameter declaration \"a\" should be a vector"
-          (eval-in-temp-ns (defn foo a)))))
+    (is (fails-with-cause?
+         IllegalArgumentException
+         #"Parameter declaration \"a\" should be a vector"
+         (eval-in-temp-ns (defn foo a)))))
 
   (testing "bad name"
-    (is (fails-with-cause? 
-          IllegalArgumentException 
-          #"First argument to defn must be a symbol"
-          (eval-in-temp-ns (defn "bad docstring" testname [arg1 arg2])))))
-         
+    (is (fails-with-cause?
+         IllegalArgumentException
+         #"First argument to defn must be a symbol"
+         (eval-in-temp-ns (defn "bad docstring" testname [arg1 arg2])))))
+
   (testing "missing parameter/signature"
-    (is (fails-with-cause? 
-          IllegalArgumentException 
-          #"Parameter declaration missing"
-          (eval-in-temp-ns (defn testname)))))
+    (is (fails-with-cause?
+         IllegalArgumentException
+         #"Parameter declaration missing"
+         (eval-in-temp-ns (defn testname)))))
 
   (testing "allow trailing map"
     (is (eval-in-temp-ns (defn a "asdf" ([a] 1) {:a :b}))))
 
   (testing "don't allow interleaved map"
-    (is (fails-with-cause? 
-          IllegalArgumentException 
-          #"Invalid signature \"\{:a :b\}\" should be a list"
-          (eval-in-temp-ns (defn a "asdf" ([a] 1) {:a :b} ([] 1)))))))
+    (is (fails-with-cause?
+         IllegalArgumentException
+         #"Invalid signature \"\{:a :b\}\" should be a list"
+         (eval-in-temp-ns (defn a "asdf" ([a] 1) {:a :b} ([] 1)))))))
 
 (deftest non-dynamic-warnings
   (testing "no warning for **"
@@ -64,7 +64,7 @@
   ;; too many contextual things for this kind of caching to work...
   (testing "classes are never cached, even if their bodies are the same"
     (is (= :b
-          (eval
+           (eval
             '(do
                (defmacro my-macro [] :a)
                (defn do-macro [] (my-macro))
@@ -75,10 +75,10 @@
 (deftest nested-dynamic-declaration
   (testing "vars :dynamic meta data is applied immediately to vars declared anywhere"
     (is (= 10
-          (eval
+           (eval
             '(do
                (list
-                 (declare ^:dynamic p)
-                 (defn q [] @p))
+                (declare ^:dynamic p)
+                (defn q [] @p))
                (binding [p (atom 10)]
                  (q))))))))

--- a/test/clojure/test_clojure/edn.clj
+++ b/test/clojure/test_clojure/edn.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stuart Halloway
+;; Author: Stuart Halloway
 
 
 (ns clojure.test-clojure.edn
@@ -22,8 +22,8 @@
             *print-dup* nil
             *print-level* nil]
     (try
-     (-> o pr-str edn/read-string)
-     (catch Throwable t t))))
+      (-> o pr-str edn/read-string)
+      (catch Throwable t t))))
 
 (defspec types-that-should-roundtrip
   roundtrip

--- a/test/clojure/test_clojure/errors.clj
+++ b/test/clojure/test_clojure/errors.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Tests for error handling and messages
 
@@ -26,26 +26,26 @@
 (deftest arity-exception
   ;; IllegalArgumentException is pre-1.3
   (is (thrown-with-msg? IllegalArgumentException #"Wrong number of args \(1\) passed to"
-        (f0 1)))
+                        (f0 1)))
   (is (thrown-with-msg? ArityException #"Wrong number of args \(0\) passed to"
-        (f1)))
+                        (f1)))
   (is (thrown-with-msg? ArityException #"Wrong number of args \(1\) passed to"
-        (macroexpand `(m0 1))))
+                        (macroexpand `(m0 1))))
   (is (thrown-with-msg? ArityException #"Wrong number of args \(2\) passed to"
-        (macroexpand `(m1 1 2))))
+                        (macroexpand `(m1 1 2))))
   (is (thrown-with-msg? ArityException #"\Q/f2:+><->!#%&*|b\E"
-        (f2:+><->!#%&*|b 1 2))
-        "ArityException messages should demunge function names"))
+                        (f2:+><->!#%&*|b 1 2))
+      "ArityException messages should demunge function names"))
 
 (deftest assert-arg-messages
   ; used to ensure that error messages properly use local names for macros
   (refer 'clojure.core :rename '{with-open renamed-with-open})
-  
+
   ; would have used `are` here, but :line meta on &form doesn't survive successive macroexpansions
   (doseq [[msg-regex-str form] [["if-let .* in %s:\\d+" '(if-let [a 5
-                                                                 b 6]
-                                                          true nil)]
-                                ["let .* in %s:\\d+" '(let [a])] 
+                                                                  b 6]
+                                                           true nil)]
+                                ["let .* in %s:\\d+" '(let [a])]
                                 ["let .* in %s:\\d+" '(let (a))]
                                 ["renamed-with-open .* in %s:\\d+" '(renamed-with-open [a])]]]
     (is (thrown-with-msg? IllegalArgumentException
@@ -54,9 +54,9 @@
 
 (deftest extract-ex-data
   (try
-   (throw (ex-info "example error" {:foo 1}))
-   (catch Throwable t
-     (is (= {:foo 1} (ex-data t)))))
+    (throw (ex-info "example error" {:foo 1}))
+    (catch Throwable t
+      (is (= {:foo 1} (ex-data t)))))
   (is (nil? (ex-data (RuntimeException. "example non ex-data")))))
 
 (deftest Throwable->map-test

--- a/test/clojure/test_clojure/evaluation.clj
+++ b/test/clojure/test_clojure/evaluation.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 
 ;;  Tests for the Clojure functions documented at the URL:
@@ -27,11 +27,11 @@
   acts like a comment and the forms are run unchanged."
   [purpose & test-forms]
   (let [tests (map
-                #(if (= (:ns (meta (resolve (first %))))
-                        (the-ns 'clojure.test))
-                   (concat % (list purpose))
-                   %)
-                test-forms)]
+               #(if (= (:ns (meta (resolve (first %))))
+                       (the-ns 'clojure.test))
+                  (concat % (list purpose))
+                  %)
+               test-forms)]
     `(do ~@tests)))
 
 (deftest Eval
@@ -42,8 +42,8 @@
              (is (= (eval (eval '(list + 1 2 3))) 6)))
   (is (= (eval (list '+ 1 2 3)) 6)))
 
-; not using Clojure's RT/classForName since a bug in it could hide a bug in
-; eval's resolution
+;; not using Clojure's RT/classForName since a bug in it could hide a bug in
+;; eval's resolution
 (defn class-for-name [name]
   (java.lang.Class/forName name))
 
@@ -92,53 +92,53 @@
 (defmacro throws-with-msg
   ([re form] `(throws-with-msg ~re ~form Exception))
   ([re form x] `(throws-with-msg
-                  ~re
-                  ~form
-                  ~(if (instance? Exception x) x Exception)
-                  ~(if (instance? String x) x nil)))
+                 ~re
+                 ~form
+                 ~(if (instance? Exception x) x Exception)
+                 ~(if (instance? String x) x nil)))
   ([re form class msg]
-       `(let [ex# (try
-                    ~form
-                    (catch ~class e# e#)
-                    (catch Exception e#
-                      (let [cause# (.getCause e#)]
-                        (if (= ~class (class cause#)) cause# (throw e#)))))]
-          (is (a-match? ~re (.toString ex#))
-              (or ~msg
-                  (str "Expected exception that matched " (pr-str ~re)
-                       ", but got exception with message: \"" ex#))))))
+   `(let [ex# (try
+                ~form
+                (catch ~class e# e#)
+                (catch Exception e#
+                  (let [cause# (.getCause e#)]
+                    (if (= ~class (class cause#)) cause# (throw e#)))))]
+      (is (a-match? ~re (.toString ex#))
+          (or ~msg
+              (str "Expected exception that matched " (pr-str ~re)
+                   ", but got exception with message: \"" ex#))))))
 
 (deftest SymbolResolution
   (test-that
-    "If a symbol is namespace-qualified, the evaluated value is the value
+   "If a symbol is namespace-qualified, the evaluated value is the value
      of the binding of the global var named by the symbol"
-    (is (= (eval 'resolution-test/bar) 123)))
+   (is (= (eval 'resolution-test/bar) 123)))
 
   (test-that
-    "It is an error if there is no global var named by the symbol"
-    (throws-with-msg
-      #".*Unable to resolve symbol: bar.*" (eval 'bar)))
+   "It is an error if there is no global var named by the symbol"
+   (throws-with-msg
+    #".*Unable to resolve symbol: bar.*" (eval 'bar)))
 
   (test-that
-    "It is an error if the symbol reference is to a non-public var in a
+   "It is an error if the symbol reference is to a non-public var in a
     different namespace"
-    (throws-with-msg
-      #".*resolution-test/baz is not public.*"
-      (eval 'resolution-test/baz)
-      Compiler$CompilerException))
+   (throws-with-msg
+    #".*resolution-test/baz is not public.*"
+    (eval 'resolution-test/baz)
+    Compiler$CompilerException))
 
   (test-that
-    "If a symbol is package-qualified, its value is the Java class named by the
+   "If a symbol is package-qualified, its value is the Java class named by the
     symbol"
-    (is (= (eval 'java.lang.Math) (class-for-name "java.lang.Math"))))
+   (is (= (eval 'java.lang.Math) (class-for-name "java.lang.Math"))))
 
   (test-that
-    "If a symbol is package-qualified, it is an error if there is no Class named
+   "If a symbol is package-qualified, it is an error if there is no Class named
     by the symbol"
-    (is (thrown? Compiler$CompilerException (eval 'java.lang.FooBar))))
+   (is (thrown? Compiler$CompilerException (eval 'java.lang.FooBar))))
 
   (test-that
-    "If a symbol is not qualified, the following applies, in this order:
+   "If a symbol is not qualified, the following applies, in this order:
 
       1. If it names a special form it is considered a special form, and must
          be utilized accordingly.
@@ -158,26 +158,26 @@
       5. It is an error."
 
     ; First
-    (doall (for [form '(def if do let quote var fn loop recur throw try
-                         monitor-enter monitor-exit)]
-             (is (thrown? Compiler$CompilerException (eval form)))))
-    (let [if "foo"]
-      (is (thrown? Compiler$CompilerException (eval 'if)))
+   (doall (for [form '(def if do let quote var fn loop recur throw try
+                        monitor-enter monitor-exit)]
+            (is (thrown? Compiler$CompilerException (eval form)))))
+   (let [if "foo"]
+     (is (thrown? Compiler$CompilerException (eval 'if)))
 
     ; Second
-      (is (= (eval 'Boolean) (class-for-name "java.lang.Boolean"))))
-    (let [Boolean "foo"]
-      (is (= (eval 'Boolean) (class-for-name "java.lang.Boolean"))))
+     (is (= (eval 'Boolean) (class-for-name "java.lang.Boolean"))))
+   (let [Boolean "foo"]
+     (is (= (eval 'Boolean) (class-for-name "java.lang.Boolean"))))
 
     ; Third
-    (is (= (eval '(let [foo "bar"] foo)) "bar"))
+   (is (= (eval '(let [foo "bar"] foo)) "bar"))
 
     ; Fourth
-    (in-test-ns (is (= (eval 'foo) "abc")))
-    (is (thrown? Compiler$CompilerException (eval 'bar))) ; not in this namespace
+   (in-test-ns (is (= (eval 'foo) "abc")))
+   (is (thrown? Compiler$CompilerException (eval 'bar))) ; not in this namespace
 
     ; Fifth
-    (is (thrown? Compiler$CompilerException (eval 'foobar)))))
+   (is (thrown? Compiler$CompilerException (eval 'foobar)))))
 
 ;;; Metadata tests ;;;
 
@@ -186,9 +186,9 @@
 (deftest Metadata
 
   (test-that
-    "find returns key symbols and their metadata"
-    (let [s (struct struct-with-symbols 1)]
-      (is (= {:a "A"} (meta (first (find s 'k))))))))
+   "find returns key symbols and their metadata"
+   (let [s (struct struct-with-symbols 1)]
+     (is (= {:a "A"} (meta (first (find s 'k))))))))
 
 ;;; Collections tests ;;;
 (def x 1)
@@ -196,30 +196,30 @@
 
 (deftest Collections
   (in-test-ns
-    (test-that
-      "Vectors and Maps yield vectors and (hash) maps whose contents are the
+   (test-that
+    "Vectors and Maps yield vectors and (hash) maps whose contents are the
       evaluated values of the objects they contain."
-      (is (= (eval '[x y 3]) [1 2 3]))
-      (is (= (eval '{:x x :y y :z 3}) {:x 1 :y 2 :z 3}))
-      (is (instance? clojure.lang.IPersistentMap (eval '{:x x :y y})))))
+    (is (= (eval '[x y 3]) [1 2 3]))
+    (is (= (eval '{:x x :y y :z 3}) {:x 1 :y 2 :z 3}))
+    (is (instance? clojure.lang.IPersistentMap (eval '{:x x :y y})))))
 
   (in-test-ns
-    (test-that
-      "Metadata maps yield maps whose contents are the evaluated values of
+   (test-that
+    "Metadata maps yield maps whose contents are the evaluated values of
       the objects they contain. If a vector or map has metadata, the evaluated
       metadata map will become the metadata of the resulting value."
-      (is (= (eval #^{:x x} '[x y]) #^{:x 1} [1 2]))))
+    (is (= (eval #^{:x x} '[x y]) #^{:x 1} [1 2]))))
 
   (test-that
-    "An empty list () evaluates to an empty list."
-    (is (= (eval '()) ()))
-    (is (empty? (eval ())))
-    (is (= (eval (list)) ())))
+   "An empty list () evaluates to an empty list."
+   (is (= (eval '()) ()))
+   (is (empty? (eval ())))
+   (is (= (eval (list)) ())))
 
   ;aargh, fragile tests, please fix
   #_(test-that
-    "Non-empty lists are considered calls"
-    (is (thrown? Compiler$CompilerException (eval '(1 2 3))))))
+     "Non-empty lists are considered calls"
+     (is (thrown? Compiler$CompilerException (eval '(1 2 3))))))
 
 (deftest Macros)
 

--- a/test/clojure/test_clojure/fn.clj
+++ b/test/clojure/test_clojure/fn.clj
@@ -1,55 +1,55 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Ambrose Bonnaire-Sergeant
+;; Author: Ambrose Bonnaire-Sergeant
 
 (ns clojure.test-clojure.fn
   (:use clojure.test))
 
 (deftest fn-error-checking
   (testing "bad arglist"
-    (is (fails-with-cause? java.lang.IllegalArgumentException 
-          #"Parameter declaration a should be a vector"
-          (eval '(fn "a" a)))))
+    (is (fails-with-cause? java.lang.IllegalArgumentException
+                           #"Parameter declaration a should be a vector"
+                           (eval '(fn "a" a)))))
 
   (testing "treat first param as args"
-    (is (fails-with-cause? java.lang.IllegalArgumentException 
-          #"Parameter declaration a should be a vector"
-          (eval '(fn "a" [])))))
+    (is (fails-with-cause? java.lang.IllegalArgumentException
+                           #"Parameter declaration a should be a vector"
+                           (eval '(fn "a" [])))))
 
   (testing "looks like listy signature, but malformed declaration"
     (is (fails-with-cause? java.lang.IllegalArgumentException
-          #"Parameter declaration 1 should be a vector"
-          (eval '(fn (1))))))
+                           #"Parameter declaration 1 should be a vector"
+                           (eval '(fn (1))))))
 
   (testing "checks each signature"
     (is (fails-with-cause? java.lang.IllegalArgumentException
-          #"Parameter declaration a should be a vector"
-          (eval '(fn
-                   ([a] 1)
-                   ("a" 2))))))
+                           #"Parameter declaration a should be a vector"
+                           (eval '(fn
+                                    ([a] 1)
+                                    ("a" 2))))))
 
   (testing "correct name but invalid args"
     (is (fails-with-cause? java.lang.IllegalArgumentException
-          #"Parameter declaration a should be a vector"
-          (eval '(fn a "a")))))
+                           #"Parameter declaration a should be a vector"
+                           (eval '(fn a "a")))))
 
   (testing "first sig looks multiarity, rest of sigs should be lists"
-    (is (fails-with-cause? java.lang.IllegalArgumentException 
-          #"Invalid signature \[a b\] should be a list"
-          (eval '(fn a
-                   ([a] 1)
-                   [a b])))))
-  
+    (is (fails-with-cause? java.lang.IllegalArgumentException
+                           #"Invalid signature \[a b\] should be a list"
+                           (eval '(fn a
+                                    ([a] 1)
+                                    [a b])))))
+
   (testing "missing parameter declaration"
-    (is (fails-with-cause? java.lang.IllegalArgumentException 
-          #"Parameter declaration missing"
-          (eval '(fn a))))
-    (is (fails-with-cause? java.lang.IllegalArgumentException 
-          #"Parameter declaration missing"
-          (eval '(fn))))))
+    (is (fails-with-cause? java.lang.IllegalArgumentException
+                           #"Parameter declaration missing"
+                           (eval '(fn a))))
+    (is (fails-with-cause? java.lang.IllegalArgumentException
+                           #"Parameter declaration missing"
+                           (eval '(fn))))))

--- a/test/clojure/test_clojure/for.clj
+++ b/test/clojure/test_clojure/for.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;  Tests for the Clojure 'for' macro
 ;;
@@ -19,31 +19,31 @@
                          y (range 1000000) :while (< y x)]
                      [x y]))
          '([1 0] [2 0] [2 1] [3 0] [3 1] [3 2] [4 0] [4 1] [4 2] [4 3]
-           [5 0] [5 1] [5 2] [5 3] [5 4]
-           [6 0] [6 1] [6 2] [6 3] [6 4] [6 5]
-           [7 0] [7 1] [7 2] [7 3] [7 4] [7 5] [7 6]
-           [8 0] [8 1] [8 2] [8 3] [8 4] [8 5] [8 6] [8 7]
-           [9 0] [9 1] [9 2] [9 3] [9 4] [9 5] [9 6] [9 7] [9 8]
-           [10 0] [10 1] [10 2] [10 3] [10 4] [10 5] [10 6] [10 7] [10 8] [10 9]
-           [11 0] [11 1] [11 2] [11 3] [11 4] [11 5] [11 6] [11 7] [11 8] [11 9]
-             [11 10]
-           [12 0] [12 1] [12 2] [12 3] [12 4] [12 5] [12 6] [12 7] [12 8] [12 9]
-             [12 10] [12 11]
-           [13 0] [13 1] [13 2] [13 3] [13 4] [13 5] [13 6] [13 7] [13 8] [13 9]
-             [13 10] [13 11] [13 12]
-           [14 0] [14 1] [14 2] [14 3] [14 4] [14 5] [14 6] [14 7] [14 8]))))
+                 [5 0] [5 1] [5 2] [5 3] [5 4]
+                 [6 0] [6 1] [6 2] [6 3] [6 4] [6 5]
+                 [7 0] [7 1] [7 2] [7 3] [7 4] [7 5] [7 6]
+                 [8 0] [8 1] [8 2] [8 3] [8 4] [8 5] [8 6] [8 7]
+                 [9 0] [9 1] [9 2] [9 3] [9 4] [9 5] [9 6] [9 7] [9 8]
+                 [10 0] [10 1] [10 2] [10 3] [10 4] [10 5] [10 6] [10 7] [10 8] [10 9]
+                 [11 0] [11 1] [11 2] [11 3] [11 4] [11 5] [11 6] [11 7] [11 8] [11 9]
+                 [11 10]
+                 [12 0] [12 1] [12 2] [12 3] [12 4] [12 5] [12 6] [12 7] [12 8] [12 9]
+                 [12 10] [12 11]
+                 [13 0] [13 1] [13 2] [13 3] [13 4] [13 5] [13 6] [13 7] [13 8] [13 9]
+                 [13 10] [13 11] [13 12]
+                 [14 0] [14 1] [14 2] [14 3] [14 4] [14 5] [14 6] [14 7] [14 8]))))
 
 (defmacro deftest-both [txt & ises]
   `(do
      (deftest ~(symbol (str "For-" txt)) ~@ises)
      (deftest ~(symbol (str "Doseq-" txt))
-              ~@(map (fn [[x-is [x-= [x-for binds body] value]]]
-                       (when (and (= x-is 'is) (= x-= '=) (= x-for 'for))
-                         `(is (= (let [acc# (atom [])]
-                                   (doseq ~binds (swap! acc# conj ~body))
-                                   @acc#)
-                                 ~value))))
-                     ises))))
+       ~@(map (fn [[x-is [x-= [x-for binds body] value]]]
+                (when (and (= x-is 'is) (= x-= '=) (= x-for 'for))
+                  `(is (= (let [acc# (atom [])]
+                            (doseq ~binds (swap! acc# conj ~body))
+                            @acc#)
+                          ~value))))
+              ises))))
 
 (deftest-both When
   (is (= (for [x (range 10) :when (odd? x)] x) '(1 3 5 7 9)))
@@ -68,13 +68,13 @@
   (is (= (for [x (only 6) :while (< x 5)] x) '(0 1 2 3 4)))
   (is (= (for [x (range 4) y (only 4) :while (< y 3)] [x y])
          '([0 0] [0 1] [0 2] [1 0] [1 1] [1 2]
-           [2 0] [2 1] [2 2] [3 0] [3 1] [3 2])))
+                 [2 0] [2 1] [2 2] [3 0] [3 1] [3 2])))
   (is (= (for [x (range 4) y (range 4) :while (< x 3)] [x y])
          '([0 0] [0 1] [0 2] [0 3] [1 0] [1 1] [1 2] [1 3]
-           [2 0] [2 1] [2 2] [2 3])))
+                 [2 0] [2 1] [2 2] [2 3])))
   (is (= (for [x (only 4) :while (< x 3) y (range 4)] [x y])
          '([0 0] [0 1] [0 2] [0 3] [1 0] [1 1] [1 2] [1 3]
-           [2 0] [2 1] [2 2] [2 3])))
+                 [2 0] [2 1] [2 2] [2 3])))
   (is (= (for [x (range 4) y (range 4) :while (even? x)] [x y])
          '([0 0] [0 1] [0 2] [0 3] [2 0] [2 1] [2 2] [2 3])))
   (is (= (for [x (only 2) :while (even? x) y (range 4)] [x y])
@@ -106,7 +106,7 @@
 (deftest-both Nesting
   (is (= (for [x '(a b) y (interpose x '(1 2)) z (list x y)] [x y z])
          '([a 1 a] [a 1 1] [a a a] [a a a] [a 2 a] [a 2 2]
-           [b 1 b] [b 1 1] [b b b] [b b b] [b 2 b] [b 2 2])))
+                   [b 1 b] [b 1 1] [b b b] [b b b] [b 2 b] [b 2 2])))
   (is (= (for [x ['a nil] y [x 'b]] [x y])
          '([a a] [a b] [nil nil] [nil b]))))
 
@@ -122,7 +122,7 @@
   (is (= (for [x (range 6) :let [y (rem x 2)] :when (even? y) z [8 9]] [x z])
          '([0 8] [0 9] [2 8] [2 9] [4 8] [4 9]))))
 
-; :while must skip all subsequent chunks as well as the remainder of
-; the current chunk:
+;; :while must skip all subsequent chunks as well as the remainder of
+;; the current chunk:
 (deftest-both Chunked-While
   (is (= (for [x (range 100) :while (even? x)] x) '(0))))

--- a/test/clojure/test_clojure/genclass.clj
+++ b/test/clojure/test_clojure/genclass.clj
@@ -1,14 +1,14 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "Tests for clojure.core/gen-class"
       :author "Stuart Halloway, Daniel Solano Gómez"}
-  clojure.test-clojure.genclass
+ clojure.test-clojure.genclass
   (:use clojure.test clojure.test-helper)
   (:require clojure.test_clojure.genclass.examples)
   (:import [clojure.test_clojure.genclass.examples
@@ -19,9 +19,9 @@
             ArrayGenInterface]
 
            [java.lang.annotation ElementType
-                                 Retention
-                                 RetentionPolicy
-                                 Target]))
+            Retention
+            RetentionPolicy
+            Target]))
 
 (deftest arg-support
   (let [example (ExampleClass.)
@@ -39,37 +39,37 @@
 
 ;todo - fix this, it depends on the order of things out of a hash-map
 #_(deftest test-annotations
-  (let [annot-class ExampleAnnotationClass
-        foo-method          (.getDeclaredMethod annot-class "foo" (into-array [String]))]
-    (testing "Class annotations:"
-      (is (= 2 (count (.getDeclaredAnnotations annot-class))))
-      (testing "@Deprecated"
-        (let [deprecated (.getAnnotation annot-class Deprecated)]
-          (is deprecated)))
-      (testing "@Target([])"
-        (let [resource (.getAnnotation annot-class Target)]
-          (is (= 0 (count (.value resource)))))))
-    (testing "Method annotations:"
-      (testing "@Deprecated void foo(String):"
-        (is (= 1 (count (.getDeclaredAnnotations foo-method))))
-        (is (.getAnnotation foo-method Deprecated))))
-    (testing "Parameter annotations:"
-      (let [param-annots (.getParameterAnnotations foo-method)]
-        (is (= 1 (alength param-annots)))
-        (let [first-param-annots (aget param-annots 0)]
-          (is (= 2 (alength first-param-annots)))
-          (testing "void foo(@Retention(…) String)"
-            (let [retention (aget first-param-annots 0)]
-              (is (instance? Retention retention))
-              (= RetentionPolicy/SOURCE (.value retention))))
-          (testing "void foo(@Target(…) String)"
-            (let [target (aget first-param-annots 1)]
-              (is (instance? Target target))
-              (is (= [ElementType/TYPE ElementType/PARAMETER] (seq (.value target)))))))))))
+    (let [annot-class ExampleAnnotationClass
+          foo-method          (.getDeclaredMethod annot-class "foo" (into-array [String]))]
+      (testing "Class annotations:"
+        (is (= 2 (count (.getDeclaredAnnotations annot-class))))
+        (testing "@Deprecated"
+          (let [deprecated (.getAnnotation annot-class Deprecated)]
+            (is deprecated)))
+        (testing "@Target([])"
+          (let [resource (.getAnnotation annot-class Target)]
+            (is (= 0 (count (.value resource)))))))
+      (testing "Method annotations:"
+        (testing "@Deprecated void foo(String):"
+          (is (= 1 (count (.getDeclaredAnnotations foo-method))))
+          (is (.getAnnotation foo-method Deprecated))))
+      (testing "Parameter annotations:"
+        (let [param-annots (.getParameterAnnotations foo-method)]
+          (is (= 1 (alength param-annots)))
+          (let [first-param-annots (aget param-annots 0)]
+            (is (= 2 (alength first-param-annots)))
+            (testing "void foo(@Retention(…) String)"
+              (let [retention (aget first-param-annots 0)]
+                (is (instance? Retention retention))
+                (= RetentionPolicy/SOURCE (.value retention))))
+            (testing "void foo(@Target(…) String)"
+              (let [target (aget first-param-annots 1)]
+                (is (instance? Target target))
+                (is (= [ElementType/TYPE ElementType/PARAMETER] (seq (.value target)))))))))))
 
 (deftest genclass-option-validation
   (is (fails-with-cause? IllegalArgumentException #"Not a valid method name: has-hyphen"
-        (@#'clojure.core/validate-generate-class-options {:methods '[[fine [] void] [has-hyphen [] void]]}))))
+                         (@#'clojure.core/validate-generate-class-options {:methods '[[fine [] void] [has-hyphen [] void]]}))))
 
 (deftest protected-final-access
   (let [obj (ProtectedFinalTester.)]
@@ -98,49 +98,49 @@
         (testing "sugar primitive array hints"
           (are [name type] (= (type array-types)
                               (parameter-type (method-with-name name)))
-               "takesByteArray"    :bytes
-               "takesCharArray"    :chars
-               "takesShortArray"   :shorts
-               "takesIntArray"     :ints
-               "takesLongArray"    :longs
-               "takesFloatArray"   :floats
-               "takesDoubleArray"  :doubles
-               "takesBooleanArray" :booleans))
+            "takesByteArray"    :bytes
+            "takesCharArray"    :chars
+            "takesShortArray"   :shorts
+            "takesIntArray"     :ints
+            "takesLongArray"    :longs
+            "takesFloatArray"   :floats
+            "takesDoubleArray"  :doubles
+            "takesBooleanArray" :booleans))
         (testing "raw primitive array hints"
           (are [name type] (= (type array-types)
                               (return-type (method-with-name name)))
-               "returnsByteArray"    :bytes
-               "returnsCharArray"    :chars
-               "returnsShortArray"   :shorts
-               "returnsIntArray"     :ints
-               "returnsLongArray"    :longs
-               "returnsFloatArray"   :floats
-               "returnsDoubleArray"  :doubles
-               "returnsBooleanArray" :booleans))))
+            "returnsByteArray"    :bytes
+            "returnsCharArray"    :chars
+            "returnsShortArray"   :shorts
+            "returnsIntArray"     :ints
+            "returnsLongArray"    :longs
+            "returnsFloatArray"   :floats
+            "returnsDoubleArray"  :doubles
+            "returnsBooleanArray" :booleans))))
     (testing "gen-interface"
       (let [method-with-name #(method-with-name % (.getMethods ArrayGenInterface))]
         (testing "sugar primitive array hints"
           (are [name type] (= (type array-types)
                               (parameter-type (method-with-name name)))
-               "takesByteArray"    :bytes
-               "takesCharArray"    :chars
-               "takesShortArray"   :shorts
-               "takesIntArray"     :ints
-               "takesLongArray"    :longs
-               "takesFloatArray"   :floats
-               "takesDoubleArray"  :doubles
-               "takesBooleanArray" :booleans))
+            "takesByteArray"    :bytes
+            "takesCharArray"    :chars
+            "takesShortArray"   :shorts
+            "takesIntArray"     :ints
+            "takesLongArray"    :longs
+            "takesFloatArray"   :floats
+            "takesDoubleArray"  :doubles
+            "takesBooleanArray" :booleans))
         (testing "raw primitive array hints"
           (are [name type] (= (type array-types)
                               (return-type (method-with-name name)))
-               "returnsByteArray"    :bytes
-               "returnsCharArray"    :chars
-               "returnsShortArray"   :shorts
-               "returnsIntArray"     :ints
-               "returnsLongArray"    :longs
-               "returnsFloatArray"   :floats
-               "returnsDoubleArray"  :doubles
-               "returnsBooleanArray" :booleans))))))
+            "returnsByteArray"    :bytes
+            "returnsCharArray"    :chars
+            "returnsShortArray"   :shorts
+            "returnsIntArray"     :ints
+            "returnsLongArray"    :longs
+            "returnsFloatArray"   :floats
+            "returnsDoubleArray"  :doubles
+            "returnsBooleanArray" :booleans))))))
 
 (deftest gen-interface-source-file
   (let [classReader (clojure.asm.ClassReader. "clojure.test_clojure.genclass.examples.ArrayGenInterface")

--- a/test/clojure/test_clojure/genclass/examples.clj
+++ b/test/clojure/test_clojure/genclass/examples.clj
@@ -1,15 +1,15 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns ^{:doc "Test classes that are AOT-compile for the tests in
            clojure.test-clojure.genclass."
       :author "Stuart Halloway, Daniel Solano Gómez"}
-  clojure.test-clojure.genclass.examples)
+ clojure.test-clojure.genclass.examples)
 
 (definterface ExampleInterface
   (foo [a])
@@ -34,7 +34,7 @@
 (gen-class :name ^{Deprecated {}
                    SuppressWarnings ["Warning1"] ; discarded
                    java.lang.annotation.Target []}
-                 clojure.test_clojure.genclass.examples.ExampleAnnotationClass
+           clojure.test_clojure.genclass.examples.ExampleAnnotationClass
            :prefix "annot-"
            :methods [[^{Deprecated {}
                         Override {}} ;discarded
@@ -80,22 +80,22 @@
    [^clojure.test-clojure.genclass.examples.ArrayDefInterface a]))
 
 (gen-interface
-  :name clojure.test_clojure.genclass.examples.ArrayGenInterface
-  :methods [; sugar
-            [takesByteArray [bytes] void]
-            [takesCharArray [chars] void]
-            [takesShortArray [shorts] void]
-            [takesIntArray [ints] void]
-            [takesLongArray [longs] void]
-            [takesFloatArray [floats] void]
-            [takesDoubleArray [doubles] void]
-            [takesBooleanArray [booleans] void]
+ :name clojure.test_clojure.genclass.examples.ArrayGenInterface
+ :methods [; sugar
+           [takesByteArray [bytes] void]
+           [takesCharArray [chars] void]
+           [takesShortArray [shorts] void]
+           [takesIntArray [ints] void]
+           [takesLongArray [longs] void]
+           [takesFloatArray [floats] void]
+           [takesDoubleArray [doubles] void]
+           [takesBooleanArray [booleans] void]
             ; raw primitive types
-            [returnsByteArray [] "[B"]
-            [returnsCharArray [] "[C"]
-            [returnsShortArray [] "[S"]
-            [returnsIntArray [] "[I"]
-            [returnsLongArray [] "[J"]
-            [returnsFloatArray [] "[F"]
-            [returnsDoubleArray [] "[D"]
-            [returnsBooleanArray [] "[Z"]])
+           [returnsByteArray [] "[B"]
+           [returnsCharArray [] "[C"]
+           [returnsShortArray [] "[S"]
+           [returnsIntArray [] "[I"]
+           [returnsLongArray [] "[J"]
+           [returnsFloatArray [] "[F"]
+           [returnsDoubleArray [] "[D"]
+           [returnsBooleanArray [] "[Z"]])

--- a/test/clojure/test_clojure/java/io.clj
+++ b/test/clojure/test_clojure/java/io.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.java.io
   (:use clojure.test clojure.java.io
@@ -22,19 +22,19 @@
 
 ;; does not work on IBM JDK
 #_(deftest test-spit-and-slurp
-  (let [f (temp-file "clojure.java.io" "test")
-        content (apply str (concat "a" (repeat 500 "\u226a\ud83d\ude03")))]
-    (spit f content)
-    (is (= content (slurp f)))
+    (let [f (temp-file "clojure.java.io" "test")
+          content (apply str (concat "a" (repeat 500 "\u226a\ud83d\ude03")))]
+      (spit f content)
+      (is (= content (slurp f)))
     ;; UTF-16 must be last for the following test
-    (doseq [enc [ "UTF-8" "UTF-16BE" "UTF-16LE" "UTF-16" ]]
-      (spit f content :encoding enc)
-      (is (= content (slurp f :encoding enc))))
-    (testing "deprecated arity"
-      (is (=
-           (platform-newlines "WARNING: (slurp f enc) is deprecated, use (slurp f :encoding enc).\n")
-           (with-out-str
-             (is (= content (slurp f "UTF-16")))))))))
+      (doseq [enc ["UTF-8" "UTF-16BE" "UTF-16LE" "UTF-16"]]
+        (spit f content :encoding enc)
+        (is (= content (slurp f :encoding enc))))
+      (testing "deprecated arity"
+        (is (=
+             (platform-newlines "WARNING: (slurp f enc) is deprecated, use (slurp f :encoding enc).\n")
+             (with-out-str
+               (is (= content (slurp f "UTF-16")))))))))
 
 (deftest test-streams-defaults
   (let [f (temp-file "clojure.java.io" "test-reader-writer")
@@ -46,19 +46,19 @@
       (are [write-to read-from] (= content (do
                                              (spit write-to content :encoding "UTF-8")
                                              (slurp read-from :encoding "UTF-8")))
-           f f
-           (.getAbsolutePath f) (.getAbsolutePath f)
-           (.toURL f) (.toURL f)
-           (.toURI f) (.toURI f)
-           (FileOutputStream. f) (FileInputStream. f)
-           (OutputStreamWriter. (FileOutputStream. f) "UTF-8") (reader f :encoding "UTF-8")
-           f (FileInputStream. f)
-           (writer f :encoding "UTF-8") (InputStreamReader. (FileInputStream. f) "UTF-8"))
+        f f
+        (.getAbsolutePath f) (.getAbsolutePath f)
+        (.toURL f) (.toURL f)
+        (.toURI f) (.toURI f)
+        (FileOutputStream. f) (FileInputStream. f)
+        (OutputStreamWriter. (FileOutputStream. f) "UTF-8") (reader f :encoding "UTF-8")
+        f (FileInputStream. f)
+        (writer f :encoding "UTF-8") (InputStreamReader. (FileInputStream. f) "UTF-8"))
 
       (is (= content (slurp (.getBytes content "UTF-8"))))
       (is (= content (slurp (.toCharArray content))))
       (finally
-       (.delete f)))))
+        (.delete f)))))
 
 (deftest test-streams-nil
   (is (thrown-with-msg? IllegalArgumentException #"Cannot open.*nil" (reader nil)))
@@ -102,7 +102,7 @@
           {:in :cs :out :w}
           {:in :bs :out :o}
           {:in :bs :out :w}]
-         
+
          opts
          [{} {:buffer-size 16} {:buffer-size 256}]]
      (let [{:keys [s o] :as d} (data-fixture "UTF-8")]
@@ -114,27 +114,27 @@
                            (str "combination " test opts))))))
 ;; does not work on IBM JDK
 #_(deftest test-copy-encodings
-  (doseq [enc [ "UTF-8" "UTF-16" "UTF-16BE" "UTF-16LE" ]]
-    (testing (str "from inputstream " enc " to writer UTF-8")
-      (let [{:keys [i s o w bs]} (data-fixture enc)]
-        (copy i w :encoding enc :buffer-size 16)
-        (.flush w)
-        (bytes-should-equal (.getBytes s "UTF-8") (.toByteArray o) "")))
-    (testing (str "from reader UTF-8 to output-stream " enc)
-      (let [{:keys [r o s]} (data-fixture "UTF-8")]
-        (copy r o :encoding enc :buffer-size 16)
-        (bytes-should-equal (.getBytes s enc) (.toByteArray o) "")))))
+    (doseq [enc ["UTF-8" "UTF-16" "UTF-16BE" "UTF-16LE"]]
+      (testing (str "from inputstream " enc " to writer UTF-8")
+        (let [{:keys [i s o w bs]} (data-fixture enc)]
+          (copy i w :encoding enc :buffer-size 16)
+          (.flush w)
+          (bytes-should-equal (.getBytes s "UTF-8") (.toByteArray o) "")))
+      (testing (str "from reader UTF-8 to output-stream " enc)
+        (let [{:keys [r o s]} (data-fixture "UTF-8")]
+          (copy r o :encoding enc :buffer-size 16)
+          (bytes-should-equal (.getBytes s enc) (.toByteArray o) "")))))
 
 (deftest test-as-file
   (are [result input] (= result (as-file input))
-       (File. "foo") "foo"
-       (File. "bar") (File. "bar")
-       (File. "baz") (URL. "file:baz")
-       (File. "bar+baz") (URL. "file:bar+baz")
-       (File. "bar baz qux") (URL. "file:bar%20baz%20qux")
-       (File. "quux") (URI. "file:quux")
-       (File. "abcíd/foo.txt") (URL. "file:abc%c3%add/foo.txt")
-       nil nil))
+    (File. "foo") "foo"
+    (File. "bar") (File. "bar")
+    (File. "baz") (URL. "file:baz")
+    (File. "bar+baz") (URL. "file:bar+baz")
+    (File. "bar baz qux") (URL. "file:bar%20baz%20qux")
+    (File. "quux") (URI. "file:quux")
+    (File. "abcíd/foo.txt") (URL. "file:abc%c3%add/foo.txt")
+    nil nil))
 
 (deftest test-resources-with-spaces
   (let [file-with-spaces (temp-file "test resource 2" "txt")
@@ -147,14 +147,14 @@
 
 (deftest test-file
   (are [result args] (= (File. result) (apply file args))
-       "foo" ["foo"]
-       "foo/bar" ["foo" "bar"]
-       "foo/bar/baz" ["foo" "bar" "baz"]))
+    "foo" ["foo"]
+    "foo/bar" ["foo" "bar"]
+    "foo/bar/baz" ["foo" "bar" "baz"]))
 (deftest test-as-url
   (are [file-part input] (= (URL. (str "file:" file-part)) (as-url input))
-       "foo" "file:foo"
-       "baz" (URL. "file:baz")
-       "quux" (URI. "file:quux"))
+    "foo" "file:foo"
+    "baz" (URL. "file:baz")
+    "quux" (URI. "file:quux"))
   (is (nil? (as-url nil))))
 
 (deftest test-delete-file

--- a/test/clojure/test_clojure/java/javadoc.clj
+++ b/test/clojure/test_clojure/java/javadoc.clj
@@ -1,22 +1,22 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.java.javadoc
   (:use clojure.test
-	[clojure.java.javadoc :as j])
+        [clojure.java.javadoc :as j])
   (:import (java.io File)))
 
 (deftest javadoc-url-test
   (testing "for a core api"
     (binding [*feeling-lucky* false]
       (are [x y] (= x (#'j/javadoc-url y))
-           nil "foo.Bar"
-           (str *core-java-api* "java/lang/String.html") "java.lang.String")))
+        nil "foo.Bar"
+        (str *core-java-api* "java/lang/String.html") "java.lang.String")))
   (testing "for a remote javadoc"
     (binding [*remote-javadocs* (ref (sorted-map "java." "http://example.com/"))]
       (is (= "http://example.com/java/lang/Number.html" (#'j/javadoc-url "java.lang.Number"))))))

--- a/test/clojure/test_clojure/java/shell.clj
+++ b/test/clojure/test_clojure/java/shell.clj
@@ -1,14 +1,14 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.java.shell
   (:use clojure.test
-	[clojure.java.shell :as sh])
+        [clojure.java.shell :as sh])
   (:import (java.io File)))
 
 (def platform-enc (.name (java.nio.charset.Charset/defaultCharset)))
@@ -16,12 +16,12 @@
 
 (deftest test-parse-args
   (are [x y] (= x y)
-       [[] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args [])
-       [["ls"] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args ["ls"])
-       [["ls" "-l"] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args ["ls" "-l"])
-       [["ls"] {:in-enc default-enc :out-enc "ISO-8859-1" :dir nil :env nil}] (#'sh/parse-args ["ls" :out-enc "ISO-8859-1"])
-       [[] {:in-enc platform-enc :out-enc platform-enc :dir nil :env nil}] (#'sh/parse-args [:in-enc platform-enc :out-enc platform-enc])))
-  
+    [[] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args [])
+    [["ls"] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args ["ls"])
+    [["ls" "-l"] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args ["ls" "-l"])
+    [["ls"] {:in-enc default-enc :out-enc "ISO-8859-1" :dir nil :env nil}] (#'sh/parse-args ["ls" :out-enc "ISO-8859-1"])
+    [[] {:in-enc platform-enc :out-enc platform-enc :dir nil :env nil}] (#'sh/parse-args [:in-enc platform-enc :out-enc platform-enc])))
+
 (deftest test-with-sh-dir
   (are [x y] (= x y)
     nil *sh-dir*

--- a/test/clojure/test_clojure/java_interop.clj
+++ b/test/clojure/test_clojure/java_interop.clj
@@ -1,59 +1,59 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 
 (ns clojure.test-clojure.java-interop
   (:use clojure.test))
 
-; http://clojure.org/java_interop
-; http://clojure.org/compilation
+;; http://clojure.org/java_interop
+;; http://clojure.org/compilation
 
 
 (deftest test-dot
   ; (.instanceMember instance args*)
   (are [x] (= x "FRED")
-      (.toUpperCase "fred") 
-      (. "fred" toUpperCase)
-      (. "fred" (toUpperCase)) )
+    (.toUpperCase "fred")
+    (. "fred" toUpperCase)
+    (. "fred" (toUpperCase)))
 
   (are [x] (= x true)
-      (.startsWith "abcde" "ab")
-      (. "abcde" startsWith "ab")
-      (. "abcde" (startsWith "ab")) )
+    (.startsWith "abcde" "ab")
+    (. "abcde" startsWith "ab")
+    (. "abcde" (startsWith "ab")))
 
   ; (.instanceMember Classname args*)
   (are [x] (= x "java.lang.String")
-      (.getName String)
-      (. (identity String) getName)
-      (. (identity String) (getName)) )
+    (.getName String)
+    (. (identity String) getName)
+    (. (identity String) (getName)))
 
   ; (Classname/staticMethod args*)
   (are [x] (= x 7)
-      (Math/abs -7)
-      (. Math abs -7)
-      (. Math (abs -7)) )
+    (Math/abs -7)
+    (. Math abs -7)
+    (. Math (abs -7)))
 
   ; (. target -prop)
   (let [p (java.awt.Point. 1 2)]
     (are [x y] (= x y)
-       1 (.-x p)
-       2 (.-y p)
-       1 (. p -x)
-       2 (. p -y)
-       1 (. (java.awt.Point. 1 2) -x)
-       2 (. (java.awt.Point. 1 2) -y)))
-  
+      1 (.-x p)
+      2 (.-y p)
+      1 (. p -x)
+      2 (. p -y)
+      1 (. (java.awt.Point. 1 2) -x)
+      2 (. (java.awt.Point. 1 2) -y)))
+
   ; Classname/staticField
   (are [x] (= x 2147483647)
-      Integer/MAX_VALUE
-      (. Integer MAX_VALUE) ))
+    Integer/MAX_VALUE
+    (. Integer MAX_VALUE)))
 
 (definterface I (a []))
 (deftype T [a] I (a [_] "method"))
@@ -70,55 +70,52 @@
   (is (= (.. System (getProperties) (get "os.name"))
          (. (. System (getProperties)) (get "os.name")))))
 
-
 (deftest test-doto
   (let [m (doto (new java.util.HashMap)
             (.put "a" 1)
             (.put "b" 2))]
     (are [x y] (= x y)
-        (class m) java.util.HashMap
-        m {"a" 1 "b" 2} )))
-
+      (class m) java.util.HashMap
+      m {"a" 1 "b" 2})))
 
 (deftest test-new
   ; Integer
   (are [expr cls value] (and (= (class expr) cls)
-                            (= expr value))
-      (new java.lang.Integer 42) java.lang.Integer 42
-      (java.lang.Integer. 123) java.lang.Integer 123 )
+                             (= expr value))
+    (new java.lang.Integer 42) java.lang.Integer 42
+    (java.lang.Integer. 123) java.lang.Integer 123)
 
   ; Date
   (are [x] (= (class x) java.util.Date)
-      (new java.util.Date)
-      (java.util.Date.) ))
-
+    (new java.util.Date)
+    (java.util.Date.)))
 
 (deftest test-instance?
   ; evaluation
   (are [x y] (= x y)
-      (instance? java.lang.Integer (+ 1 2)) false
-      (instance? java.lang.Long (+ 1 2)) true )
+    (instance? java.lang.Integer (+ 1 2)) false
+    (instance? java.lang.Long (+ 1 2)) true)
 
   ; different types
   (are [type literal] (instance? literal type)
-      1   java.lang.Long
-      1.0 java.lang.Double
-      1M  java.math.BigDecimal
-      \a  java.lang.Character
-      "a" java.lang.String )
+    1   java.lang.Long
+    1.0 java.lang.Double
+    1M  java.math.BigDecimal
+    \a  java.lang.Character
+    "a" java.lang.String)
 
   ; it is a Long, nothing else
   (are [x y] (= (instance? x 42) y)
-      java.lang.Integer false
-      java.lang.Long true
-      java.lang.Character false
-      java.lang.String false )
+    java.lang.Integer false
+    java.lang.Long true
+    java.lang.Character false
+    java.lang.String false)
 
   ; test compiler macro
   (is (let [Long String] (instance? Long "abc")))
   (is (thrown? clojure.lang.ArityException (instance? Long))))
 
-; set!
+;; set!
 
 (defprotocol p (f [_]))
 (deftype t [^:unsynchronized-mutable x] p (f [_] (set! (.x _) 1)))
@@ -126,71 +123,70 @@
 (deftest test-set!
   (is (= 1 (f (t. 1)))))
 
-; memfn
+;; memfn
 
 
 (deftest test-bean
   (let [b (bean java.awt.Color/black)]
     (are [x y] (= x y)
-        (map? b) true
+      (map? b) true
 
-        (:red b) 0
-        (:green b) 0
-        (:blue b) 0
-        (:RGB b) -16777216
+      (:red b) 0
+      (:green b) 0
+      (:blue b) 0
+      (:RGB b) -16777216
 
-        (:alpha b) 255
-        (:transparency b) 1
+      (:alpha b) 255
+      (:transparency b) 1
 
-        (:missing b) nil
-        (:missing b :default) :default
-        (get b :missing) nil
-        (get b :missing :default) :default
+      (:missing b) nil
+      (:missing b :default) :default
+      (get b :missing) nil
+      (get b :missing :default) :default
 
-        (:class b) java.awt.Color )))
+      (:class b) java.awt.Color)))
 
 (deftest test-iterable-bean
   (is (.iterator ^Iterable (bean (java.util.Date.))))
   (is (hash (bean (java.util.Date.)))))
 
-; proxy, proxy-super
+;; proxy, proxy-super
 
 (deftest test-proxy-chain
   (testing "That the proxy functions can chain"
     (are [x y] (= x y)
-        (-> (get-proxy-class Object) 
-            construct-proxy
-            (init-proxy {}) 
-            (update-proxy {"toString" (fn [_] "chain chain chain")}) 
-            str)
-        "chain chain chain"
+      (-> (get-proxy-class Object)
+          construct-proxy
+          (init-proxy {})
+          (update-proxy {"toString" (fn [_] "chain chain chain")})
+          str)
+      "chain chain chain"
 
-        (-> (proxy [Object] [] (toString [] "superfuzz bigmuff")) 
-            (update-proxy {"toString" (fn [_] "chain chain chain")}) 
-            str)
-        "chain chain chain")))
-
+      (-> (proxy [Object] [] (toString [] "superfuzz bigmuff"))
+          (update-proxy {"toString" (fn [_] "chain chain chain")})
+          str)
+      "chain chain chain")))
 
 (deftest test-bases
   (are [x y] (= x y)
-      (bases java.lang.Math)
-        (list java.lang.Object)
-      (bases java.util.Collection)
-        (list java.lang.Iterable)
-      (bases java.lang.Object)
-        nil
-      (bases java.lang.Comparable)
-        nil
-      (bases java.lang.Integer)
-        (list java.lang.Number java.lang.Comparable) ))
+    (bases java.lang.Math)
+    (list java.lang.Object)
+    (bases java.util.Collection)
+    (list java.lang.Iterable)
+    (bases java.lang.Object)
+    nil
+    (bases java.lang.Comparable)
+    nil
+    (bases java.lang.Integer)
+    (list java.lang.Number java.lang.Comparable)))
 
 (deftest test-supers
   (are [x y] (= x y)
-      (supers java.lang.Math)
-        #{java.lang.Object}
-      (supers java.lang.Integer)
-        #{java.lang.Number java.lang.Object
-          java.lang.Comparable java.io.Serializable} ))
+    (supers java.lang.Math)
+    #{java.lang.Object}
+    (supers java.lang.Integer)
+    #{java.lang.Number java.lang.Object
+      java.lang.Comparable java.io.Serializable}))
 
 (deftest test-proxy-super
   (let [d (proxy [java.util.BitSet] []
@@ -211,46 +207,46 @@
   (let [p (proxy [java.io.Writer] [])]
     (is (thrown? UnsupportedOperationException (.close p)))))
 
-; Arrays: [alength] aget aset [make-array to-array into-array to-array-2d aclone]
-;   [float-array, int-array, etc]
-;   amap, areduce
+;; Arrays: [alength] aget aset [make-array to-array into-array to-array-2d aclone]
+;;    [float-array, int-array, etc]
+;;    amap, areduce
 
 (defmacro deftest-type-array [type-array type]
   `(deftest ~(symbol (str "test-" type-array))
       ; correct type
-      #_(is (= (class (first (~type-array [1 2]))) (class (~type 1))))
+     #_(is (= (class (first (~type-array [1 2]))) (class (~type 1))))
 
       ; given size (and empty)
-      (are [x] (and (= (alength (~type-array x)) x)
-                    (= (vec (~type-array x)) (repeat x 0)))
-          0 1 5 )
+     (are [x] (and (= (alength (~type-array x)) x)
+                   (= (vec (~type-array x)) (repeat x 0)))
+       0 1 5)
 
       ; copy of a sequence
-      (are [x] (and (= (alength (~type-array x)) (count x))
-                    (= (vec (~type-array x)) x))
-          []
-          [1]
-          [1 -2 3 0 5] )
+     (are [x] (and (= (alength (~type-array x)) (count x))
+                   (= (vec (~type-array x)) x))
+       []
+       [1]
+       [1 -2 3 0 5])
 
       ; given size and init-value
-      (are [x] (and (= (alength (~type-array x 42)) x)
-                    (= (vec (~type-array x 42)) (repeat x 42)))
-          0 1 5 )
+     (are [x] (and (= (alength (~type-array x 42)) x)
+                   (= (vec (~type-array x 42)) (repeat x 42)))
+       0 1 5)
 
       ; given size and init-seq
-      (are [x y z] (and (= (alength (~type-array x y)) x)
-                        (= (vec (~type-array x y)) z))
-          0 [] []
-          0 [1] []
-          0 [1 2 3] []
-          1 [] [0]
-          1 [1] [1]
-          1 [1 2 3] [1]
-          5 [] [0 0 0 0 0]
-          5 [1] [1 0 0 0 0]
-          5 [1 2 3] [1 2 3 0 0]
-          5 [1 2 3 4 5] [1 2 3 4 5]
-          5 [1 2 3 4 5 6 7] [1 2 3 4 5] )))
+     (are [x y z] (and (= (alength (~type-array x y)) x)
+                       (= (vec (~type-array x y)) z))
+       0 [] []
+       0 [1] []
+       0 [1 2 3] []
+       1 [] [0]
+       1 [1] [1]
+       1 [1 2 3] [1]
+       5 [] [0 0 0 0 0]
+       5 [1] [1 0 0 0 0]
+       5 [1 2 3] [1 2 3 0 0]
+       5 [1 2 3 4 5] [1 2 3 4 5]
+       5 [1 2 3 4 5 6 7] [1 2 3 4 5])))
 
 (deftest-type-array int-array int)
 (deftest-type-array long-array long)
@@ -258,14 +254,13 @@
 #_(deftest-type-array float-array float)
 #_(deftest-type-array double-array double)
 
-; separate test for exceptions (doesn't work with above macro...)
+;; separate test for exceptions (doesn't work with above macro...)
 (deftest test-type-array-exceptions
   (are [x] (thrown? NegativeArraySizeException x)
-       (int-array -1)
-       (long-array -1)
-       (float-array -1)
-       (double-array -1) ))
-
+    (int-array -1)
+    (long-array -1)
+    (float-array -1)
+    (double-array -1)))
 
 (deftest test-make-array
   ; negative size
@@ -273,56 +268,55 @@
 
   ; one-dimensional
   (are [x] (= (alength (make-array Integer x)) x)
-      0 1 5 )
+    0 1 5)
 
   (let [a (make-array Long 5)]
     (aset a 3 42)
     (are [x y] (= x y)
-        (aget a 3) 42
-        (class (aget a 3)) Long ))
-      
+      (aget a 3) 42
+      (class (aget a 3)) Long))
+
   ; multi-dimensional
   (let [a (make-array Long 3 2 4)]
     (aset a 0 1 2 987)
     (are [x y] (= x y)
-        (alength a) 3
-        (alength (first a)) 2
-        (alength (first (first a))) 4
+      (alength a) 3
+      (alength (first a)) 2
+      (alength (first (first a))) 4
 
-        (aget a 0 1 2) 987
-        (class (aget a 0 1 2)) Long )))
-
+      (aget a 0 1 2) 987
+      (class (aget a 0 1 2)) Long)))
 
 (deftest test-to-array
   (let [v [1 "abc" :kw \c []]
         a (to-array v)]
     (are [x y] (= x y)
         ; length
-        (alength a) (count v)
+      (alength a) (count v)
 
         ; content
-        (vec a) v
-        (class (aget a 0)) (class (nth v 0))
-        (class (aget a 1)) (class (nth v 1))
-        (class (aget a 2)) (class (nth v 2))
-        (class (aget a 3)) (class (nth v 3))
-        (class (aget a 4)) (class (nth v 4)) ))
+      (vec a) v
+      (class (aget a 0)) (class (nth v 0))
+      (class (aget a 1)) (class (nth v 1))
+      (class (aget a 2)) (class (nth v 2))
+      (class (aget a 3)) (class (nth v 3))
+      (class (aget a 4)) (class (nth v 4))))
 
   ; different kinds of collections
   (are [x] (and (= (alength (to-array x)) (count x))
                 (= (vec (to-array x)) (vec x)))
-      ()
-      '(1 2)
-      []
-      [1 2]
-      (sorted-set)
-      (sorted-set 1 2)
-      
-      (int-array 0)
-      (int-array [1 2 3])
+    ()
+    '(1 2)
+    []
+    [1 2]
+    (sorted-set)
+    (sorted-set 1 2)
 
-      (to-array [])
-      (to-array [1 2 3]) ))
+    (int-array 0)
+    (int-array [1 2 3])
+
+    (to-array [])
+    (to-array [1 2 3])))
 
 (defn queue [& contents]
   (apply conj (clojure.lang.PersistentQueue/EMPTY) contents))
@@ -338,10 +332,9 @@
            same-length# (~collection-type "1" "2" "3" "4" "5")
            longer# (~collection-type "1" "2" "3" "4" "5" "6")]
        (are [expected actual] (array-typed-equals expected actual)
-            (into-array String ["1" "2" "3" nil nil]) (.toArray shorter# string-array#)
-            (into-array String ["1" "2" "3" "4" "5"]) (.toArray same-length# string-array#)
-            (into-array String ["1" "2" "3" "4" "5" "6"]) (.toArray longer# string-array#)))))
-
+         (into-array String ["1" "2" "3" nil nil]) (.toArray shorter# string-array#)
+         (into-array String ["1" "2" "3" "4" "5"]) (.toArray same-length# string-array#)
+         (into-array String ["1" "2" "3" "4" "5" "6"]) (.toArray longer# string-array#)))))
 
 (test-to-passed-array-for vector)
 (test-to-passed-array-for list)
@@ -354,19 +347,19 @@
   (is (thrown? IllegalArgumentException (into-array [1.2 4])))
   (is (thrown? IllegalArgumentException (into-array [(byte 2) (short 3)])))
   (is (thrown? IllegalArgumentException (into-array Byte/TYPE [100000000000000])))
-  
+
   ; simple case
   (let [v [1 2 3 4 5]
         a (into-array v)]
     (are [x y] (= x y)
-        (alength a) (count v)
-        (vec a) v
-        (class (first a)) (class (first v)) ))
+      (alength a) (count v)
+      (vec a) v
+      (class (first a)) (class (first v))))
 
   (is (= \a (aget (into-array Character/TYPE [\a \b \c]) 0)))
 
   (is (= [nil 1 2] (seq (into-array [nil 1 2]))))
-  
+
   (let [types [Integer/TYPE
                Byte/TYPE
                Float/TYPE
@@ -380,25 +373,24 @@
         (is (== (aget a 1) 3))
         (is (== (aget a 2) 4))
         (is (== (aget a 3) 5)))))
-  
+
   ; different kinds of collections
   (are [x] (and (= (alength (into-array x)) (count x))
                 (= (vec (into-array x)) (vec x))
                 (= (alength (into-array Long/TYPE x)) (count x))
                 (= (vec (into-array Long/TYPE x)) (vec x)))
-      ()
-      '(1 2)
-      []
-      [1 2]
-      (sorted-set)
-      (sorted-set 1 2)
+    ()
+    '(1 2)
+    []
+    [1 2]
+    (sorted-set)
+    (sorted-set 1 2)
 
-      (int-array 0)
-      (int-array [1 2 3])
+    (int-array 0)
+    (int-array [1 2 3])
 
-      (to-array [])
-      (to-array [1 2 3]) ))
-
+    (to-array [])
+    (to-array [1 2 3])))
 
 (deftest test-to-array-2d
   ; needs to be a collection of collection(s)
@@ -408,129 +400,125 @@
   (let [v [[1] [2 3] [4 5 6]]
         a (to-array-2d v)]
     (are [x y] (= x y)
-        (alength a) (count v)
-        (alength (aget a 0)) (count (nth v 0))
-        (alength (aget a 1)) (count (nth v 1))
-        (alength (aget a 2)) (count (nth v 2))
+      (alength a) (count v)
+      (alength (aget a 0)) (count (nth v 0))
+      (alength (aget a 1)) (count (nth v 1))
+      (alength (aget a 2)) (count (nth v 2))
 
-        (vec (aget a 0)) (nth v 0)
-        (vec (aget a 1)) (nth v 1)
-        (vec (aget a 2)) (nth v 2) ))
+      (vec (aget a 0)) (nth v 0)
+      (vec (aget a 1)) (nth v 1)
+      (vec (aget a 2)) (nth v 2)))
 
   ; empty array
   (let [a (to-array-2d [])]
     (are [x y] (= x y)
-        (alength a) 0
-        (vec a) [] )))
-
+      (alength a) 0
+      (vec a) [])))
 
 (deftest test-alength
   (are [x] (= (alength x) 0)
-      (int-array 0)
-      (long-array 0)
-      (float-array 0)
-      (double-array 0)
-      (boolean-array 0)
-      (byte-array 0)
-      (char-array 0)
-      (short-array 0)
-      (make-array Integer/TYPE 0)
-      (to-array [])
-      (into-array [])
-      (to-array-2d []) )
+    (int-array 0)
+    (long-array 0)
+    (float-array 0)
+    (double-array 0)
+    (boolean-array 0)
+    (byte-array 0)
+    (char-array 0)
+    (short-array 0)
+    (make-array Integer/TYPE 0)
+    (to-array [])
+    (into-array [])
+    (to-array-2d []))
 
   (are [x] (= (alength x) 1)
-      (int-array 1)
-      (long-array 1)
-      (float-array 1)
-      (double-array 1)
-      (boolean-array 1)
-      (byte-array 1)
-      (char-array 1)
-      (short-array 1)
-      (make-array Integer/TYPE 1)
-      (to-array [1])
-      (into-array [1])
-      (to-array-2d [[1]]) )
+    (int-array 1)
+    (long-array 1)
+    (float-array 1)
+    (double-array 1)
+    (boolean-array 1)
+    (byte-array 1)
+    (char-array 1)
+    (short-array 1)
+    (make-array Integer/TYPE 1)
+    (to-array [1])
+    (into-array [1])
+    (to-array-2d [[1]]))
 
   (are [x] (= (alength x) 3)
-      (int-array 3)
-      (long-array 3)
-      (float-array 3)
-      (double-array 3)
-      (boolean-array 3)
-      (byte-array 3)
-      (char-array 3)
-      (short-array 3)
-      (make-array Integer/TYPE 3)
-      (to-array [1 "a" :k])
-      (into-array [1 2 3])
-      (to-array-2d [[1] [2 3] [4 5 6]]) ))
-
+    (int-array 3)
+    (long-array 3)
+    (float-array 3)
+    (double-array 3)
+    (boolean-array 3)
+    (byte-array 3)
+    (char-array 3)
+    (short-array 3)
+    (make-array Integer/TYPE 3)
+    (to-array [1 "a" :k])
+    (into-array [1 2 3])
+    (to-array-2d [[1] [2 3] [4 5 6]])))
 
 (deftest test-aclone
   ; clone all arrays except 2D
   (are [x] (and (= (alength (aclone x)) (alength x))
                 (= (vec (aclone x)) (vec x)))
-      (int-array 0)
-      (long-array 0)
-      (float-array 0)
-      (double-array 0)
-      (boolean-array 0)
-      (byte-array 0)
-      (char-array 0)
-      (short-array 0)
-      (make-array Integer/TYPE 0)
-      (to-array [])
-      (into-array [])
+    (int-array 0)
+    (long-array 0)
+    (float-array 0)
+    (double-array 0)
+    (boolean-array 0)
+    (byte-array 0)
+    (char-array 0)
+    (short-array 0)
+    (make-array Integer/TYPE 0)
+    (to-array [])
+    (into-array [])
 
-      (int-array [1 2 3])
-      (long-array [1 2 3])
-      (float-array [1 2 3])
-      (double-array [1 2 3])
-      (boolean-array [true false])
-      (byte-array [(byte 1) (byte 2)])
-      (byte-array [1 2])
-      (byte-array 2 [1 2])
-      (char-array [\a \b \c])
-      (short-array [(short 1) (short 2)])
-      (short-array [1 2])
-      (short-array 2 [1 2])
-      (make-array Integer/TYPE 3)
-      (to-array [1 "a" :k])
-      (into-array [1 2 3]) )
+    (int-array [1 2 3])
+    (long-array [1 2 3])
+    (float-array [1 2 3])
+    (double-array [1 2 3])
+    (boolean-array [true false])
+    (byte-array [(byte 1) (byte 2)])
+    (byte-array [1 2])
+    (byte-array 2 [1 2])
+    (char-array [\a \b \c])
+    (short-array [(short 1) (short 2)])
+    (short-array [1 2])
+    (short-array 2 [1 2])
+    (make-array Integer/TYPE 3)
+    (to-array [1 "a" :k])
+    (into-array [1 2 3]))
 
   ; clone 2D
   (are [x] (and (= (alength (aclone x)) (alength x))
                 (= (map alength (aclone x)) (map alength x))
                 (= (map vec (aclone x)) (map vec x)))
-      (to-array-2d [])
-      (to-array-2d [[1] [2 3] [4 5 6]]) ))
+    (to-array-2d [])
+    (to-array-2d [[1] [2 3] [4 5 6]])))
 
+;; Type Hints, *warn-on-reflection*
+;;    #^ints, #^floats, #^longs, #^doubles
 
-; Type Hints, *warn-on-reflection*
-;   #^ints, #^floats, #^longs, #^doubles
-
-; Coercions: [int, long, float, double, char, boolean, short, byte]
-;   num
-;   ints/longs/floats/doubles
+;; Coercions: [int, long, float, double, char, boolean, short, byte]
+;;    num
+;;    ints/longs/floats/doubles
 
 (deftest test-boolean
   (are [x y] (and (instance? java.lang.Boolean (boolean x))
                   (= (boolean x) y))
-      nil false
-      false false
-      true true
+    nil false
+    false false
+    true true
 
-      0 true
-      1 true
-      () true
-      [1] true
+    0 true
+    1 true
+    () true
+    [1] true
 
-      "" true
-      \space true
-      :kw true ))
-
+    "" true
+    \space true
+    :kw true))
 
 (deftest test-char
   ; int -> char

--- a/test/clojure/test_clojure/keywords.clj
+++ b/test/clojure/test_clojure/keywords.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.keywords
   (:use clojure.test))
@@ -15,11 +15,11 @@
     ::foo
     (let [absent-keyword-sym (gensym "absent-keyword-sym")]
       (are [result lookup] (= result (find-keyword lookup))
-           :foo :foo
-           :foo 'foo
-           :foo "foo"
-           nil absent-keyword-sym
-           nil (str absent-keyword-sym))
+        :foo :foo
+        :foo 'foo
+        :foo "foo"
+        nil absent-keyword-sym
+        nil (str absent-keyword-sym))
       (are [result lookup] (= result (find-keyword this-ns lookup))
-           ::foo "foo"
-           nil (str absent-keyword-sym)))))
+        ::foo "foo"
+        nil (str absent-keyword-sym)))))

--- a/test/clojure/test_clojure/logic.clj
+++ b/test/clojure/test_clojure/logic.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 ;;
 ;;  Created 1/29/2009
@@ -15,72 +15,70 @@
   (:use clojure.test
         [clojure.test-helper :only (exception)]))
 
-
 ;; *** Tests ***
 
 (deftest test-if
   ; true/false/nil
   (are [x y] (= x y)
-      (if true :t) :t
-      (if true :t :f) :t
-      (if true :t (exception)) :t
+    (if true :t) :t
+    (if true :t :f) :t
+    (if true :t (exception)) :t
 
-      (if false :t) nil
-      (if false :t :f) :f
-      (if false (exception) :f) :f
+    (if false :t) nil
+    (if false :t :f) :f
+    (if false (exception) :f) :f
 
-      (if nil :t) nil
-      (if nil :t :f) :f
-      (if nil (exception) :f) :f )
+    (if nil :t) nil
+    (if nil :t :f) :f
+    (if nil (exception) :f) :f)
 
   ; zero/empty is true
   (are [x] (= (if x :t :f) :t)
-      (byte 0)
-      (short 0)
-      (int 0)
-      (long 0)
-      (bigint 0)
-      (float 0)
-      (double 0)
-      (bigdec 0)
+    (byte 0)
+    (short 0)
+    (int 0)
+    (long 0)
+    (bigint 0)
+    (float 0)
+    (double 0)
+    (bigdec 0)
 
-      0/2
-      ""
-      #""
-      (symbol "")
+    0/2
+    ""
+    #""
+    (symbol "")
 
-      ()
-      []
-      {}
-      #{}
-      (into-array []) )
+    ()
+    []
+    {}
+    #{}
+    (into-array []))
 
   ; anything except nil/false is true
   (are [x]  (= (if x :t :f) :t)
-      (byte 2)
-      (short 2)
-      (int 2)
-      (long 2)
-      (bigint 2)
-      (float 2)
-      (double 2)
-      (bigdec 2)
+    (byte 2)
+    (short 2)
+    (int 2)
+    (long 2)
+    (bigint 2)
+    (float 2)
+    (double 2)
+    (bigdec 2)
 
-      2/3
-      \a
-      "abc"
-      #"a*b"
-      'abc
-      :kw
+    2/3
+    \a
+    "abc"
+    #"a*b"
+    'abc
+    :kw
 
-      '(1 2)
-      [1 2]
-      {:a 1 :b 2}
-      #{1 2}
-      (into-array [1 2])
+    '(1 2)
+    [1 2]
+    {:a 1 :b 2}
+    #{1 2}
+    (into-array [1 2])
 
-      (new java.util.Date) ))
-
+    (new java.util.Date)))
 
 (deftest test-nil-punning
   (are [x y]  (= (if x :no :yes) y)
@@ -110,103 +108,100 @@
     (reverse []) :no
 
     (sort nil) :no
-    (sort []) :no ))
-
+    (sort []) :no))
 
 (deftest test-and
   (are [x y] (= x y)
-      (and) true
-      (and true) true
-      (and nil) nil
-      (and false) false
+    (and) true
+    (and true) true
+    (and nil) nil
+    (and false) false
 
-      (and true nil) nil
-      (and true false) false
+    (and true nil) nil
+    (and true false) false
 
-      (and 1 true :kw 'abc "abc") "abc"
+    (and 1 true :kw 'abc "abc") "abc"
 
-      (and 1 true :kw nil 'abc "abc") nil
-      (and 1 true :kw nil (exception) 'abc "abc") nil
+    (and 1 true :kw nil 'abc "abc") nil
+    (and 1 true :kw nil (exception) 'abc "abc") nil
 
-      (and 1 true :kw 'abc "abc" false) false
-      (and 1 true :kw 'abc "abc" false (exception)) false ))
-
+    (and 1 true :kw 'abc "abc" false) false
+    (and 1 true :kw 'abc "abc" false (exception)) false))
 
 (deftest test-or
   (are [x y] (= x y)
-      (or) nil
-      (or true) true
-      (or nil) nil
-      (or false) false
+    (or) nil
+    (or true) true
+    (or nil) nil
+    (or false) false
 
-      (or nil false true) true
-      (or nil false 1 2) 1
-      (or nil false "abc" :kw) "abc"
+    (or nil false true) true
+    (or nil false 1 2) 1
+    (or nil false "abc" :kw) "abc"
 
-      (or false nil) nil
-      (or nil false) false
-      (or nil nil nil false) false
+    (or false nil) nil
+    (or nil false) false
+    (or nil nil nil false) false
 
-      (or nil true false) true
-      (or nil true (exception) false) true
-      (or nil false "abc" (exception)) "abc" ))
-
+    (or nil true false) true
+    (or nil true (exception) false) true
+    (or nil false "abc" (exception)) "abc"))
 
 (deftest test-not
 ;  (is (thrown? IllegalArgumentException (not)))
   (are [x] (= (not x) true)
-      nil
-      false )
+    nil
+    false)
   (are [x]  (= (not x) false)
-      true
+    true
 
       ; numbers
-      0
-      0.0
-      42
-      1.2
-      0/2
-      2/3
+    0
+    0.0
+    42
+    1.2
+    0/2
+    2/3
 
       ; characters
-      \space
-      \tab
-      \a
+    \space
+    \tab
+    \a
 
       ; strings
-      ""
-      "abc"
+    ""
+    "abc"
 
       ; regexes
-      #""
-      #"a*b"
+    #""
+    #"a*b"
 
       ; symbols
-      (symbol "")
-      'abc
+    (symbol "")
+    'abc
 
       ; keywords
-      :kw
+    :kw
 
       ; collections/arrays
-      ()
-      '(1 2)
-      []
-      [1 2]
-      {}
-      {:a 1 :b 2}
-      #{}
-      #{1 2}
-      (into-array [])
-      (into-array [1 2])
+    ()
+    '(1 2)
+    []
+    [1 2]
+    {}
+    {:a 1 :b 2}
+    #{}
+    #{1 2}
+    (into-array [])
+    (into-array [1 2])
 
       ; Java objects
-      (new java.util.Date) ))
+    (new java.util.Date)))
 
 (deftest test-some?
   (are [expected x] (= expected (some? x))
-       false nil
-       true false
-       true 0
-       true "abc"
-       true []))
+    false nil
+    true false
+    true 0
+    true "abc"
+    true []))

--- a/test/clojure/test_clojure/macros.clj
+++ b/test/clojure/test_clojure/macros.clj
@@ -1,20 +1,20 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 (ns clojure.test-clojure.macros
   (:use clojure.test))
 
-; http://clojure.org/macros
+;; http://clojure.org/macros
 
-; ->
-; defmacro definline macroexpand-1 macroexpand
+;; ->
+;; defmacro definline macroexpand-1 macroexpand
 
 
 ;; -> and ->> should not be dependent on the meaning of their arguments
@@ -50,7 +50,6 @@
       (is (= {:baz :quux} (meta (first expanded))))
       (is (= {:bar :baz} (meta (second expanded))))
       (is (= {:foo :bar} (meta (second (second expanded))))))))
-
 
 (deftest ->>metadata-test
   (testing "a trivial form"

--- a/test/clojure/test_clojure/main.clj
+++ b/test/clojure/test_clojure/main.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stuart Halloway
+;; Author: Stuart Halloway
 
 
 (ns clojure.test-clojure.main
@@ -46,7 +46,7 @@
 
 ;argh - test fragility, please fix
 #_(deftest repl-exception-safety
-  (testing "catches and prints exception on bad equals"
-    (is (re-matches #"java\.lang\.NullPointerException\r?\n"
-           (run-repl-and-return-err
-            "(proxy [Object] [] (equals [o] (.toString nil)))")))))
+    (testing "catches and prints exception on bad equals"
+      (is (re-matches #"java\.lang\.NullPointerException\r?\n"
+                      (run-repl-and-return-err
+                       "(proxy [Object] [] (equals [o] (.toString nil)))")))))

--- a/test/clojure/test_clojure/metadata.clj
+++ b/test/clojure/test_clojure/metadata.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Authors: Stuart Halloway, Frantisek Sodomka
+;; Authors: Stuart Halloway, Frantisek Sodomka
 
 (ns clojure.test-clojure.metadata
   (:use clojure.test
@@ -52,19 +52,19 @@
              #'foo)]
       (is (= 1 (-> v meta :a)))))
   #_(testing "subsequent declare doesn't overwrite metadata"
-    (let [v (eval-in-temp-ns
-             (def ^{:b 2} bar 0)
-             (declare bar)
-             #'bar)]
-      (is (= 2 (-> v meta :b))))
-    (testing "when compiled"
       (let [v (eval-in-temp-ns
-               (def ^{:c 3} bar 0)
-               (defn declare-bar []
-                 (declare bar))
-               (declare-bar)
+               (def ^{:b 2} bar 0)
+               (declare bar)
                #'bar)]
-        (is (= 3 (-> v meta :c))))))
+        (is (= 2 (-> v meta :b))))
+      (testing "when compiled"
+        (let [v (eval-in-temp-ns
+                 (def ^{:c 3} bar 0)
+                 (defn declare-bar []
+                   (declare bar))
+                 (declare-bar)
+                 #'bar)]
+          (is (= 3 (-> v meta :c))))))
   (testing "subsequent def with init-expr *does* overwrite metadata"
     (let [v (eval-in-temp-ns
              (def ^{:d 4} quux 0)
@@ -89,108 +89,108 @@
         (is (eval-in-temp-ns
              (defn foo ^long [^long x] x)
              (def x (foo (inc 10)))))))))
- 
- (deftest fns-preserve-metadata-on-maps
-   (let [xm {:a 1 :b -7}
-         x (with-meta {:foo 1 :bar 2} xm)
-         ym {:c "foo"}
-         y (with-meta {:baz 4 :guh x} ym)]
- 
-     (is (= xm (meta (:guh y))))
-     (is (= xm (meta (reduce #(assoc %1 %2 (inc %2)) x (range 1000)))))
-     (is (= xm (meta (-> x (dissoc :foo) (dissoc :bar)))))
-     (let [z (assoc-in y [:guh :la] 18)]
-       (is (= ym (meta z)))
-       (is (= xm (meta (:guh z)))))
-     (let [z (update-in y [:guh :bar] inc)]
-       (is (= ym (meta z)))
-       (is (= xm (meta (:guh z)))))
-     (is (= xm (meta (get-in y [:guh]))))
-     (is (= xm (meta (into x y))))
-     (is (= ym (meta (into y x))))
-     
-     (is (= xm (meta (merge x y))))
-     (is (= ym (meta (merge y x))))
-     (is (= xm (meta (merge-with + x y))))
-     (is (= ym (meta (merge-with + y x))))
- 
-     (is (= xm (meta (select-keys x [:bar]))))
-     (is (= xm (meta (set/rename-keys x {:foo :new-foo}))))
- 
+
+(deftest fns-preserve-metadata-on-maps
+  (let [xm {:a 1 :b -7}
+        x (with-meta {:foo 1 :bar 2} xm)
+        ym {:c "foo"}
+        y (with-meta {:baz 4 :guh x} ym)]
+
+    (is (= xm (meta (:guh y))))
+    (is (= xm (meta (reduce #(assoc %1 %2 (inc %2)) x (range 1000)))))
+    (is (= xm (meta (-> x (dissoc :foo) (dissoc :bar)))))
+    (let [z (assoc-in y [:guh :la] 18)]
+      (is (= ym (meta z)))
+      (is (= xm (meta (:guh z)))))
+    (let [z (update-in y [:guh :bar] inc)]
+      (is (= ym (meta z)))
+      (is (= xm (meta (:guh z)))))
+    (is (= xm (meta (get-in y [:guh]))))
+    (is (= xm (meta (into x y))))
+    (is (= ym (meta (into y x))))
+
+    (is (= xm (meta (merge x y))))
+    (is (= ym (meta (merge y x))))
+    (is (= xm (meta (merge-with + x y))))
+    (is (= ym (meta (merge-with + y x))))
+
+    (is (= xm (meta (select-keys x [:bar]))))
+    (is (= xm (meta (set/rename-keys x {:foo :new-foo}))))
+
      ;; replace returns a seq when given a set.  Can seqs have
      ;; metadata?
-     
+
      ;; TBD: rseq, subseq, and rsubseq returns seqs.  If it is even
      ;; possible to put metadata on a seq, does it make sense that the
      ;; seqs returned by these functions should have the same metadata
      ;; as the sorted collection on which they are called?
-     ))
- 
- (deftest fns-preserve-metadata-on-vectors
-   (let [xm {:a 1 :b -7}
-         x (with-meta [1 2 3] xm)
-         ym {:c "foo"}
-         y (with-meta [4 x 6] ym)]
- 
-     (is (= xm (meta (y 1))))
-     (is (= xm (meta (assoc x 1 "one"))))
-     (is (= xm (meta (reduce #(conj %1 %2) x (range 1000)))))
-     (is (= xm (meta (pop (pop (pop x))))))
-     (let [z (assoc-in y [1 2] 18)]
-       (is (= ym (meta z)))
-       (is (= xm (meta (z 1)))))
-     (let [z (update-in y [1 2] inc)]
-       (is (= ym (meta z)))
-       (is (= xm (meta (z 1)))))
-     (is (= xm (meta (get-in y [1]))))
-     (is (= xm (meta (into x y))))
-     (is (= ym (meta (into y x))))
- 
-     (is (= xm (meta (replace {2 "two"} x))))
-     (is (= [1 "two" 3] (replace {2 "two"} x)))
- 
+))
+
+(deftest fns-preserve-metadata-on-vectors
+  (let [xm {:a 1 :b -7}
+        x (with-meta [1 2 3] xm)
+        ym {:c "foo"}
+        y (with-meta [4 x 6] ym)]
+
+    (is (= xm (meta (y 1))))
+    (is (= xm (meta (assoc x 1 "one"))))
+    (is (= xm (meta (reduce #(conj %1 %2) x (range 1000)))))
+    (is (= xm (meta (pop (pop (pop x))))))
+    (let [z (assoc-in y [1 2] 18)]
+      (is (= ym (meta z)))
+      (is (= xm (meta (z 1)))))
+    (let [z (update-in y [1 2] inc)]
+      (is (= ym (meta z)))
+      (is (= xm (meta (z 1)))))
+    (is (= xm (meta (get-in y [1]))))
+    (is (= xm (meta (into x y))))
+    (is (= ym (meta (into y x))))
+
+    (is (= xm (meta (replace {2 "two"} x))))
+    (is (= [1 "two" 3] (replace {2 "two"} x)))
+
      ;; TBD: Currently subvec drops metadata.  Should it preserve it?
      ;;(is (= xm (meta (subvec x 2 3))))
- 
+
      ;; TBD: rseq returns a seq.  If it is even possible to put
      ;; metadata on a seq, does it make sense that the seqs returned by
      ;; these functions should have the same metadata as the sorted
      ;; collection on which they are called?
-     ))
- 
- (deftest fns-preserve-metadata-on-sets
+))
+
+(deftest fns-preserve-metadata-on-sets
    ;; TBD: Do tests independently for set, hash-set, and sorted-set,
    ;; perhaps with a loop here.
-   (let [xm {:a 1 :b -7}
-         x (with-meta #{1 2 3} xm)
-         ym {:c "foo"}
-         y (with-meta #{4 x 6} ym)]
- 
-     (is (= xm (meta (y #{3 2 1}))))
-     (is (= xm (meta (reduce #(conj %1 %2) x (range 1000)))))
-     (is (= xm (meta (-> x (disj 1) (disj 2) (disj 3)))))
-     (is (= xm (meta (into x y))))
-     (is (= ym (meta (into y x))))
- 
-     (is (= xm (meta (set/select even? x))))
-     (let [cow1m {:what "betsy cow"}
-           cow1 (with-meta {:name "betsy" :id 33} cow1m)
-           cow2m {:what "panda cow"}
-           cow2 (with-meta {:name "panda" :id 34} cow2m)
-           cowsm {:what "all the cows"}
-           cows (with-meta #{cow1 cow2} cowsm)
-           cow-names (set/project cows [:name])
-           renamed (set/rename cows {:id :number})]
-       (is (= cowsm (meta cow-names)))
-       (is (= cow1m (meta (first (filter #(= "betsy" (:name %)) cow-names)))))
-       (is (= cow2m (meta (first (filter #(= "panda" (:name %)) cow-names)))))
-       (is (= cowsm (meta renamed)))
-       (is (= cow1m (meta (first (filter #(= "betsy" (:name %)) renamed)))))
-       (is (= cow2m (meta (first (filter #(= "panda" (:name %)) renamed))))))
- 
+  (let [xm {:a 1 :b -7}
+        x (with-meta #{1 2 3} xm)
+        ym {:c "foo"}
+        y (with-meta #{4 x 6} ym)]
+
+    (is (= xm (meta (y #{3 2 1}))))
+    (is (= xm (meta (reduce #(conj %1 %2) x (range 1000)))))
+    (is (= xm (meta (-> x (disj 1) (disj 2) (disj 3)))))
+    (is (= xm (meta (into x y))))
+    (is (= ym (meta (into y x))))
+
+    (is (= xm (meta (set/select even? x))))
+    (let [cow1m {:what "betsy cow"}
+          cow1 (with-meta {:name "betsy" :id 33} cow1m)
+          cow2m {:what "panda cow"}
+          cow2 (with-meta {:name "panda" :id 34} cow2m)
+          cowsm {:what "all the cows"}
+          cows (with-meta #{cow1 cow2} cowsm)
+          cow-names (set/project cows [:name])
+          renamed (set/rename cows {:id :number})]
+      (is (= cowsm (meta cow-names)))
+      (is (= cow1m (meta (first (filter #(= "betsy" (:name %)) cow-names)))))
+      (is (= cow2m (meta (first (filter #(= "panda" (:name %)) cow-names)))))
+      (is (= cowsm (meta renamed)))
+      (is (= cow1m (meta (first (filter #(= "betsy" (:name %)) renamed)))))
+      (is (= cow2m (meta (first (filter #(= "panda" (:name %)) renamed))))))
+
      ;; replace returns a seq when given a set.  Can seqs have
      ;; metadata?
- 
+
      ;; union: Currently returns the metadata of the largest input set.
      ;; This is an artifact of union's current implementation.  I doubt
      ;; any explicit design decision was made to do so.  Like join,
@@ -198,17 +198,17 @@
      ;; one input set over another, if at least two input sets are
      ;; given, but perhaps defining it to always return a set with the
      ;; metadata of the first input set would be reasonable?
- 
+
      ;; intersection: Returns metadata of the smallest input set.
      ;; Otherwise similar to union.
- 
+
      ;; difference: Seems to always return a set with metadata of first
      ;; input set.  Seems reasonable.  Not sure we want to add a test
      ;; for it, if it is an accident of the current implementation.
- 
+
      ;; join, index, map-invert: Currently always returns a value with
      ;; no metadata.  This seems reasonable.
-     ))
+))
 
 (deftest defn-primitive-args
   (testing "Hinting the arg vector of a primitive-taking fn with a non-primitive type should not result in AbstractMethodError when invoked."

--- a/test/clojure/test_clojure/multimethods.clj
+++ b/test/clojure/test_clojure/multimethods.clj
@@ -1,25 +1,25 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka, Robert Lachlan
+;; Author: Frantisek Sodomka, Robert Lachlan
 
 (ns clojure.test-clojure.multimethods
   (:use clojure.test [clojure.test-helper :only (with-var-roots)])
   (:require [clojure.set :as set]))
 
-; http://clojure.org/multimethods
+;; http://clojure.org/multimethods
 
-; defmulti
-; defmethod
-; remove-method
-; prefer-method
-; methods
-; prefers
+;; defmulti
+;; defmethod
+;; remove-method
+;; prefer-method
+;; methods
+;; prefers
 
 (defmacro for-all
   [& args]
@@ -55,37 +55,37 @@
   (let [tags (hierarchy-tags h)]
     (testing "ancestors are the transitive closure of parents"
       (for-all [tag tags]
-        (is (= (transitive-closure tag #(parents h %))
-               (or (ancestors h tag) #{})))))
+               (is (= (transitive-closure tag #(parents h %))
+                      (or (ancestors h tag) #{})))))
     (testing "ancestors are transitive"
       (for-all [tag tags]
-        (is (= (transitive-closure tag #(ancestors h %))
-               (or (ancestors h tag) #{})))))
+               (is (= (transitive-closure tag #(ancestors h %))
+                      (or (ancestors h tag) #{})))))
     (testing "tag descendants are transitive"
       (for-all [tag tags]
-        (is (= (transitive-closure tag #(tag-descendants h %))
-               (or (tag-descendants h tag) #{})))))
+               (is (= (transitive-closure tag #(tag-descendants h %))
+                      (or (tag-descendants h tag) #{})))))
     (testing "a tag isa? all of its parents"
       (for-all [tag tags
-               :let [parents (parents h tag)]
-               parent parents]
-        (is (isa? h tag parent))))
+                :let [parents (parents h tag)]
+                parent parents]
+               (is (isa? h tag parent))))
     (testing "a tag isa? all of its ancestors"
       (for-all [tag tags
-               :let [ancestors (ancestors h tag)]
-               ancestor ancestors]
-        (is (isa? h tag ancestor))))
+                :let [ancestors (ancestors h tag)]
+                ancestor ancestors]
+               (is (isa? h tag ancestor))))
     (testing "all my descendants have me as an ancestor"
       (for-all [tag tags
-               :let [descendants (descendants h tag)]
+                :let [descendants (descendants h tag)]
                 descendant descendants]
-        (is (isa? h descendant tag))))
+               (is (isa? h descendant tag))))
     (testing "there are no cycles in parents"
       (for-all [tag tags]
-        (is (not (contains? (transitive-closure tag #(parents h %)) tag)))))
+               (is (not (contains? (transitive-closure tag #(parents h %)) tag)))))
     (testing "there are no cycles in descendants"
       (for-all [tag tags]
-        (is (not (contains? (descendants h tag) tag)))))))
+               (is (not (contains? (descendants h tag) tag)))))))
 
 (def family
   (reduce #(apply derive (cons %1 %2)) (make-hierarchy)
@@ -98,10 +98,10 @@
 (deftest cycles-are-forbidden
   (testing "a tag cannot be its own parent"
     (is (thrown-with-msg? Throwable #"\(not= tag parent\)"
-          (derive family ::child ::child))))
+                          (derive family ::child ::child))))
   (testing "a tag cannot be its own ancestor"
     (is (thrown-with-msg? Throwable #"Cyclic derivation: :clojure.test-clojure.multimethods/child has :clojure.test-clojure.multimethods/ancestor-1 as ancestor"
-          (derive family ::ancestor-1 ::child)))))
+                          (derive family ::ancestor-1 ::child)))))
 
 (deftest using-diamond-inheritance
   (let [diamond (reduce #(apply derive (cons %1 %2)) (make-hierarchy)
@@ -152,11 +152,11 @@
       (is (nil? (ancestors ::manx))))))
 
 #_(defmacro for-all
-  "Better than the actual for-all, if only it worked."
-  [& args]
-  `(reduce
-    #(and %1 %2)
-    (map true? (for ~@args))))
+    "Better than the actual for-all, if only it worked."
+    [& args]
+    `(reduce
+      #(and %1 %2)
+      (map true? (for ~@args))))
 
 (deftest basic-multimethod-test
   (testing "Check basic dispatch"
@@ -187,7 +187,7 @@
     (is (= :a-string (foo "bar")))))
 
 (deftest preferences-multimethod-test
- (testing "Multiple method match dispatch error is caught"
+  (testing "Multiple method match dispatch error is caught"
     ;; Example from the multimethod docs.
     (derive ::rect ::shape)
     (defmulti bar (fn [x y] [x y]))
@@ -195,13 +195,13 @@
     (defmethod bar [::shape ::rect] [x y] :shape-rect)
     (is (thrown? java.lang.IllegalArgumentException
                  (bar ::rect ::rect))))
- (testing "The prefers method returns empty table w/ no prefs"
-   (is (= {} (prefers bar))))
- (testing "Adding a preference to resolve it dispatches correctly"
-   (prefer-method bar [::rect ::shape] [::shape ::rect])
-   (is (= :rect-shape (bar ::rect ::rect))))
- (testing "The prefers method now returns the correct table"
-   (is (= {[::rect ::shape] #{[::shape ::rect]}} (prefers bar)))))
+  (testing "The prefers method returns empty table w/ no prefs"
+    (is (= {} (prefers bar))))
+  (testing "Adding a preference to resolve it dispatches correctly"
+    (prefer-method bar [::rect ::shape] [::shape ::rect])
+    (is (= :rect-shape (bar ::rect ::rect))))
+  (testing "The prefers method now returns the correct table"
+    (is (= {[::rect ::shape] #{[::shape ::rect]}} (prefers bar)))))
 
 (deftest remove-all-methods-test
   (testing "Core function remove-all-methods works"

--- a/test/clojure/test_clojure/ns_libs.clj
+++ b/test/clojure/test_clojure/ns_libs.clj
@@ -1,30 +1,30 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Authors: Frantisek Sodomka, Stuart Halloway
+;; Authors: Frantisek Sodomka, Stuart Halloway
 
 (ns clojure.test-clojure.ns-libs
   (:use clojure.test))
 
-; http://clojure.org/namespaces
+;; http://clojure.org/namespaces
 
-; in-ns ns create-ns
-; alias import intern refer
-; all-ns find-ns
-; ns-name ns-aliases ns-imports ns-interns ns-map ns-publics ns-refers
-; resolve ns-resolve namespace
-; ns-unalias ns-unmap remove-ns
+;; in-ns ns create-ns
+;; alias import intern refer
+;; all-ns find-ns
+;; ns-name ns-aliases ns-imports ns-interns ns-map ns-publics ns-refers
+;; resolve ns-resolve namespace
+;; ns-unalias ns-unmap remove-ns
 
 
-; http://clojure.org/libs
+;; http://clojure.org/libs
 
-; require use
-; loaded-libs
+;; require use
+;; loaded-libs
 
 (deftest test-alias
   (is (thrown-with-msg? Exception #"No namespace: epicfail found" (alias 'bogus 'epicfail)))
@@ -56,12 +56,12 @@
         (re-find #"referring deprecated var:" err))))
 
 (deftest test-require
-         (is (thrown? Exception (require :foo)))
-         (is (thrown? Exception (require))))
+  (is (thrown? Exception (require :foo)))
+  (is (thrown? Exception (require))))
 
 (deftest test-use
-         (is (thrown? Exception (use :foo)))
-         (is (thrown? Exception (use))))
+  (is (thrown? Exception (use :foo)))
+  (is (thrown? Exception (use))))
 
 (deftest reimporting-deftypes
   (let [inst1 (binding [*ns* *ns*]
@@ -81,14 +81,14 @@
       (is (= [:a :b] (keys inst2))))
     ;fragile tests, please fix
     #_(testing "you cannot import same local name from a different namespace"
-      (is (thrown? clojure.lang.Compiler$CompilerException
-                  #"ReimportMe already refers to: class exporter.ReimportMe in namespace: importer"
-                  (binding [*ns* *ns*]
-                    (eval '(do (ns exporter-2)
-                               (defrecord ReimportMe [a b])
-                               (ns importer)
-                               (import exporter-2.ReimportMe)
-                               (ReimportMe. 1 2)))))))))
+        (is (thrown? clojure.lang.Compiler$CompilerException
+                     #"ReimportMe already refers to: class exporter.ReimportMe in namespace: importer"
+                     (binding [*ns* *ns*]
+                       (eval '(do (ns exporter-2)
+                                  (defrecord ReimportMe [a b])
+                                  (ns importer)
+                                  (import exporter-2.ReimportMe)
+                                  (ReimportMe. 1 2)))))))))
 
 (deftest naming-types
   (testing "you cannot use a name already referred from another namespace"
@@ -105,11 +105,11 @@
 (deftest resolution
   (let [s (gensym)]
     (are [result expr] (= result expr)
-         #'clojure.core/first (ns-resolve 'clojure.core 'first)
-         nil (ns-resolve 'clojure.core s)
-         nil (ns-resolve 'clojure.core {'first :local-first} 'first)
-         nil (ns-resolve 'clojure.core {'first :local-first} s))))
-  
+      #'clojure.core/first (ns-resolve 'clojure.core 'first)
+      nil (ns-resolve 'clojure.core s)
+      nil (ns-resolve 'clojure.core {'first :local-first} 'first)
+      nil (ns-resolve 'clojure.core {'first :local-first} s))))
+
 (deftest refer-error-messages
   (let [temp-ns (gensym)]
     (binding [*ns* *ns*]
@@ -117,10 +117,10 @@
       (eval '(def ^{:private true} hidden-var)))
     (testing "referring to something that does not exist"
       (is (thrown-with-msg? IllegalAccessError #"nonexistent-var does not exist"
-            (refer temp-ns :only '(nonexistent-var)))))
+                            (refer temp-ns :only '(nonexistent-var)))))
     (testing "referring to something non-public"
       (is (thrown-with-msg? IllegalAccessError #"hidden-var is not public"
-            (refer temp-ns :only '(hidden-var)))))))
+                            (refer temp-ns :only '(hidden-var)))))))
 
 (deftest test-defrecord-deftype-err-msg
   (is (thrown-with-msg? clojure.lang.Compiler$CompilerException

--- a/test/clojure/test_clojure/numbers.clj
+++ b/test/clojure/test_clojure/numbers.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stephen C. Gilardi
+;; Author: Stephen C. Gilardi
 ;;  scgilardi (gmail)
 ;;  Created 30 October 2008
 ;;
@@ -18,10 +18,9 @@
   (:require [clojure.data.generators :as gen]
             [clojure.test-helper :as helper]))
 
-
-; TODO:
-; ==
-; and more...
+;; TODO:
+;; ==
+;; and more...
 
 
 ;; *** Types ***
@@ -30,21 +29,21 @@
 (deftest Coerced-BigDecimal
   (doseq [v [(bigdec 3) (bigdec (inc (bigint Long/MAX_VALUE)))]]
     (are [x] (true? x)
-     (instance? BigDecimal v)
-     (number? v)
-     (decimal? v)
-     (not (float? v)))))
+      (instance? BigDecimal v)
+      (number? v)
+      (decimal? v)
+      (not (float? v)))))
 
 (deftest BigInteger-conversions
   (doseq [coerce-fn [bigint biginteger]]
-    (doseq [v (map coerce-fn [ Long/MAX_VALUE
+    (doseq [v (map coerce-fn [Long/MAX_VALUE
                               13178456923875639284562345789M
                               13178456923875639284562345789N
                               Float/MAX_VALUE
                               (- Float/MAX_VALUE)
                               Double/MAX_VALUE
                               (- Double/MAX_VALUE)
-                              (* 2 (bigdec Double/MAX_VALUE)) ])]
+                              (* 2 (bigdec Double/MAX_VALUE))])]
       (are [x] (true? x)
         (integer? v)
         (number? v)
@@ -99,55 +98,55 @@
 
 (deftest unchecked-cast-num-obj
   (do-template [prim-array cast]
-    (are [n]
-      (let [a (prim-array 1)]
-        (aset a 0 (cast n)))
-      (Byte. Byte/MAX_VALUE)
-      (Short. Short/MAX_VALUE)
-      (Integer. Integer/MAX_VALUE)
-      (Long. Long/MAX_VALUE)
-      (Float. Float/MAX_VALUE)
-      (Double. Double/MAX_VALUE))
-    byte-array
-    unchecked-byte
-    short-array
-    unchecked-short
-    char-array
-    unchecked-char
-    int-array
-    unchecked-int
-    long-array
-    unchecked-long
-    float-array
-    unchecked-float
-    double-array
-    unchecked-double))
+               (are [n]
+                    (let [a (prim-array 1)]
+                      (aset a 0 (cast n)))
+                 (Byte. Byte/MAX_VALUE)
+                 (Short. Short/MAX_VALUE)
+                 (Integer. Integer/MAX_VALUE)
+                 (Long. Long/MAX_VALUE)
+                 (Float. Float/MAX_VALUE)
+                 (Double. Double/MAX_VALUE))
+               byte-array
+               unchecked-byte
+               short-array
+               unchecked-short
+               char-array
+               unchecked-char
+               int-array
+               unchecked-int
+               long-array
+               unchecked-long
+               float-array
+               unchecked-float
+               double-array
+               unchecked-double))
 
 (deftest unchecked-cast-num-prim
   (do-template [prim-array cast]
-    (are [n]
-      (let [a (prim-array 1)]
-        (aset a 0 (cast n)))
-      Byte/MAX_VALUE
-      Short/MAX_VALUE
-      Integer/MAX_VALUE
-      Long/MAX_VALUE
-      Float/MAX_VALUE
-      Double/MAX_VALUE)
-    byte-array
-    unchecked-byte
-    short-array
-    unchecked-short
-    char-array
-    unchecked-char
-    int-array
-    unchecked-int
-    long-array
-    unchecked-long
-    float-array
-    unchecked-float
-    double-array
-    unchecked-double))
+               (are [n]
+                    (let [a (prim-array 1)]
+                      (aset a 0 (cast n)))
+                 Byte/MAX_VALUE
+                 Short/MAX_VALUE
+                 Integer/MAX_VALUE
+                 Long/MAX_VALUE
+                 Float/MAX_VALUE
+                 Double/MAX_VALUE)
+               byte-array
+               unchecked-byte
+               short-array
+               unchecked-short
+               char-array
+               unchecked-char
+               int-array
+               unchecked-int
+               long-array
+               unchecked-long
+               float-array
+               unchecked-float
+               double-array
+               unchecked-double))
 
 (deftest unchecked-cast-char
   ; in keeping with the checked cast functions, char and Character can only be cast to int
@@ -155,14 +154,13 @@
   (is (let [c (char 0xFFFF)] (unchecked-int c)))) ; force primitive char
 
 (def expected-casts
-  [
-   [:input           [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  Integer/MAX_VALUE  Long/MAX_VALUE         Float/MAX_VALUE    Double/MAX_VALUE]]
+  [[:input           [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  Integer/MAX_VALUE  Long/MAX_VALUE         Float/MAX_VALUE    Double/MAX_VALUE]]
    [char             [:error        (char 0)    (char 1)    (char 127)      (char 32767)     :error             :error                 :error             :error]]
    [unchecked-char   [(char 65535)  (char 0)    (char 1)    (char 127)      (char 32767)     (char 65535)       (char 65535)           (char 65535)       (char 65535)]]
    [byte             [-1            0           1           Byte/MAX_VALUE  :error           :error             :error                 :error             :error]]
    [unchecked-byte   [-1            0           1           Byte/MAX_VALUE  -1               -1                 -1                     -1                 -1]]
    [short            [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  :error             :error                 :error             :error]]
-   [unchecked-short  [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  -1                 -1                     -1                 -1]] 
+   [unchecked-short  [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  -1                 -1                     -1                 -1]]
    [int              [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  Integer/MAX_VALUE  :error                 :error             :error]]
    [unchecked-int    [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  Integer/MAX_VALUE  -1                     Integer/MAX_VALUE  Integer/MAX_VALUE]]
    [long             [-1            0           1           Byte/MAX_VALUE  Short/MAX_VALUE  Integer/MAX_VALUE  Long/MAX_VALUE         :error             :error]]
@@ -178,8 +176,8 @@
     (doseq [[f vals] expectations]
       (let [wrapped (fn [x]
                       (try
-                       (f x)
-                       (catch IllegalArgumentException e :error)))]
+                        (f x)
+                        (catch IllegalArgumentException e :error)))]
         (is (= vals (map wrapped inputs)))))))
 
 ;; *** Functions ***
@@ -188,87 +186,87 @@
 
 (deftest test-add
   (are [x y] (= x y)
-      (+) 0
-      (+ 1) 1
-      (+ 1 2) 3
-      (+ 1 2 3) 6
+    (+) 0
+    (+ 1) 1
+    (+ 1 2) 3
+    (+ 1 2 3) 6
 
-      (+ -1) -1
-      (+ -1 -2) -3
-      (+ -1 +2 -3) -2
+    (+ -1) -1
+    (+ -1 -2) -3
+    (+ -1 +2 -3) -2
 
-      (+ 1 -1) 0
-      (+ -1 1) 0
+    (+ 1 -1) 0
+    (+ -1 1) 0
 
-      (+ 2/3) 2/3
-      (+ 2/3 1) 5/3
-      (+ 2/3 1/3) 1 )
+    (+ 2/3) 2/3
+    (+ 2/3 1) 5/3
+    (+ 2/3 1/3) 1)
 
   (are [x y] (< (- x y) DELTA)
-      (+ 1.2) 1.2
-      (+ 1.1 2.4) 3.5
-      (+ 1.1 2.2 3.3) 6.6 )
+    (+ 1.2) 1.2
+    (+ 1.1 2.4) 3.5
+    (+ 1.1 2.2 3.3) 6.6)
 
   (is (> (+ Integer/MAX_VALUE 10) Integer/MAX_VALUE))  ; no overflow
-  (is (thrown? ClassCastException (+ "ab" "cd"))) )    ; no string concatenation
+  (is (thrown? ClassCastException (+ "ab" "cd"))))    ; no string concatenation
 
 
 (deftest test-subtract
   (is (thrown? IllegalArgumentException (-)))
   (are [x y] (= x y)
-      (- 1) -1
-      (- 1 2) -1
-      (- 1 2 3) -4
+    (- 1) -1
+    (- 1 2) -1
+    (- 1 2 3) -4
 
-      (- -2) 2
-      (- 1 -2) 3
-      (- 1 -2 -3) 6
+    (- -2) 2
+    (- 1 -2) 3
+    (- 1 -2 -3) 6
 
-      (- 1 1) 0
-      (- -1 -1) 0
+    (- 1 1) 0
+    (- -1 -1) 0
 
-      (- 2/3) -2/3
-      (- 2/3 1) -1/3
-      (- 2/3 1/3) 1/3 )
+    (- 2/3) -2/3
+    (- 2/3 1) -1/3
+    (- 2/3 1/3) 1/3)
 
   (are [x y] (< (- x y) DELTA)
-      (- 1.2) -1.2
-      (- 2.2 1.1) 1.1
-      (- 6.6 2.2 1.1) 3.3 )
+    (- 1.2) -1.2
+    (- 2.2 1.1) 1.1
+    (- 6.6 2.2 1.1) 3.3)
 
-  (is (< (- Integer/MIN_VALUE 10) Integer/MIN_VALUE)) )  ; no underflow
+  (is (< (- Integer/MIN_VALUE 10) Integer/MIN_VALUE)))  ; no underflow
 
 
 (deftest test-multiply
   (are [x y] (= x y)
-      (*) 1
-      (* 2) 2
-      (* 2 3) 6
-      (* 2 3 4) 24
+    (*) 1
+    (* 2) 2
+    (* 2 3) 6
+    (* 2 3 4) 24
 
-      (* -2) -2
-      (* 2 -3) -6
-      (* 2 -3 -1) 6
+    (* -2) -2
+    (* 2 -3) -6
+    (* 2 -3 -1) 6
 
-      (* 1/2) 1/2
-      (* 1/2 1/3) 1/6
-      (* 1/2 1/3 -1/4) -1/24 )
+    (* 1/2) 1/2
+    (* 1/2 1/3) 1/6
+    (* 1/2 1/3 -1/4) -1/24)
 
   (are [x y] (< (- x y) DELTA)
-      (* 1.2) 1.2
-      (* 2.0 1.2) 2.4
-      (* 3.5 2.0 1.2) 8.4 )
+    (* 1.2) 1.2
+    (* 2.0 1.2) 2.4
+    (* 3.5 2.0 1.2) 8.4)
 
-  (is (> (* 3 (int (/ Integer/MAX_VALUE 2.0))) Integer/MAX_VALUE)) )  ; no overflow
+  (is (> (* 3 (int (/ Integer/MAX_VALUE 2.0))) Integer/MAX_VALUE)))  ; no overflow
 
 (deftest test-multiply-longs-at-edge
   (are [x] (= x 9223372036854775808N)
-       (*' -1 Long/MIN_VALUE)
-       (*' Long/MIN_VALUE -1)
-       (* -1N Long/MIN_VALUE)
-       (* Long/MIN_VALUE -1N)
-       (* -1 (bigint Long/MIN_VALUE))
-       (* (bigint Long/MIN_VALUE) -1))
+    (*' -1 Long/MIN_VALUE)
+    (*' Long/MIN_VALUE -1)
+    (* -1N Long/MIN_VALUE)
+    (* Long/MIN_VALUE -1N)
+    (* -1 (bigint Long/MIN_VALUE))
+    (* (bigint Long/MIN_VALUE) -1))
   (is (thrown? ArithmeticException (* Long/MIN_VALUE -1)))
   (is (thrown? ArithmeticException (* -1 Long/MIN_VALUE))))
 
@@ -279,35 +277,35 @@
 
 (deftest test-divide
   (are [x y] (= x y)
-      (/ 1) 1
-      (/ 2) 1/2
-      (/ 3 2) 3/2
-      (/ 4 2) 2
-      (/ 24 3 2) 4
-      (/ 24 3 2 -1) -4
+    (/ 1) 1
+    (/ 2) 1/2
+    (/ 3 2) 3/2
+    (/ 4 2) 2
+    (/ 24 3 2) 4
+    (/ 24 3 2 -1) -4
 
-      (/ -1) -1
-      (/ -2) -1/2
-      (/ -3 -2) 3/2
-      (/ -4 -2) 2
-      (/ -4 2) -2 )
+    (/ -1) -1
+    (/ -2) -1/2
+    (/ -3 -2) 3/2
+    (/ -4 -2) 2
+    (/ -4 2) -2)
 
   (are [x y] (< (- x y) DELTA)
-      (/ 4.5 3) 1.5
-      (/ 4.5 3.0 3.0) 0.5 )
+    (/ 4.5 3) 1.5
+    (/ 4.5 3.0 3.0) 0.5)
 
   (is (thrown? ArithmeticException (/ 0)))
   (is (thrown? ArithmeticException (/ 2 0)))
-  (is (thrown? IllegalArgumentException (/))) )
+  (is (thrown? IllegalArgumentException (/))))
 
 (deftest test-divide-bigint-at-edge
   (are [x] (= x (-' Long/MIN_VALUE))
-       (/ Long/MIN_VALUE -1N)
-       (/ (bigint Long/MIN_VALUE) -1)
-       (/ (bigint Long/MIN_VALUE) -1N)
-       (quot Long/MIN_VALUE -1N)
-       (quot (bigint Long/MIN_VALUE) -1)
-       (quot (bigint Long/MIN_VALUE) -1N)))
+    (/ Long/MIN_VALUE -1N)
+    (/ (bigint Long/MIN_VALUE) -1)
+    (/ (bigint Long/MIN_VALUE) -1N)
+    (quot Long/MIN_VALUE -1N)
+    (quot (bigint Long/MIN_VALUE) -1)
+    (quot (bigint Long/MIN_VALUE) -1N)))
 
 ;; mod
 ;; http://en.wikipedia.org/wiki/Modulo_operation
@@ -365,11 +363,7 @@
     (mod 0 -3) 0
 
     ; large args
-    (mod 3216478362187432 432143214) 120355456
-  )
-)
-
-;; rem & quot
+    (mod 3216478362187432 432143214) 120355456));; rem & quot
 ;; http://en.wikipedia.org/wiki/Remainder
 
 (deftest test-rem
@@ -381,7 +375,7 @@
   ; divide by zero
   (is (thrown? ArithmeticException (rem 9 0)))
   (is (thrown? ArithmeticException (rem 0 0)))
-  
+
   (are [x y] (= x y)
     (rem 4 2) 0
     (rem 3 2) 1
@@ -412,62 +406,53 @@
     (rem 2 -5) 2
     (rem -2 5) -2
     (rem -2 -5) -2
-    
+
     ; num = 0, div != 0
     (rem 0 3) 0
-    (rem 0 -3) 0
-  )
-)
-
-(deftest test-quot
+    (rem 0 -3) 0)) (deftest test-quot
   ; wrong number of args
 ;  (is (thrown? IllegalArgumentException (quot)))
 ;  (is (thrown? IllegalArgumentException (quot 1)))
 ;  (is (thrown? IllegalArgumentException (quot 3 2 1)))
 
   ; divide by zero
-  (is (thrown? ArithmeticException (quot 9 0)))
-  (is (thrown? ArithmeticException (quot 0 0)))
-  
-  (are [x y] (= x y)
-    (quot 4 2) 2
-    (quot 3 2) 1
-    (quot 6 4) 1
-    (quot 0 5) 0
+                     (is (thrown? ArithmeticException (quot 9 0)))
+                     (is (thrown? ArithmeticException (quot 0 0)))
 
-    (quot 2 1/2) 4
-    (quot 2/3 1/2) 1
-    (quot 1 2/3) 1
+                     (are [x y] (= x y)
+                       (quot 4 2) 2
+                       (quot 3 2) 1
+                       (quot 6 4) 1
+                       (quot 0 5) 0
 
-    (quot 4.0 2.0) 2.0
-    (quot 4.5 2.0) 2.0
+                       (quot 2 1/2) 4
+                       (quot 2/3 1/2) 1
+                       (quot 1 2/3) 1
+
+                       (quot 4.0 2.0) 2.0
+                       (quot 4.5 2.0) 2.0
 
     ; |num| > |div|, num != k * div
-    (quot 42 5) 8     ; (8 * 5) + 2 == 42
-    (quot 42 -5) -8   ; (-8 * -5) + 2 == 42
-    (quot -42 5) -8   ; (-8 * 5) + -2 == -42
-    (quot -42 -5) 8   ; (8 * -5) + -2 == -42
+                       (quot 42 5) 8     ; (8 * 5) + 2 == 42
+                       (quot 42 -5) -8   ; (-8 * -5) + 2 == 42
+                       (quot -42 5) -8   ; (-8 * 5) + -2 == -42
+                       (quot -42 -5) 8   ; (8 * -5) + -2 == -42
 
     ; |num| > |div|, num = k * div
-    (quot 9 3) 3
-    (quot 9 -3) -3
-    (quot -9 3) -3
-    (quot -9 -3) 3
+                       (quot 9 3) 3
+                       (quot 9 -3) -3
+                       (quot -9 3) -3
+                       (quot -9 -3) 3
 
     ; |num| < |div|
-    (quot 2 5) 0
-    (quot 2 -5) 0
-    (quot -2 5) 0
-    (quot -2 -5) 0
+                       (quot 2 5) 0
+                       (quot 2 -5) 0
+                       (quot -2 5) 0
+                       (quot -2 -5) 0
 
     ; num = 0, div != 0
-    (quot 0 3) 0
-    (quot 0 -3) 0
-  )
-)
-
-
-;; *** Predicates ***
+                       (quot 0 3) 0
+                       (quot 0 -3) 0));; *** Predicates ***
 
 ;; pos? zero? neg?
 
@@ -483,12 +468,11 @@
               [2/3 0 -2/3]]
         pred-result [[pos?  [true false false]]
                      [zero? [false true false]]
-                     [neg?  [false false true]]] ]
+                     [neg?  [false false true]]]]
     (doseq [pr pred-result]
       (doseq [n nums]
         (is (= (map (first pr) n) (second pr))
-          (pr-str (first pr) n))))))
-
+            (pr-str (first pr) n))))))
 
 ;; even? odd?
 
@@ -519,45 +503,43 @@ Math/pow overflows to Infinity."
 
 (deftest test-bit-shift-left
   (are [x y] (= x y)
-       2r10 (bit-shift-left 2r1 1)
-       2r100 (bit-shift-left 2r1 2)
-       2r1000 (bit-shift-left 2r1 3)
-       2r00101110 (bit-shift-left 2r00010111 1)
-       2r00101110 (apply bit-shift-left [2r00010111 1])
-       0 (bit-shift-left 2r10 -1) ; truncated to least 6-bits, 63
-       (expt 2 32) (bit-shift-left 1 32)
-       (expt 2 16) (bit-shift-left 1 10000) ; truncated to least 6-bits, 16
-       )
+    2r10 (bit-shift-left 2r1 1)
+    2r100 (bit-shift-left 2r1 2)
+    2r1000 (bit-shift-left 2r1 3)
+    2r00101110 (bit-shift-left 2r00010111 1)
+    2r00101110 (apply bit-shift-left [2r00010111 1])
+    0 (bit-shift-left 2r10 -1) ; truncated to least 6-bits, 63
+    (expt 2 32) (bit-shift-left 1 32)
+    (expt 2 16) (bit-shift-left 1 10000) ; truncated to least 6-bits, 16
+)
   (is (thrown? IllegalArgumentException (bit-shift-left 1N 1))))
 
 (deftest test-bit-shift-right
   (are [x y] (= x y)
-       2r0 (bit-shift-right 2r1 1)
-       2r010 (bit-shift-right 2r100 1)
-       2r001 (bit-shift-right 2r100 2)
-       2r000 (bit-shift-right 2r100 3)
-       2r0001011 (bit-shift-right 2r00010111 1)
-       2r0001011 (apply bit-shift-right [2r00010111 1])
-       0 (bit-shift-right 2r10 -1) ; truncated to least 6-bits, 63
-       1 (bit-shift-right (expt 2 32) 32)
-       1 (bit-shift-right (expt 2 16) 10000) ; truncated to least 6-bits, 16
-       -1 (bit-shift-right -2r10 1)
-       )
+    2r0 (bit-shift-right 2r1 1)
+    2r010 (bit-shift-right 2r100 1)
+    2r001 (bit-shift-right 2r100 2)
+    2r000 (bit-shift-right 2r100 3)
+    2r0001011 (bit-shift-right 2r00010111 1)
+    2r0001011 (apply bit-shift-right [2r00010111 1])
+    0 (bit-shift-right 2r10 -1) ; truncated to least 6-bits, 63
+    1 (bit-shift-right (expt 2 32) 32)
+    1 (bit-shift-right (expt 2 16) 10000) ; truncated to least 6-bits, 16
+    -1 (bit-shift-right -2r10 1))
   (is (thrown? IllegalArgumentException (bit-shift-right 1N 1))))
 
 (deftest test-unsigned-bit-shift-right
   (are [x y] (= x y)
-       2r0 (unsigned-bit-shift-right 2r1 1)
-       2r010 (unsigned-bit-shift-right 2r100 1)
-       2r001 (unsigned-bit-shift-right 2r100 2)
-       2r000 (unsigned-bit-shift-right 2r100 3)
-       2r0001011 (unsigned-bit-shift-right 2r00010111 1)
-       2r0001011 (apply unsigned-bit-shift-right [2r00010111 1])
-       0 (unsigned-bit-shift-right 2r10 -1) ; truncated to least 6-bits, 63
-       1 (unsigned-bit-shift-right (expt 2 32) 32)
-       1 (unsigned-bit-shift-right (expt 2 16) 10000) ; truncated to least 6-bits, 16
-       9223372036854775807 (unsigned-bit-shift-right -2r10 1)
-       )
+    2r0 (unsigned-bit-shift-right 2r1 1)
+    2r010 (unsigned-bit-shift-right 2r100 1)
+    2r001 (unsigned-bit-shift-right 2r100 2)
+    2r000 (unsigned-bit-shift-right 2r100 3)
+    2r0001011 (unsigned-bit-shift-right 2r00010111 1)
+    2r0001011 (apply unsigned-bit-shift-right [2r00010111 1])
+    0 (unsigned-bit-shift-right 2r10 -1) ; truncated to least 6-bits, 63
+    1 (unsigned-bit-shift-right (expt 2 32) 32)
+    1 (unsigned-bit-shift-right (expt 2 16) 10000) ; truncated to least 6-bits, 16
+    9223372036854775807 (unsigned-bit-shift-right -2r10 1))
   (is (thrown? IllegalArgumentException (unsigned-bit-shift-right 1N 1))))
 
 (deftest test-bit-clear
@@ -579,15 +561,14 @@ Math/pow overflows to Infinity."
 ;; arrays
 (deftest test-array-types
   (are [x y z] (= (Class/forName x) (class y) (class z))
-       "[Z" (boolean-array 1) (booleans (boolean-array 1 true))
-       "[B" (byte-array 1) (bytes (byte-array 1 (byte 1)))
-       "[C" (char-array 1) (chars (char-array 1 \a))
-       "[S" (short-array 1) (shorts (short-array 1 (short 1)))
-       "[F" (float-array 1) (floats (float-array 1 1))
-       "[D" (double-array 1) (doubles (double-array 1 1))
-       "[I" (int-array 1) (ints (int-array 1 1))
-       "[J" (long-array 1) (longs (long-array 1 1))))
-
+    "[Z" (boolean-array 1) (booleans (boolean-array 1 true))
+    "[B" (byte-array 1) (bytes (byte-array 1 (byte 1)))
+    "[C" (char-array 1) (chars (char-array 1 \a))
+    "[S" (short-array 1) (shorts (short-array 1 (short 1)))
+    "[F" (float-array 1) (floats (float-array 1 1))
+    "[D" (double-array 1) (doubles (double-array 1 1))
+    "[I" (int-array 1) (ints (int-array 1 1))
+    "[J" (long-array 1) (longs (long-array 1 1))))
 
 (deftest test-ratios
   (is (== (denominator 1/2) 2))
@@ -597,9 +578,9 @@ Math/pow overflows to Infinity."
 
 (deftest test-arbitrary-precision-subtract
   (are [x y] (= x y)
-       9223372036854775808N (-' 0 -9223372036854775808)
-       clojure.lang.BigInt  (class (-' 0 -9223372036854775808))
-       java.lang.Long       (class (-' 0 -9223372036854775807))))
+    9223372036854775808N (-' 0 -9223372036854775808)
+    clojure.lang.BigInt  (class (-' 0 -9223372036854775808))
+    java.lang.Long       (class (-' 0 -9223372036854775807))))
 
 (deftest test-min-max
   (testing "min/max on different numbers of floats and doubles"
@@ -608,24 +589,24 @@ Math/pow overflows to Infinity."
               (= (Float. xmax) (max (Float. a)))
               (= xmin (min a))
               (= xmax (max a)))
-         0.0 0.0 0.0)
+      0.0 0.0 0.0)
     (are [xmin xmax a b]
          (and (= (Float. xmin) (min (Float. a) (Float. b)))
               (= (Float. xmax) (max (Float. a) (Float. b)))
               (= xmin (min a b))
               (= xmax (max a b)))
-         -1.0  0.0  0.0 -1.0
-         -1.0  0.0 -1.0  0.0
-         0.0  1.0  0.0  1.0
-         0.0  1.0  1.0  0.0)
+      -1.0  0.0  0.0 -1.0
+      -1.0  0.0 -1.0  0.0
+      0.0  1.0  0.0  1.0
+      0.0  1.0  1.0  0.0)
     (are [xmin xmax a b c]
          (and (= (Float. xmin) (min (Float. a) (Float. b) (Float. c)))
               (= (Float. xmax) (max (Float. a) (Float. b) (Float. c)))
               (= xmin (min a b c))
               (= xmax (max a b c)))
-         -1.0  1.0  0.0  1.0 -1.0
-         -1.0  1.0  0.0 -1.0  1.0
-         -1.0  1.0 -1.0  1.0  0.0))
+      -1.0  1.0  0.0  1.0 -1.0
+      -1.0  1.0  0.0 -1.0  1.0
+      -1.0  1.0 -1.0  1.0  0.0))
   (testing "min/max preserves type of winner"
     (is (= java.lang.Long (class (max 10))))
     (is (= java.lang.Long (class (max 1.0 10))))
@@ -649,13 +630,13 @@ Math/pow overflows to Infinity."
       (are [minmax]
            (are [nan? nan zero]
                 (every? nan? (map minmax
-                                  [ nan zero zero]
+                                  [nan zero zero]
                                   [zero  nan zero]
                                   [zero zero  nan]))
-                fnan?  Float/NaN  (Float. 0.0)
-                dnan? Double/NaN          0.0)
-           min
-           max))))
+             fnan?  Float/NaN  (Float. 0.0)
+             dnan? Double/NaN          0.0)
+        min
+        max))))
 
 (defn integer
   "Distribution of integers biased towards the small, but
@@ -666,9 +647,9 @@ Math/pow overflows to Infinity."
 (defn longable?
   [n]
   (try
-   (long n)
-   true
-   (catch Exception _)))
+    (long n)
+    true
+    (catch Exception _)))
 
 (defspec integer-commutative-laws
   (partial map identity)
@@ -734,23 +715,23 @@ Math/pow overflows to Infinity."
 
 (defmacro check-warn-on-box [warn? form]
   `(do (binding [*unchecked-math* :warn-on-boxed]
-                (is (= ~warn?
-                       (boolean
-                         (re-find #"^Boxed math warning"
-                                  (helper/with-err-string-writer
-                                    (helper/eval-in-temp-ns ~form)))))))
+         (is (= ~warn?
+                (boolean
+                 (re-find #"^Boxed math warning"
+                          (helper/with-err-string-writer
+                            (helper/eval-in-temp-ns ~form)))))))
        (binding [*unchecked-math* true]
-                (is (false?
-                      (boolean
-                        (re-find #"^Boxed math warning"
-                                 (helper/with-err-string-writer
-                                   (helper/eval-in-temp-ns ~form)))))))
+         (is (false?
+              (boolean
+               (re-find #"^Boxed math warning"
+                        (helper/with-err-string-writer
+                          (helper/eval-in-temp-ns ~form)))))))
        (binding [*unchecked-math* false]
-                (is (false?
-                      (boolean
-                        (re-find #"^Boxed math warning"
-                                 (helper/with-err-string-writer
-                                   (helper/eval-in-temp-ns ~form)))))))))
+         (is (false?
+              (boolean
+               (re-find #"^Boxed math warning"
+                        (helper/with-err-string-writer
+                          (helper/eval-in-temp-ns ~form)))))))))
 
 (deftest warn-on-boxed
   (check-warn-on-box true (#(inc %) 2))
@@ -758,7 +739,6 @@ Math/pow overflows to Infinity."
   (check-warn-on-box false (long-array 5))
   (check-warn-on-box true (> (first (range 3)) 0))
   (check-warn-on-box false (> ^long (first (range 3)) 0)))
-
 
 (deftest comparisons
   (let [small-numbers [1 1.0 (Integer. 1) (Float. 1.0) 9/10 1N 1M]
@@ -803,7 +783,7 @@ Math/pow overflows to Infinity."
 
 (deftest test-nan-comparison
   (are [x y] (= x y)
-       (< 1000 Double/NaN) (< 1000 (Double. Double/NaN))
-       (<= 1000 Double/NaN) (<= 1000 (Double. Double/NaN))
-       (> 1000 Double/NaN) (> 1000 (Double. Double/NaN))
-       (>= 1000 Double/NaN) (>= 1000 (Double. Double/NaN))))
+    (< 1000 Double/NaN) (< 1000 (Double. Double/NaN))
+    (<= 1000 Double/NaN) (<= 1000 (Double. Double/NaN))
+    (> 1000 Double/NaN) (> 1000 (Double. Double/NaN))
+    (>= 1000 Double/NaN) (>= 1000 (Double. Double/NaN))))

--- a/test/clojure/test_clojure/other_functions.clj
+++ b/test/clojure/test_clojure/other_functions.clj
@@ -1,20 +1,20 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 
 (ns clojure.test-clojure.other-functions
   (:use clojure.test))
 
-; http://clojure.org/other_functions
+;; http://clojure.org/other_functions
 
-; [= not= (tests in data_structures.clj and elsewhere)]
+;; [= not= (tests in data_structures.clj and elsewhere)]
 
 
 (deftest test-identity
@@ -23,71 +23,70 @@
 ;  (is (thrown? IllegalArgumentException (identity 1 2)))
 
   (are [x] (= (identity x) x)
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      () '(1 2)
-      [] [1 2]
-      {} {:a 1 :b 2}
-      #{} #{1 2} )
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2})
 
   ; evaluation
   (are [x y] (= (identity x) y)
-      (+ 1 2) 3
-      (> 5 0) true ))
-
+    (+ 1 2) 3
+    (> 5 0) true))
 
 (deftest test-name
   (are [x y] (= x (name y))
-       "foo" :foo
-       "bar" 'bar
-       "quux" "quux"))
+    "foo" :foo
+    "bar" 'bar
+    "quux" "quux"))
 
 (deftest test-fnil
   (let [f1 (fnil vector :a)
         f2 (fnil vector :a :b)
         f3 (fnil vector :a :b :c)]
     (are [result input] (= result [(apply f1 input) (apply f2 input) (apply f3 input)])
-         [[1 2 3 4] [1 2 3 4] [1 2 3 4]]  [1 2 3 4]
-         [[:a 2 3 4] [:a 2 3 4] [:a 2 3 4]] [nil 2 3 4]
-         [[:a nil 3 4] [:a :b 3 4] [:a :b 3 4]] [nil nil 3 4]
-         [[:a nil nil 4] [:a :b nil 4] [:a :b :c 4]] [nil nil nil 4]
-         [[:a nil nil nil] [:a :b nil nil] [:a :b :c nil]] [nil nil nil nil]))
+      [[1 2 3 4] [1 2 3 4] [1 2 3 4]]  [1 2 3 4]
+      [[:a 2 3 4] [:a 2 3 4] [:a 2 3 4]] [nil 2 3 4]
+      [[:a nil 3 4] [:a :b 3 4] [:a :b 3 4]] [nil nil 3 4]
+      [[:a nil nil 4] [:a :b nil 4] [:a :b :c 4]] [nil nil nil 4]
+      [[:a nil nil nil] [:a :b nil nil] [:a :b :c nil]] [nil nil nil nil]))
   (are [x y] (= x y)
-       ((fnil + 0) nil 42) 42
-       ((fnil conj []) nil 42) [42]
-       (reduce #(update-in %1 [%2] (fnil inc 0)) {} 
-               ["fun" "counting" "words" "fun"])
-       {"words" 1, "counting" 1, "fun" 2}
-       (reduce #(update-in %1 [(first %2)] (fnil conj []) (second %2)) {} 
-               [[:a 1] [:a 2] [:b 3]])
-       {:b [3], :a [1 2]}))
+    ((fnil + 0) nil 42) 42
+    ((fnil conj []) nil 42) [42]
+    (reduce #(update-in %1 [%2] (fnil inc 0)) {}
+            ["fun" "counting" "words" "fun"])
+    {"words" 1, "counting" 1, "fun" 2}
+    (reduce #(update-in %1 [(first %2)] (fnil conj []) (second %2)) {}
+            [[:a 1] [:a 2] [:b 3]])
+    {:b [3], :a [1 2]}))
 
-; time assert comment doc
+;; time assert comment doc
 
-; partial
-; comp
+;; partial
+;; comp
 
 (deftest test-comp
   (let [c0 (comp)]
     (are [x] (= (identity x) (c0 x))
-         nil
-         42
-         [1 2 3]
-         #{}
-         :foo)
+      nil
+      42
+      [1 2 3]
+      #{}
+      :foo)
     (are [x y] (= (identity x) (c0 y))
-         (+ 1 2 3) 6
-         (keyword "foo") :foo)))
+      (+ 1 2 3) 6
+      (keyword "foo") :foo)))
 
-; complement
+;; complement
 
 (deftest test-complement
   (let [not-contains? (complement contains?)]
@@ -97,14 +96,14 @@
     (is (= true (first-elem-not-1? [2 3])))
     (is (= false (first-elem-not-1? [1 2])))))
 
-; constantly
+;; constantly
 
 (deftest test-constantly
   (let [c0 (constantly 10)]
     (are [x] (= 10 (c0 x))
-         nil
-         42
-         "foo")))
+      nil
+      42
+      "foo")))
 ;juxt
 
 (deftest test-juxt
@@ -128,214 +127,214 @@
     (is (= 40 (p1 20)))
     (is (= [1 2 3] (p2 3)))))
 
-; every-pred
+;; every-pred
 (deftest test-every-pred
   (are [result expr] (= result expr)
    ;; 1 pred
-   true     ((every-pred even?))
-   true     ((every-pred even?) 2)
-   true     ((every-pred even?) 2 4)
-   true     ((every-pred even?) 2 4 6)
-   true     ((every-pred even?) 2 4 6 8)
-   true     ((every-pred even?) 2 4 6 8 10)
-   false    ((every-pred odd?) 2)
-   false    ((every-pred odd?) 2 4)
-   false    ((every-pred odd?) 2 4 6)
-   false    ((every-pred odd?) 2 4 6 8)
-   false    ((every-pred odd?) 2 4 6 8 10)
+    true     ((every-pred even?))
+    true     ((every-pred even?) 2)
+    true     ((every-pred even?) 2 4)
+    true     ((every-pred even?) 2 4 6)
+    true     ((every-pred even?) 2 4 6 8)
+    true     ((every-pred even?) 2 4 6 8 10)
+    false    ((every-pred odd?) 2)
+    false    ((every-pred odd?) 2 4)
+    false    ((every-pred odd?) 2 4 6)
+    false    ((every-pred odd?) 2 4 6 8)
+    false    ((every-pred odd?) 2 4 6 8 10)
    ;; 2 preds
-   true     ((every-pred even? number?))
-   true     ((every-pred even? number?) 2)
-   true     ((every-pred even? number?) 2 4)
-   true     ((every-pred even? number?) 2 4 6)
-   true     ((every-pred even? number?) 2 4 6 8)
-   true     ((every-pred even? number?) 2 4 6 8 10)
-   false    ((every-pred number? odd?) 2)
-   false    ((every-pred number? odd?) 2 4)
-   false    ((every-pred number? odd?) 2 4 6)
-   false    ((every-pred number? odd?) 2 4 6 8)
-   false    ((every-pred number? odd?) 2 4 6 8 10)
+    true     ((every-pred even? number?))
+    true     ((every-pred even? number?) 2)
+    true     ((every-pred even? number?) 2 4)
+    true     ((every-pred even? number?) 2 4 6)
+    true     ((every-pred even? number?) 2 4 6 8)
+    true     ((every-pred even? number?) 2 4 6 8 10)
+    false    ((every-pred number? odd?) 2)
+    false    ((every-pred number? odd?) 2 4)
+    false    ((every-pred number? odd?) 2 4 6)
+    false    ((every-pred number? odd?) 2 4 6 8)
+    false    ((every-pred number? odd?) 2 4 6 8 10)
    ;; 2 preds, short-circuiting
-   false    ((every-pred number? odd?) 1 :a)
-   false    ((every-pred number? odd?) 1 3 :a)
-   false    ((every-pred number? odd?) 1 3 5 :a)
-   false    ((every-pred number? odd?) 1 3 5 7 :a)
-   false    ((every-pred number? odd?) 1 :a 3 5 7)
+    false    ((every-pred number? odd?) 1 :a)
+    false    ((every-pred number? odd?) 1 3 :a)
+    false    ((every-pred number? odd?) 1 3 5 :a)
+    false    ((every-pred number? odd?) 1 3 5 7 :a)
+    false    ((every-pred number? odd?) 1 :a 3 5 7)
    ;; 3 preds
-   true     ((every-pred even? number? #(> % 0)))
-   true     ((every-pred even? number? #(> % 0)) 2)
-   true     ((every-pred even? number? #(> % 0)) 2 4)
-   true     ((every-pred even? number? #(> % 0)) 2 4 6)
-   true     ((every-pred even? number? #(> % 0)) 2 4 6 8)
-   true     ((every-pred even? number? #(> % 0)) 2 4 6 8 10)
-   true     ((every-pred number? even? #(> % 0)) 2 4 6 8 10 12)
-   false    ((every-pred number? odd? #(> % 0)) 2)
-   false    ((every-pred number? odd? #(> % 0)) 2 4)
-   false    ((every-pred number? odd? #(> % 0)) 2 4 6)
-   false    ((every-pred number? odd? #(> % 0)) 2 4 6 8)
-   false    ((every-pred number? odd? #(> % 0)) 2 4 6 8 10)
-   false    ((every-pred number? odd? #(> % 0)) 2 4 6 8 -10)
+    true     ((every-pred even? number? #(> % 0)))
+    true     ((every-pred even? number? #(> % 0)) 2)
+    true     ((every-pred even? number? #(> % 0)) 2 4)
+    true     ((every-pred even? number? #(> % 0)) 2 4 6)
+    true     ((every-pred even? number? #(> % 0)) 2 4 6 8)
+    true     ((every-pred even? number? #(> % 0)) 2 4 6 8 10)
+    true     ((every-pred number? even? #(> % 0)) 2 4 6 8 10 12)
+    false    ((every-pred number? odd? #(> % 0)) 2)
+    false    ((every-pred number? odd? #(> % 0)) 2 4)
+    false    ((every-pred number? odd? #(> % 0)) 2 4 6)
+    false    ((every-pred number? odd? #(> % 0)) 2 4 6 8)
+    false    ((every-pred number? odd? #(> % 0)) 2 4 6 8 10)
+    false    ((every-pred number? odd? #(> % 0)) 2 4 6 8 -10)
    ;; 3 preds, short-circuiting
-   false    ((every-pred number? odd? #(> % 0)) 1 :a)
-   false    ((every-pred number? odd? #(> % 0)) 1 3 :a)
-   false    ((every-pred number? odd? #(> % 0)) 1 3 5 :a)
-   false    ((every-pred number? odd? #(> % 0)) 1 3 5 7 :a)
-   false    ((every-pred number? odd? #(> % 0)) 1 :a 3 5 7)
+    false    ((every-pred number? odd? #(> % 0)) 1 :a)
+    false    ((every-pred number? odd? #(> % 0)) 1 3 :a)
+    false    ((every-pred number? odd? #(> % 0)) 1 3 5 :a)
+    false    ((every-pred number? odd? #(> % 0)) 1 3 5 7 :a)
+    false    ((every-pred number? odd? #(> % 0)) 1 :a 3 5 7)
    ;; 4 preds
-   true     ((every-pred even? number? #(> % 0) #(<= % 12)))
-   true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4 6)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4 6 8)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4 6 8 10)
-   true     ((every-pred number? even? #(> % 0) #(<= % 12)) 2 4 6 8 10 12)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6 8)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 10)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 14)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12)))
+    true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4 6)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4 6 8)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12)) 2 4 6 8 10)
+    true     ((every-pred number? even? #(> % 0) #(<= % 12)) 2 4 6 8 10 12)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6 8)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 10)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 14)
    ;; 4 preds, short-circuiting
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 3 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 3 5 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 3 5 7 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 :a 3 5 7)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 3 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 3 5 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 3 5 7 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12)) 1 :a 3 5 7)
    ;; 5 preds
-   true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))))
-   true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
-   true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
-   true     ((every-pred number? even? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10 12)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 13)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))))
+    true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
+    true     ((every-pred even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
+    true     ((every-pred number? even? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10 12)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 13)
    ;; 5 preds, short-circuiting
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 7 :a)
-   false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a 3 5 7)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 7 :a)
+    false    ((every-pred number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a 3 5 7)
    ;; truthiness
-   true     (reduce #(and % %2)
-                    (for [i (range 1 25)]
-                      (apply (apply every-pred (repeat i identity))
-                             (range i))))))
+    true     (reduce #(and % %2)
+                     (for [i (range 1 25)]
+                       (apply (apply every-pred (repeat i identity))
+                              (range i))))))
 
-; some-fn
+;; some-fn
 
 (deftest test-some-fn
   (are [result] (identity result)
    ;; 1 pred
-   (not ((some-fn even?)))
-   ((some-fn even?) 2)
-   ((some-fn even?) 2 4)
-   ((some-fn even?) 2 4 6)
-   ((some-fn even?) 2 4 6 8)
-   ((some-fn even?) 2 4 6 8 10)
-   (not ((some-fn odd?) 2))
-   (not ((some-fn odd?) 2 4))
-   (not ((some-fn odd?) 2 4 6))
-   (not ((some-fn odd?) 2 4 6 8))
-   (not ((some-fn odd?) 2 4 6 8 10))
+    (not ((some-fn even?)))
+    ((some-fn even?) 2)
+    ((some-fn even?) 2 4)
+    ((some-fn even?) 2 4 6)
+    ((some-fn even?) 2 4 6 8)
+    ((some-fn even?) 2 4 6 8 10)
+    (not ((some-fn odd?) 2))
+    (not ((some-fn odd?) 2 4))
+    (not ((some-fn odd?) 2 4 6))
+    (not ((some-fn odd?) 2 4 6 8))
+    (not ((some-fn odd?) 2 4 6 8 10))
    ;; 2 preds
-   (not ((some-fn even? number?)))
-   ((some-fn even? number?) 2)
-   ((some-fn even? number?) 2 4)
-   ((some-fn even? number?) 2 4 6)
-   ((some-fn even? number?) 2 4 6 8)
-   ((some-fn even? number?) 2 4 6 8 10)
-   ((some-fn number? odd?) 2)
-   ((some-fn number? odd?) 2 4)
-   ((some-fn number? odd?) 2 4 6)
-   ((some-fn number? odd?) 2 4 6 8)
-   ((some-fn number? odd?) 2 4 6 8 10)
+    (not ((some-fn even? number?)))
+    ((some-fn even? number?) 2)
+    ((some-fn even? number?) 2 4)
+    ((some-fn even? number?) 2 4 6)
+    ((some-fn even? number?) 2 4 6 8)
+    ((some-fn even? number?) 2 4 6 8 10)
+    ((some-fn number? odd?) 2)
+    ((some-fn number? odd?) 2 4)
+    ((some-fn number? odd?) 2 4 6)
+    ((some-fn number? odd?) 2 4 6 8)
+    ((some-fn number? odd?) 2 4 6 8 10)
    ;; 2 preds, short-circuiting
-   ((some-fn number? odd?) 1 :a)
-   ((some-fn number? odd?) 1 3 :a)
-   ((some-fn number? odd?) 1 3 5 :a)
-   ((some-fn number? odd?) 1 3 5 7 :a)
-   ((some-fn number? odd?) 1 :a 3 5 7)
+    ((some-fn number? odd?) 1 :a)
+    ((some-fn number? odd?) 1 3 :a)
+    ((some-fn number? odd?) 1 3 5 :a)
+    ((some-fn number? odd?) 1 3 5 7 :a)
+    ((some-fn number? odd?) 1 :a 3 5 7)
    ;; 3 preds
-   (not ((some-fn even? number? #(> % 0))))
-   ((some-fn even? number? #(> % 0)) 2)
-   ((some-fn even? number? #(> % 0)) 2 4)
-   ((some-fn even? number? #(> % 0)) 2 4 6)
-   ((some-fn even? number? #(> % 0)) 2 4 6 8)
-   ((some-fn even? number? #(> % 0)) 2 4 6 8 10)
-   ((some-fn number? even? #(> % 0)) 2 4 6 8 10 12)
-   ((some-fn number? odd? #(> % 0)) 2)
-   ((some-fn number? odd? #(> % 0)) 2 4)
-   ((some-fn number? odd? #(> % 0)) 2 4 6)
-   ((some-fn number? odd? #(> % 0)) 2 4 6 8)
-   ((some-fn number? odd? #(> % 0)) 2 4 6 8 10)
-   ((some-fn number? odd? #(> % 0)) 2 4 6 8 -10)
+    (not ((some-fn even? number? #(> % 0))))
+    ((some-fn even? number? #(> % 0)) 2)
+    ((some-fn even? number? #(> % 0)) 2 4)
+    ((some-fn even? number? #(> % 0)) 2 4 6)
+    ((some-fn even? number? #(> % 0)) 2 4 6 8)
+    ((some-fn even? number? #(> % 0)) 2 4 6 8 10)
+    ((some-fn number? even? #(> % 0)) 2 4 6 8 10 12)
+    ((some-fn number? odd? #(> % 0)) 2)
+    ((some-fn number? odd? #(> % 0)) 2 4)
+    ((some-fn number? odd? #(> % 0)) 2 4 6)
+    ((some-fn number? odd? #(> % 0)) 2 4 6 8)
+    ((some-fn number? odd? #(> % 0)) 2 4 6 8 10)
+    ((some-fn number? odd? #(> % 0)) 2 4 6 8 -10)
    ;; 3 preds, short-circuiting
-   ((some-fn number? odd? #(> % 0)) 1 :a)
-   ((some-fn number? odd? #(> % 0)) 1 3 :a)
-   ((some-fn number? odd? #(> % 0)) 1 3 5 :a)
-   ((some-fn number? odd? #(> % 0)) 1 :a 3 5 7)
+    ((some-fn number? odd? #(> % 0)) 1 :a)
+    ((some-fn number? odd? #(> % 0)) 1 3 :a)
+    ((some-fn number? odd? #(> % 0)) 1 3 5 :a)
+    ((some-fn number? odd? #(> % 0)) 1 :a 3 5 7)
    ;; 4 preds
-   (not ((some-fn even? number? #(> % 0) #(<= % 12))))
-   ((some-fn even? number? #(> % 0) #(<= % 12)) 2)
-   ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4)
-   ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4 6)
-   ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4 6 8)
-   ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4 6 8 10)
-   ((some-fn number? even? #(> % 0) #(<= % 12)) 2 4 6 8 10 12)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 2)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6 8)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 10)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 14)
+    (not ((some-fn even? number? #(> % 0) #(<= % 12))))
+    ((some-fn even? number? #(> % 0) #(<= % 12)) 2)
+    ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4)
+    ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4 6)
+    ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4 6 8)
+    ((some-fn even? number? #(> % 0) #(<= % 12)) 2 4 6 8 10)
+    ((some-fn number? even? #(> % 0) #(<= % 12)) 2 4 6 8 10 12)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 2)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6 8)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 10)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 2 4 6 8 14)
    ;; 4 preds, short-circuiting
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 3 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 3 5 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 3 5 7 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 :a 3 5 7)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 3 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 3 5 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 3 5 7 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12)) 1 :a 3 5 7)
    ;; 5 preds
-   (not ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2)))))
-   ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
-   ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
-   ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
-   ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
-   ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
-   ((some-fn number? even? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10 12)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 13)
+    (not ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2)))))
+    ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
+    ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
+    ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
+    ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
+    ((some-fn even? number? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
+    ((some-fn number? even? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10 12)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 10)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 2 4 6 8 13)
    ;; 5 preds, short-circuiting
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 7 :a)
-   ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a 3 5 7)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 3 5 7 :a)
+    ((some-fn number? odd? #(> % 0) #(<= % 12) #(zero? (rem % 2))) 1 :a 3 5 7)
    ;; truthiness
-   (reduce #(or % %2)
-           (conj
+    (reduce #(or % %2)
+            (conj
              (vec
-               (for [i (range 1 25)]
-                 (apply (apply some-fn (repeat i (comp not boolean))) (range i))))
-                 true))))
+              (for [i (range 1 25)]
+                (apply (apply some-fn (repeat i (comp not boolean))) (range i))))
+             true))))
 
-; Printing
-; pr prn print println newline
-; pr-str prn-str print-str println-str [with-out-str (vars.clj)]
+;; Printing
+;; pr prn print println newline
+;; pr-str prn-str print-str println-str [with-out-str (vars.clj)]
 
-; Regex Support
-; re-matcher re-find re-matches re-groups re-seq
+;; Regex Support
+;; re-matcher re-find re-matches re-groups re-seq
 
-; update
+;; update
 
 (deftest test-update
   (are [result expr] (= result expr)

--- a/test/clojure/test_clojure/parallel.clj
+++ b/test/clojure/test_clojure/parallel.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 
 (ns clojure.test-clojure.parallel
@@ -14,11 +14,11 @@
 
 ;; !! Tests for the parallel library will be in a separate file clojure_parallel.clj !!
 
-; future-call
-; future
-; pmap
-; pcalls
-; pvalues
+;; future-call
+;; future
+;; pmap
+;; pcalls
+;; pvalues
 
 
 ;; pmap
@@ -26,7 +26,6 @@
 (deftest pmap-does-its-thing
   ;; regression fixed in r1218; was OutOfMemoryError
   (is (= '(1) (pmap inc [0]))))
-
 
 (def ^:dynamic *test-value* 1)
 

--- a/test/clojure/test_clojure/pprint.clj
+++ b/test/clojure/test_clojure/pprint.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 

--- a/test/clojure/test_clojure/pprint/test_cl_format.clj
+++ b/test/clojure/test_clojure/pprint/test_cl_format.clj
@@ -1,12 +1,12 @@
 ;;; test_cl_format.clj -- part of the pretty printer for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -22,532 +22,497 @@
 ;; TODO add tests for ~F, etc.: 0.0, 9.9999 with rounding, 9.9999E99 with rounding
 
 (simple-tests d-tests
-  (cl-format nil "~D" 0) "0"
-  (cl-format nil "~D" 2e6) "2000000"
-  (cl-format nil "~D" 2000000) "2000000"
-  (cl-format nil "~:D" 2000000) "2,000,000"
-  (cl-format nil "~D" 1/2) "1/2"
-  (cl-format nil "~D" 'fred) "fred"
-)
-
-(simple-tests base-tests
-  (cl-format nil "~{~2r~^ ~}~%" (range 10))
-  "0 1 10 11 100 101 110 111 1000 1001\n"
-  (with-out-str
-    (dotimes [i 35]
-      (binding [*print-base* (+ i 2)]       ;print the decimal number 40 
-        (write 40)                          ;in each base from 2 to 36
-        (if (zero? (mod i 10)) (prn) (cl-format true " ")))))
-  "101000
+              (cl-format nil "~D" 0) "0"
+              (cl-format nil "~D" 2e6) "2000000"
+              (cl-format nil "~D" 2000000) "2000000"
+              (cl-format nil "~:D" 2000000) "2,000,000"
+              (cl-format nil "~D" 1/2) "1/2"
+              (cl-format nil "~D" 'fred) "fred") (simple-tests base-tests
+                                                               (cl-format nil "~{~2r~^ ~}~%" (range 10))
+                                                               "0 1 10 11 100 101 110 111 1000 1001\n"
+                                                               (with-out-str
+                                                                 (dotimes [i 35]
+                                                                   (binding [*print-base* (+ i 2)]       ;print the decimal number 40
+                                                                     (write 40)                          ;in each base from 2 to 36
+                                                                     (if (zero? (mod i 10)) (prn) (cl-format true " ")))))
+                                                               "101000
 1111 220 130 104 55 50 44 40 37 34
 31 2c 2a 28 26 24 22 20 1j 1i
 1h 1g 1f 1e 1d 1c 1b 1a 19 18
 17 16 15 14 "
-  (with-out-str
-    (doseq [pb [2 3 8 10 16]]               
-      (binding [*print-radix* true      ;print the integer 10 and 
-            *print-base* pb]            ;the ratio 1/10 in bases 2, 
-        (cl-format true "~&~S  ~S~%" 10 1/10))))        ;3, 8, 10, 16
-  "#b1010  #b1/1010\n#3r101  #3r1/101\n#o12  #o1/12\n10.  #10r1/10\n#xa  #x1/a\n")
-
-
+                                                               (with-out-str
+                                                                 (doseq [pb [2 3 8 10 16]]
+                                                                   (binding [*print-radix* true      ;print the integer 10 and
+                                                                             *print-base* pb]            ;the ratio 1/10 in bases 2,
+                                                                     (cl-format true "~&~S  ~S~%" 10 1/10))))        ;3, 8, 10, 16
+                                                               "#b1010  #b1/1010\n#3r101  #3r1/101\n#o12  #o1/12\n10.  #10r1/10\n#xa  #x1/a\n")
 
 (simple-tests cardinal-tests
-  (cl-format nil "~R" 0) "zero"
-  (cl-format nil "~R" 4) "four"
-  (cl-format nil "~R" 15) "fifteen"
-  (cl-format nil "~R" -15) "minus fifteen"
-  (cl-format nil "~R" 25) "twenty-five"
-  (cl-format nil "~R" 20) "twenty"
-  (cl-format nil "~R" 200) "two hundred"
-  (cl-format nil "~R" 203) "two hundred three"
+              (cl-format nil "~R" 0) "zero"
+              (cl-format nil "~R" 4) "four"
+              (cl-format nil "~R" 15) "fifteen"
+              (cl-format nil "~R" -15) "minus fifteen"
+              (cl-format nil "~R" 25) "twenty-five"
+              (cl-format nil "~R" 20) "twenty"
+              (cl-format nil "~R" 200) "two hundred"
+              (cl-format nil "~R" 203) "two hundred three"
 
-  (cl-format nil "~R" 44879032)
-  "forty-four million, eight hundred seventy-nine thousand, thirty-two"
+              (cl-format nil "~R" 44879032)
+              "forty-four million, eight hundred seventy-nine thousand, thirty-two"
 
-  (cl-format nil "~R" -44879032)
-  "minus forty-four million, eight hundred seventy-nine thousand, thirty-two"
-  
-  (cl-format nil "~R = ~:*~:D" 44000032)
-  "forty-four million, thirty-two = 44,000,032"
+              (cl-format nil "~R" -44879032)
+              "minus forty-four million, eight hundred seventy-nine thousand, thirty-two"
 
-  (cl-format nil "~R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094)
-  "four hundred forty-eight septendecillion, seven hundred ninety sexdecillion, three hundred twenty-nine quindecillion, four hundred eighty quattuordecillion, nine hundred forty-eight tredecillion, two hundred nine duodecillion, three hundred eighty-four undecillion, three hundred eighty-nine decillion, four hundred twenty-nine nonillion, three hundred eighty-four octillion, twenty-nine septillion, three hundred eighty-four sextillion, twenty-nine quintillion, eight hundred forty-two quadrillion, ninety-eight trillion, four hundred twenty billion, nine hundred eighty-nine million, eight hundred forty-two thousand, ninety-four = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094"
+              (cl-format nil "~R = ~:*~:D" 44000032)
+              "forty-four million, thirty-two = 44,000,032"
 
-  (cl-format nil "~R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094490320942058747587584758375847593475)
-  "448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475 = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475"
+              (cl-format nil "~R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094)
+              "four hundred forty-eight septendecillion, seven hundred ninety sexdecillion, three hundred twenty-nine quindecillion, four hundred eighty quattuordecillion, nine hundred forty-eight tredecillion, two hundred nine duodecillion, three hundred eighty-four undecillion, three hundred eighty-nine decillion, four hundred twenty-nine nonillion, three hundred eighty-four octillion, twenty-nine septillion, three hundred eighty-four sextillion, twenty-nine quintillion, eight hundred forty-two quadrillion, ninety-eight trillion, four hundred twenty billion, nine hundred eighty-nine million, eight hundred forty-two thousand, ninety-four = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094"
 
-  (cl-format nil "~R = ~:*~:D" 2e6)
-  "two million = 2,000,000"
+              (cl-format nil "~R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094490320942058747587584758375847593475)
+              "448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475 = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475"
 
-  (cl-format nil "~R = ~:*~:D" 200000200000)
-  "two hundred billion, two hundred thousand = 200,000,200,000")
+              (cl-format nil "~R = ~:*~:D" 2e6)
+              "two million = 2,000,000"
+
+              (cl-format nil "~R = ~:*~:D" 200000200000)
+              "two hundred billion, two hundred thousand = 200,000,200,000")
 
 (simple-tests ordinal-tests
-  (cl-format nil "~:R" 0) "zeroth"
-  (cl-format nil "~:R" 4) "fourth"
-  (cl-format nil "~:R" 15) "fifteenth"
-  (cl-format nil "~:R" -15) "minus fifteenth"
-  (cl-format nil "~:R" 25) "twenty-fifth"
-  (cl-format nil "~:R" 20) "twentieth"
-  (cl-format nil "~:R" 200) "two hundredth"
-  (cl-format nil "~:R" 203) "two hundred third"
+              (cl-format nil "~:R" 0) "zeroth"
+              (cl-format nil "~:R" 4) "fourth"
+              (cl-format nil "~:R" 15) "fifteenth"
+              (cl-format nil "~:R" -15) "minus fifteenth"
+              (cl-format nil "~:R" 25) "twenty-fifth"
+              (cl-format nil "~:R" 20) "twentieth"
+              (cl-format nil "~:R" 200) "two hundredth"
+              (cl-format nil "~:R" 203) "two hundred third"
 
-  (cl-format nil "~:R" 44879032)
-  "forty-four million, eight hundred seventy-nine thousand, thirty-second"
+              (cl-format nil "~:R" 44879032)
+              "forty-four million, eight hundred seventy-nine thousand, thirty-second"
 
-  (cl-format nil "~:R" -44879032)
-  "minus forty-four million, eight hundred seventy-nine thousand, thirty-second"
-  
-  (cl-format nil "~:R = ~:*~:D" 44000032)
-  "forty-four million, thirty-second = 44,000,032"
+              (cl-format nil "~:R" -44879032)
+              "minus forty-four million, eight hundred seventy-nine thousand, thirty-second"
 
-  (cl-format nil "~:R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094)
-  "four hundred forty-eight septendecillion, seven hundred ninety sexdecillion, three hundred twenty-nine quindecillion, four hundred eighty quattuordecillion, nine hundred forty-eight tredecillion, two hundred nine duodecillion, three hundred eighty-four undecillion, three hundred eighty-nine decillion, four hundred twenty-nine nonillion, three hundred eighty-four octillion, twenty-nine septillion, three hundred eighty-four sextillion, twenty-nine quintillion, eight hundred forty-two quadrillion, ninety-eight trillion, four hundred twenty billion, nine hundred eighty-nine million, eight hundred forty-two thousand, ninety-fourth = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094"
-  (cl-format nil "~:R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094490320942058747587584758375847593475)
-  "448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475th = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475"
-  (cl-format nil "~:R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094490320942058747587584758375847593471)
-  "448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,471st = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,471"
-  (cl-format nil "~:R = ~:*~:D" 2e6)
-  "two millionth = 2,000,000")
+              (cl-format nil "~:R = ~:*~:D" 44000032)
+              "forty-four million, thirty-second = 44,000,032"
+
+              (cl-format nil "~:R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094)
+              "four hundred forty-eight septendecillion, seven hundred ninety sexdecillion, three hundred twenty-nine quindecillion, four hundred eighty quattuordecillion, nine hundred forty-eight tredecillion, two hundred nine duodecillion, three hundred eighty-four undecillion, three hundred eighty-nine decillion, four hundred twenty-nine nonillion, three hundred eighty-four octillion, twenty-nine septillion, three hundred eighty-four sextillion, twenty-nine quintillion, eight hundred forty-two quadrillion, ninety-eight trillion, four hundred twenty billion, nine hundred eighty-nine million, eight hundred forty-two thousand, ninety-fourth = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094"
+              (cl-format nil "~:R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094490320942058747587584758375847593475)
+              "448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475th = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,475"
+              (cl-format nil "~:R = ~:*~:D" 448790329480948209384389429384029384029842098420989842094490320942058747587584758375847593471)
+              "448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,471st = 448,790,329,480,948,209,384,389,429,384,029,384,029,842,098,420,989,842,094,490,320,942,058,747,587,584,758,375,847,593,471"
+              (cl-format nil "~:R = ~:*~:D" 2e6)
+              "two millionth = 2,000,000")
 
 (simple-tests ordinal1-tests
-  (cl-format nil "~:R" 1) "first"
-  (cl-format nil "~:R" 11) "eleventh"
-  (cl-format nil "~:R" 21) "twenty-first"
-  (cl-format nil "~:R" 20) "twentieth"
-  (cl-format nil "~:R" 220) "two hundred twentieth"
-  (cl-format nil "~:R" 200) "two hundredth"
-  (cl-format nil "~:R" 999) "nine hundred ninety-ninth"
-  )
+              (cl-format nil "~:R" 1) "first"
+              (cl-format nil "~:R" 11) "eleventh"
+              (cl-format nil "~:R" 21) "twenty-first"
+              (cl-format nil "~:R" 20) "twentieth"
+              (cl-format nil "~:R" 220) "two hundred twentieth"
+              (cl-format nil "~:R" 200) "two hundredth"
+              (cl-format nil "~:R" 999) "nine hundred ninety-ninth")
 
 (simple-tests roman-tests
-  (cl-format nil "~@R" 3) "III"
-  (cl-format nil "~@R" 4) "IV"
-  (cl-format nil "~@R" 9) "IX"
-  (cl-format nil "~@R" 29) "XXIX"
-  (cl-format nil "~@R" 429) "CDXXIX"
-  (cl-format nil "~@:R" 429) "CCCCXXVIIII"
-  (cl-format nil "~@:R" 3429) "MMMCCCCXXVIIII"
-  (cl-format nil "~@R" 3429) "MMMCDXXIX"
-  (cl-format nil "~@R" 3479) "MMMCDLXXIX"
-  (cl-format nil "~@R" 3409) "MMMCDIX"
-  (cl-format nil "~@R" 300) "CCC"
-  (cl-format nil "~@R ~D" 300 20) "CCC 20"
-  (cl-format nil "~@R" 5000) "5,000"
-  (cl-format nil "~@R ~D" 5000 20) "5,000 20"
-  (cl-format nil "~@R" "the quick") "the quick")
+              (cl-format nil "~@R" 3) "III"
+              (cl-format nil "~@R" 4) "IV"
+              (cl-format nil "~@R" 9) "IX"
+              (cl-format nil "~@R" 29) "XXIX"
+              (cl-format nil "~@R" 429) "CDXXIX"
+              (cl-format nil "~@:R" 429) "CCCCXXVIIII"
+              (cl-format nil "~@:R" 3429) "MMMCCCCXXVIIII"
+              (cl-format nil "~@R" 3429) "MMMCDXXIX"
+              (cl-format nil "~@R" 3479) "MMMCDLXXIX"
+              (cl-format nil "~@R" 3409) "MMMCDIX"
+              (cl-format nil "~@R" 300) "CCC"
+              (cl-format nil "~@R ~D" 300 20) "CCC 20"
+              (cl-format nil "~@R" 5000) "5,000"
+              (cl-format nil "~@R ~D" 5000 20) "5,000 20"
+              (cl-format nil "~@R" "the quick") "the quick")
 
 (simple-tests c-tests
-  (cl-format nil "~{~c~^, ~}~%" "hello") "h, e, l, l, o\n"
-  (cl-format nil "~{~:c~^, ~}~%" "hello") "h, e, l, l, o\n"
-  (cl-format nil "~@C~%" \m) "\\m\n"
-  (cl-format nil "~@C~%" (char 222)) "\\Þ\n"
-  (cl-format nil "~@C~%" (char 8)) "\\backspace\n"
-  (cl-format nil "~@C~%" (char 3)) "\\\n")
+              (cl-format nil "~{~c~^, ~}~%" "hello") "h, e, l, l, o\n"
+              (cl-format nil "~{~:c~^, ~}~%" "hello") "h, e, l, l, o\n"
+              (cl-format nil "~@C~%" \m) "\\m\n"
+              (cl-format nil "~@C~%" (char 222)) "\\Þ\n"
+              (cl-format nil "~@C~%" (char 8)) "\\backspace\n"
+              (cl-format nil "~@C~%" (char 3)) "\\\n")
 
 (simple-tests e-tests
-  (cl-format nil "*~E*" 0.0) "*0.0E+0*"
-  (cl-format nil "*~6E*" 0.0) "*0.0E+0*"
-  (cl-format nil "*~6,0E*" 0.0) "* 0.E+0*"
-  (cl-format nil "*~7,2E*" 0.0) "*0.00E+0*"
-  (cl-format nil "*~5E*" 0.0) "*0.E+0*"
-  (cl-format nil "*~10,2,2,,'?E*" 2.8E120) "*??????????*"
-  (cl-format nil "*~10,2E*" 9.99999) "*   1.00E+1*"
-  (cl-format nil "*~10,2E*" 9.99999E99) "* 1.00E+100*"
-  (cl-format nil "*~10,2,2E*" 9.99999E99) "* 1.00E+100*"
-  (cl-format nil "*~10,2,2,,'?E*" 9.99999E99) "*??????????*"
-  )
-  
+              (cl-format nil "*~E*" 0.0) "*0.0E+0*"
+              (cl-format nil "*~6E*" 0.0) "*0.0E+0*"
+              (cl-format nil "*~6,0E*" 0.0) "* 0.E+0*"
+              (cl-format nil "*~7,2E*" 0.0) "*0.00E+0*"
+              (cl-format nil "*~5E*" 0.0) "*0.E+0*"
+              (cl-format nil "*~10,2,2,,'?E*" 2.8E120) "*??????????*"
+              (cl-format nil "*~10,2E*" 9.99999) "*   1.00E+1*"
+              (cl-format nil "*~10,2E*" 9.99999E99) "* 1.00E+100*"
+              (cl-format nil "*~10,2,2E*" 9.99999E99) "* 1.00E+100*"
+              (cl-format nil "*~10,2,2,,'?E*" 9.99999E99) "*??????????*")
+
 (simple-tests $-tests
-  (cl-format nil "~$" 22.3) "22.30"
-  (cl-format nil "~$" 22.375) "22.38"
-  (cl-format nil "~3,5$" 22.375) "00022.375"
-  (cl-format nil "~3,5,8$" 22.375) "00022.375"
-  (cl-format nil "~3,5,10$" 22.375) " 00022.375"
-  (cl-format nil "~3,5,14@$" 22.375) "    +00022.375"
-  (cl-format nil "~3,5,14@$" 22.375) "    +00022.375"
-  (cl-format nil "~3,5,14@:$" 22.375) "+    00022.375"
-  (cl-format nil "~3,,14@:$" 0.375) "+        0.375"
-  (cl-format nil "~1,1$" -12.0) "-12.0"
-  (cl-format nil "~1,1$" 12.0) "12.0"
-  (cl-format nil "~1,1$" 12.0) "12.0"
-  (cl-format nil "~1,1@$" 12.0) "+12.0"
-  (cl-format nil "~1,1,8,' @:$" 12.0) "+   12.0"
-  (cl-format nil "~1,1,8,' @$" 12.0) "   +12.0"
-  (cl-format nil "~1,1,8,' :$" 12.0) "    12.0"
-  (cl-format nil "~1,1,8,' $" 12.0) "    12.0"
-  (cl-format nil "~1,1,8,' @:$" -12.0) "-   12.0"
-  (cl-format nil "~1,1,8,' @$" -12.0) "   -12.0"
-  (cl-format nil "~1,1,8,' :$" -12.0) "-   12.0"
-  (cl-format nil "~1,1,8,' $" -12.0) "   -12.0"
-  (cl-format nil "~1,1$" 0.001) "0.0"
-  (cl-format nil "~2,1$" 0.001) "0.00"
-  (cl-format nil "~1,1,6$" 0.001) "   0.0"
-  (cl-format nil "~1,1,6$" 0.0015) "   0.0"
-  (cl-format nil "~2,1,6$" 0.005) "  0.01"
-  (cl-format nil "~2,1,6$" 0.01) "  0.01"
-  (cl-format nil "~$" 0.099) "0.10"
-  (cl-format nil "~1$" 0.099) "0.1"
-  (cl-format nil "~1$" 0.1) "0.1"
-  (cl-format nil "~1$" 0.99) "1.0"
-  (cl-format nil "~1$" -0.99) "-1.0")
+              (cl-format nil "~$" 22.3) "22.30"
+              (cl-format nil "~$" 22.375) "22.38"
+              (cl-format nil "~3,5$" 22.375) "00022.375"
+              (cl-format nil "~3,5,8$" 22.375) "00022.375"
+              (cl-format nil "~3,5,10$" 22.375) " 00022.375"
+              (cl-format nil "~3,5,14@$" 22.375) "    +00022.375"
+              (cl-format nil "~3,5,14@$" 22.375) "    +00022.375"
+              (cl-format nil "~3,5,14@:$" 22.375) "+    00022.375"
+              (cl-format nil "~3,,14@:$" 0.375) "+        0.375"
+              (cl-format nil "~1,1$" -12.0) "-12.0"
+              (cl-format nil "~1,1$" 12.0) "12.0"
+              (cl-format nil "~1,1$" 12.0) "12.0"
+              (cl-format nil "~1,1@$" 12.0) "+12.0"
+              (cl-format nil "~1,1,8,' @:$" 12.0) "+   12.0"
+              (cl-format nil "~1,1,8,' @$" 12.0) "   +12.0"
+              (cl-format nil "~1,1,8,' :$" 12.0) "    12.0"
+              (cl-format nil "~1,1,8,' $" 12.0) "    12.0"
+              (cl-format nil "~1,1,8,' @:$" -12.0) "-   12.0"
+              (cl-format nil "~1,1,8,' @$" -12.0) "   -12.0"
+              (cl-format nil "~1,1,8,' :$" -12.0) "-   12.0"
+              (cl-format nil "~1,1,8,' $" -12.0) "   -12.0"
+              (cl-format nil "~1,1$" 0.001) "0.0"
+              (cl-format nil "~2,1$" 0.001) "0.00"
+              (cl-format nil "~1,1,6$" 0.001) "   0.0"
+              (cl-format nil "~1,1,6$" 0.0015) "   0.0"
+              (cl-format nil "~2,1,6$" 0.005) "  0.01"
+              (cl-format nil "~2,1,6$" 0.01) "  0.01"
+              (cl-format nil "~$" 0.099) "0.10"
+              (cl-format nil "~1$" 0.099) "0.1"
+              (cl-format nil "~1$" 0.1) "0.1"
+              (cl-format nil "~1$" 0.99) "1.0"
+              (cl-format nil "~1$" -0.99) "-1.0")
 
 (simple-tests f-tests
-  (cl-format nil "~,1f" -12.0) "-12.0"
-  (cl-format nil "~,0f" 9.4) "9."
-  (cl-format nil "~,0f" 9.5) "10."
-  (cl-format nil "~,0f" -0.99) "-1."
-  (cl-format nil "~,1f" -0.99) "-1.0"
-  (cl-format nil "~,2f" -0.99) "-0.99"
-  (cl-format nil "~,3f" -0.99) "-0.990"
-  (cl-format nil "~,0f" 0.99) "1."
-  (cl-format nil "~,1f" 0.99) "1.0"
-  (cl-format nil "~,2f" 0.99) "0.99"
-  (cl-format nil "~,3f" 0.99) "0.990"
-  (cl-format nil "~,3f" -0.099) "-0.099"
-  (cl-format nil "~,4f" -0.099) "-0.0990"
-  (cl-format nil "~,5f" -0.099) "-0.09900"
-  (cl-format nil "~,3f" 0.099) "0.099"
-  (cl-format nil "~,4f" 0.099) "0.0990"
-  (cl-format nil "~,5f" 0.099) "0.09900"
-  (cl-format nil "~f" -1) "-1.0"
-  (cl-format nil "~2f" -1) "-1."
-  (cl-format nil "~3f" -1) "-1."
-  (cl-format nil "~4f" -1) "-1.0"
-  (cl-format nil "~8f" -1) "    -1.0"
-  (cl-format nil "~2f" -0.0099) "-0."
-  (cl-format nil "~3f" -0.0099) "-0."
-  (cl-format nil "~4f" -0.0099) "-.01"
-  (cl-format nil "~5f" -0.0099) "-0.01"
-  (cl-format nil "~6f" -0.0099) "-.0099"
-  (cl-format nil "~1f" 0.0099) "0."
-  (cl-format nil "~2f" 0.0099) "0."
-  (cl-format nil "~3f" 0.0099) ".01"
-  (cl-format nil "~4f" 0.0099) "0.01"
-  (cl-format nil "~5f" 0.0099) ".0099"
-  (cl-format nil "~6f" 0.0099) "0.0099"
-  (cl-format nil "~1f" -0.099) "-.1"
-  (cl-format nil "~2f" -0.099) "-.1"
-  (cl-format nil "~3f" -0.099) "-.1"
-  (cl-format nil "~4f" -0.099) "-0.1"
-  (cl-format nil "~5f" -0.099) "-.099"
-  (cl-format nil "~6f" -0.099) "-0.099"
-  (cl-format nil "~1f" 0.099) ".1"
-  (cl-format nil "~2f" 0.099) ".1"
-  (cl-format nil "~3f" 0.099) "0.1"
-  (cl-format nil "~4f" 0.099) ".099"
-  (cl-format nil "~5f" 0.099) "0.099"
-  (cl-format nil "~1f" -0.99) "-1."
-  (cl-format nil "~2f" -0.99) "-1."
-  (cl-format nil "~3f" -0.99) "-1."
-  (cl-format nil "~4f" -0.99) "-.99"
-  (cl-format nil "~5f" -0.99) "-0.99"
-  (cl-format nil "~1f" 0.99) "1."
-  (cl-format nil "~2f" 0.99) "1."
-  (cl-format nil "~3f" 0.99) ".99"
-  (cl-format nil "~4f" 0.99) "0.99"
-  (cl-format nil "~1f" 111.11111) "111."
-  (cl-format nil "~4f" 111.11111) "111."
-  (cl-format nil "~5f" 111.11111) "111.1"
-  (cl-format nil "~1f" -111.11111) "-111."
-  (cl-format nil "~5f" -111.11111) "-111."
-  (cl-format nil "~6f" -111.11111) "-111.1"
-  (cl-format nil "~1f" 555.55555) "556."
-  (cl-format nil "~4f" 555.55555) "556."
-  (cl-format nil "~5f" 555.55555) "555.6"
-  (cl-format nil "~8f" 555.55555) "555.5556"
-  (cl-format nil "~1f" -555.55555) "-556."
-  (cl-format nil "~5f" -555.55555) "-556."
-  (cl-format nil "~6f" -555.55555) "-555.6"
-  (cl-format nil "~8f" -555.55555) "-555.556"
-  (cl-format nil "~1f" 999.999) "1000."
-  (cl-format nil "~5f" 999.999) "1000."
-  (cl-format nil "~6f" 999.999) "1000.0"
-  (cl-format nil "~7f" 999.999) "999.999"
-  (cl-format nil "~8f" 999.999) " 999.999"
-  (cl-format nil "~1f" -999.999) "-1000."
-  (cl-format nil "~6f" -999.999) "-1000."
-  (cl-format nil "~7f" -999.999) "-1000.0"
-  (cl-format nil "~8f" -999.999) "-999.999"
-  (cl-format nil "~5,2f" 111.11111) "111.11"
-  (cl-format nil "~3,1f" -0.0099) "-.0"
-  (cl-format nil "~6,4f" -0.0099) "-.0099"
-  (cl-format nil "~6,5f" -0.0099) "-.00990"
-  (cl-format nil "~6,6f" -0.0099) "-.009900"
-  (cl-format nil "~6,4f" 0.0099) "0.0099"
-  (cl-format nil "~6,5f" 0.0099) ".00990"
-  (cl-format nil "~6,6f" 0.0099) ".009900"
-  (cl-format nil "~2,1f" 0.0099) ".0"
-  (cl-format nil "~6,2f" -111.11111) "-111.11"
-  (cl-format nil "~6,3f" -111.11111) "-111.111"
-  (cl-format nil "~8,5f" -111.11111) "-111.11111"
-  (cl-format nil "~12,10f" 1.23456789014) "1.2345678901"
-  (cl-format nil "~12,10f" 1.23456789016) "1.2345678902"
-  (cl-format nil "~13,10f" -1.23456789014) "-1.2345678901"
-  (cl-format nil "~13,10f" -1.23456789016) "-1.2345678902"
-  (cl-format nil "~1,1f" 0.1) ".1")
+              (cl-format nil "~,1f" -12.0) "-12.0"
+              (cl-format nil "~,0f" 9.4) "9."
+              (cl-format nil "~,0f" 9.5) "10."
+              (cl-format nil "~,0f" -0.99) "-1."
+              (cl-format nil "~,1f" -0.99) "-1.0"
+              (cl-format nil "~,2f" -0.99) "-0.99"
+              (cl-format nil "~,3f" -0.99) "-0.990"
+              (cl-format nil "~,0f" 0.99) "1."
+              (cl-format nil "~,1f" 0.99) "1.0"
+              (cl-format nil "~,2f" 0.99) "0.99"
+              (cl-format nil "~,3f" 0.99) "0.990"
+              (cl-format nil "~,3f" -0.099) "-0.099"
+              (cl-format nil "~,4f" -0.099) "-0.0990"
+              (cl-format nil "~,5f" -0.099) "-0.09900"
+              (cl-format nil "~,3f" 0.099) "0.099"
+              (cl-format nil "~,4f" 0.099) "0.0990"
+              (cl-format nil "~,5f" 0.099) "0.09900"
+              (cl-format nil "~f" -1) "-1.0"
+              (cl-format nil "~2f" -1) "-1."
+              (cl-format nil "~3f" -1) "-1."
+              (cl-format nil "~4f" -1) "-1.0"
+              (cl-format nil "~8f" -1) "    -1.0"
+              (cl-format nil "~2f" -0.0099) "-0."
+              (cl-format nil "~3f" -0.0099) "-0."
+              (cl-format nil "~4f" -0.0099) "-.01"
+              (cl-format nil "~5f" -0.0099) "-0.01"
+              (cl-format nil "~6f" -0.0099) "-.0099"
+              (cl-format nil "~1f" 0.0099) "0."
+              (cl-format nil "~2f" 0.0099) "0."
+              (cl-format nil "~3f" 0.0099) ".01"
+              (cl-format nil "~4f" 0.0099) "0.01"
+              (cl-format nil "~5f" 0.0099) ".0099"
+              (cl-format nil "~6f" 0.0099) "0.0099"
+              (cl-format nil "~1f" -0.099) "-.1"
+              (cl-format nil "~2f" -0.099) "-.1"
+              (cl-format nil "~3f" -0.099) "-.1"
+              (cl-format nil "~4f" -0.099) "-0.1"
+              (cl-format nil "~5f" -0.099) "-.099"
+              (cl-format nil "~6f" -0.099) "-0.099"
+              (cl-format nil "~1f" 0.099) ".1"
+              (cl-format nil "~2f" 0.099) ".1"
+              (cl-format nil "~3f" 0.099) "0.1"
+              (cl-format nil "~4f" 0.099) ".099"
+              (cl-format nil "~5f" 0.099) "0.099"
+              (cl-format nil "~1f" -0.99) "-1."
+              (cl-format nil "~2f" -0.99) "-1."
+              (cl-format nil "~3f" -0.99) "-1."
+              (cl-format nil "~4f" -0.99) "-.99"
+              (cl-format nil "~5f" -0.99) "-0.99"
+              (cl-format nil "~1f" 0.99) "1."
+              (cl-format nil "~2f" 0.99) "1."
+              (cl-format nil "~3f" 0.99) ".99"
+              (cl-format nil "~4f" 0.99) "0.99"
+              (cl-format nil "~1f" 111.11111) "111."
+              (cl-format nil "~4f" 111.11111) "111."
+              (cl-format nil "~5f" 111.11111) "111.1"
+              (cl-format nil "~1f" -111.11111) "-111."
+              (cl-format nil "~5f" -111.11111) "-111."
+              (cl-format nil "~6f" -111.11111) "-111.1"
+              (cl-format nil "~1f" 555.55555) "556."
+              (cl-format nil "~4f" 555.55555) "556."
+              (cl-format nil "~5f" 555.55555) "555.6"
+              (cl-format nil "~8f" 555.55555) "555.5556"
+              (cl-format nil "~1f" -555.55555) "-556."
+              (cl-format nil "~5f" -555.55555) "-556."
+              (cl-format nil "~6f" -555.55555) "-555.6"
+              (cl-format nil "~8f" -555.55555) "-555.556"
+              (cl-format nil "~1f" 999.999) "1000."
+              (cl-format nil "~5f" 999.999) "1000."
+              (cl-format nil "~6f" 999.999) "1000.0"
+              (cl-format nil "~7f" 999.999) "999.999"
+              (cl-format nil "~8f" 999.999) " 999.999"
+              (cl-format nil "~1f" -999.999) "-1000."
+              (cl-format nil "~6f" -999.999) "-1000."
+              (cl-format nil "~7f" -999.999) "-1000.0"
+              (cl-format nil "~8f" -999.999) "-999.999"
+              (cl-format nil "~5,2f" 111.11111) "111.11"
+              (cl-format nil "~3,1f" -0.0099) "-.0"
+              (cl-format nil "~6,4f" -0.0099) "-.0099"
+              (cl-format nil "~6,5f" -0.0099) "-.00990"
+              (cl-format nil "~6,6f" -0.0099) "-.009900"
+              (cl-format nil "~6,4f" 0.0099) "0.0099"
+              (cl-format nil "~6,5f" 0.0099) ".00990"
+              (cl-format nil "~6,6f" 0.0099) ".009900"
+              (cl-format nil "~2,1f" 0.0099) ".0"
+              (cl-format nil "~6,2f" -111.11111) "-111.11"
+              (cl-format nil "~6,3f" -111.11111) "-111.111"
+              (cl-format nil "~8,5f" -111.11111) "-111.11111"
+              (cl-format nil "~12,10f" 1.23456789014) "1.2345678901"
+              (cl-format nil "~12,10f" 1.23456789016) "1.2345678902"
+              (cl-format nil "~13,10f" -1.23456789014) "-1.2345678901"
+              (cl-format nil "~13,10f" -1.23456789016) "-1.2345678902"
+              (cl-format nil "~1,1f" 0.1) ".1")
 
 (simple-tests ampersand-tests
-  (cl-format nil "The quick brown ~a jumped over ~d lazy dogs" 'elephant 5)
-  "The quick brown elephant jumped over 5 lazy dogs"
-  (cl-format nil "The quick brown ~&~a jumped over ~d lazy dogs" 'elephant 5)
-  "The quick brown \nelephant jumped over 5 lazy dogs"
-  (cl-format nil (platform-newlines "The quick brown ~&~a jumped\n~& over ~d lazy dogs") 'elephant 5)
-  "The quick brown \nelephant jumped\n over 5 lazy dogs"
-  (cl-format nil (platform-newlines "~&The quick brown ~&~a jumped\n~& over ~d lazy dogs") 'elephant 5)
-  "The quick brown \nelephant jumped\n over 5 lazy dogs"
-  (cl-format nil (platform-newlines "~3&The quick brown ~&~a jumped\n~& over ~d lazy dogs") 'elephant 5)
-  "\n\nThe quick brown \nelephant jumped\n over 5 lazy dogs"
-  (cl-format nil "~@{~&The quick brown ~a jumped over ~d lazy dogs~}" 'elephant 5 'fox 10)
-  "The quick brown elephant jumped over 5 lazy dogs\nThe quick brown fox jumped over 10 lazy dogs"
-  (cl-format nil "I ~[don't ~:;d~&o ~]have one~%" 0) "I don't have one\n"
-  (cl-format nil "I ~[don't ~:;d~&o ~]have one~%" 1) "I d\no have one\n")
+              (cl-format nil "The quick brown ~a jumped over ~d lazy dogs" 'elephant 5)
+              "The quick brown elephant jumped over 5 lazy dogs"
+              (cl-format nil "The quick brown ~&~a jumped over ~d lazy dogs" 'elephant 5)
+              "The quick brown \nelephant jumped over 5 lazy dogs"
+              (cl-format nil (platform-newlines "The quick brown ~&~a jumped\n~& over ~d lazy dogs") 'elephant 5)
+              "The quick brown \nelephant jumped\n over 5 lazy dogs"
+              (cl-format nil (platform-newlines "~&The quick brown ~&~a jumped\n~& over ~d lazy dogs") 'elephant 5)
+              "The quick brown \nelephant jumped\n over 5 lazy dogs"
+              (cl-format nil (platform-newlines "~3&The quick brown ~&~a jumped\n~& over ~d lazy dogs") 'elephant 5)
+              "\n\nThe quick brown \nelephant jumped\n over 5 lazy dogs"
+              (cl-format nil "~@{~&The quick brown ~a jumped over ~d lazy dogs~}" 'elephant 5 'fox 10)
+              "The quick brown elephant jumped over 5 lazy dogs\nThe quick brown fox jumped over 10 lazy dogs"
+              (cl-format nil "I ~[don't ~:;d~&o ~]have one~%" 0) "I don't have one\n"
+              (cl-format nil "I ~[don't ~:;d~&o ~]have one~%" 1) "I d\no have one\n")
 
 (simple-tests t-tests
-  (cl-format nil "~@{~&~A~8,4T~:*~A~}" 
-             'a 'aa 'aaa 'aaaa 'aaaaa 'aaaaaa 'aaaaaaa 'aaaaaaaa 'aaaaaaaaa 'aaaaaaaaaa)
-  "a       a\naa      aa\naaa     aaa\naaaa    aaaa\naaaaa   aaaaa\naaaaaa  aaaaaa\naaaaaaa aaaaaaa\naaaaaaaa    aaaaaaaa\naaaaaaaaa   aaaaaaaaa\naaaaaaaaaa  aaaaaaaaaa"
-  (cl-format nil "~@{~&~A~,4T~:*~A~}" 
-             'a 'aa 'aaa 'aaaa 'aaaaa 'aaaaaa 'aaaaaaa 'aaaaaaaa 'aaaaaaaaa 'aaaaaaaaaa)
-  "a    a\naa   aa\naaa  aaa\naaaa aaaa\naaaaa    aaaaa\naaaaaa   aaaaaa\naaaaaaa  aaaaaaa\naaaaaaaa aaaaaaaa\naaaaaaaaa    aaaaaaaaa\naaaaaaaaaa   aaaaaaaaaa"
-  (cl-format nil "~@{~&~A~2,6@T~:*~A~}" 'a 'aa 'aaa 'aaaa 'aaaaa 'aaaaaa 'aaaaaaa 'aaaaaaaa 'aaaaaaaaa 'aaaaaaaaaa)
-  "a     a\naa    aa\naaa   aaa\naaaa  aaaa\naaaaa       aaaaa\naaaaaa      aaaaaa\naaaaaaa     aaaaaaa\naaaaaaaa    aaaaaaaa\naaaaaaaaa   aaaaaaaaa\naaaaaaaaaa  aaaaaaaaaa"
-)
-
-(simple-tests paren-tests
-  (cl-format nil "~(PLEASE SPEAK QUIETLY IN HERE~)") "please speak quietly in here"
-  (cl-format nil "~@(PLEASE SPEAK QUIETLY IN HERE~)") "Please speak quietly in here"
-  (cl-format nil "~@:(but this Is imporTant~)") "BUT THIS IS IMPORTANT"
-  (cl-format nil "~:(the greAt gatsby~)!") "The Great Gatsby!"
+              (cl-format nil "~@{~&~A~8,4T~:*~A~}"
+                         'a 'aa 'aaa 'aaaa 'aaaaa 'aaaaaa 'aaaaaaa 'aaaaaaaa 'aaaaaaaaa 'aaaaaaaaaa)
+              "a       a\naa      aa\naaa     aaa\naaaa    aaaa\naaaaa   aaaaa\naaaaaa  aaaaaa\naaaaaaa aaaaaaa\naaaaaaaa    aaaaaaaa\naaaaaaaaa   aaaaaaaaa\naaaaaaaaaa  aaaaaaaaaa"
+              (cl-format nil "~@{~&~A~,4T~:*~A~}"
+                         'a 'aa 'aaa 'aaaa 'aaaaa 'aaaaaa 'aaaaaaa 'aaaaaaaa 'aaaaaaaaa 'aaaaaaaaaa)
+              "a    a\naa   aa\naaa  aaa\naaaa aaaa\naaaaa    aaaaa\naaaaaa   aaaaaa\naaaaaaa  aaaaaaa\naaaaaaaa aaaaaaaa\naaaaaaaaa    aaaaaaaaa\naaaaaaaaaa   aaaaaaaaaa"
+              (cl-format nil "~@{~&~A~2,6@T~:*~A~}" 'a 'aa 'aaa 'aaaa 'aaaaa 'aaaaaa 'aaaaaaa 'aaaaaaaa 'aaaaaaaaa 'aaaaaaaaaa)
+              "a     a\naa    aa\naaa   aaa\naaaa  aaaa\naaaaa       aaaaa\naaaaaa      aaaaaa\naaaaaaa     aaaaaaa\naaaaaaaa    aaaaaaaa\naaaaaaaaa   aaaaaaaaa\naaaaaaaaaa  aaaaaaaaaa") (simple-tests paren-tests
+                                                                                                                                                                                                         (cl-format nil "~(PLEASE SPEAK QUIETLY IN HERE~)") "please speak quietly in here"
+                                                                                                                                                                                                         (cl-format nil "~@(PLEASE SPEAK QUIETLY IN HERE~)") "Please speak quietly in here"
+                                                                                                                                                                                                         (cl-format nil "~@:(but this Is imporTant~)") "BUT THIS IS IMPORTANT"
+                                                                                                                                                                                                         (cl-format nil "~:(the greAt gatsby~)!") "The Great Gatsby!"
   ;; Test cases from CLtL 18.3 - string-upcase, et al.
-  (cl-format nil "~@:(~A~)" "Dr. Livingstone, I presume?") "DR. LIVINGSTONE, I PRESUME?" 
-  (cl-format nil "~(~A~)" "Dr. Livingstone, I presume?") "dr. livingstone, i presume?" 
-  (cl-format nil "~:(~A~)" " hello ") " Hello " 
-  (cl-format nil "~:(~A~)" "occlUDeD cASEmenTs FOreSTAll iNADVertent DEFenestraTION") 
-  "Occluded Casements Forestall Inadvertent Defenestration" 
-  (cl-format nil "~:(~A~)" 'kludgy-hash-search) "Kludgy-Hash-Search" 
-  (cl-format nil "~:(~A~)" "DON'T!") "Don'T!"     ;not "Don't!" 
-  (cl-format nil "~:(~A~)" "pipe 13a, foo16c") "Pipe 13a, Foo16c"
-  (cl-format nil "~:(~A~)" nil) "Nil"
-  (cl-format nil "~:(~A~)" "") ""
-)
-
-(simple-tests square-bracket-tests
+                                                                                                                                                                                                         (cl-format nil "~@:(~A~)" "Dr. Livingstone, I presume?") "DR. LIVINGSTONE, I PRESUME?"
+                                                                                                                                                                                                         (cl-format nil "~(~A~)" "Dr. Livingstone, I presume?") "dr. livingstone, i presume?"
+                                                                                                                                                                                                         (cl-format nil "~:(~A~)" " hello ") " Hello "
+                                                                                                                                                                                                         (cl-format nil "~:(~A~)" "occlUDeD cASEmenTs FOreSTAll iNADVertent DEFenestraTION")
+                                                                                                                                                                                                         "Occluded Casements Forestall Inadvertent Defenestration"
+                                                                                                                                                                                                         (cl-format nil "~:(~A~)" 'kludgy-hash-search) "Kludgy-Hash-Search"
+                                                                                                                                                                                                         (cl-format nil "~:(~A~)" "DON'T!") "Don'T!"     ;not "Don't!"
+                                                                                                                                                                                                         (cl-format nil "~:(~A~)" "pipe 13a, foo16c") "Pipe 13a, Foo16c"
+                                                                                                                                                                                                         (cl-format nil "~:(~A~)" nil) "Nil"
+                                                                                                                                                                                                         (cl-format nil "~:(~A~)" "") "") (simple-tests square-bracket-tests
   ;; Tests for format without modifiers
-  (cl-format nil "I ~[don't ~]have one~%" 0) "I don't have one\n"
-  (cl-format nil "I ~[don't ~]have one~%" 1) "I have one\n"
-  (cl-format nil "I ~[don't ~;do ~]have one~%" 0) "I don't have one\n"
-  (cl-format nil "I ~[don't ~;do ~]have one~%" 1) "I do have one\n"
-  (cl-format nil "I ~[don't ~;do ~]have one~%" 2) "I have one\n"
-  (cl-format nil "I ~[don't ~:;do ~]have one~%" 0) "I don't have one\n"
-  (cl-format nil "I ~[don't ~:;do ~]have one~%" 1) "I do have one\n"
-  (cl-format nil "I ~[don't ~:;do ~]have one~%" 2) "I do have one\n"
-  (cl-format nil "I ~[don't ~:;do ~]have one~%" 700) "I do have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~]have one~%" 0) "I don't have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~]have one~%" 1) "I have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~;do ~]have one~%" 0) "I don't have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~;do ~]have one~%" 1) "I do have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~;do ~]have one~%" 2) "I have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~:;do ~]have one~%" 0) "I don't have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~:;do ~]have one~%" 1) "I do have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~:;do ~]have one~%" 2) "I do have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~[don't ~:;do ~]have one~%" 700) "I do have one\n"
 
-  ;; Tests for format with a colon 
-  (cl-format nil "I ~:[don't ~;do ~]have one~%" true) "I do have one\n"
-  (cl-format nil "I ~:[don't ~;do ~]have one~%" 700) "I do have one\n"
-  (cl-format nil "I ~:[don't ~;do ~]have one~%" '(a b)) "I do have one\n"
-  (cl-format nil "I ~:[don't ~;do ~]have one~%" nil) "I don't have one\n"
-  (cl-format nil "I ~:[don't ~;do ~]have one~%" false) "I don't have one\n"
+  ;; Tests for format with a colon
+                                                                                                                                                                                                                                                        (cl-format nil "I ~:[don't ~;do ~]have one~%" true) "I do have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~:[don't ~;do ~]have one~%" 700) "I do have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~:[don't ~;do ~]have one~%" '(a b)) "I do have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~:[don't ~;do ~]have one~%" nil) "I don't have one\n"
+                                                                                                                                                                                                                                                        (cl-format nil "I ~:[don't ~;do ~]have one~%" false) "I don't have one\n"
 
   ;; Tests for format with an at sign
-  (cl-format nil "We had ~D wins~@[ (out of ~D tries)~].~%" 15 nil) "We had 15 wins.\n"
-  (cl-format nil "We had ~D wins~@[ (out of ~D tries)~].~%" 15 17)
-  "We had 15 wins (out of 17 tries).\n"
+                                                                                                                                                                                                                                                        (cl-format nil "We had ~D wins~@[ (out of ~D tries)~].~%" 15 nil) "We had 15 wins.\n"
+                                                                                                                                                                                                                                                        (cl-format nil "We had ~D wins~@[ (out of ~D tries)~].~%" 15 17)
+                                                                                                                                                                                                                                                        "We had 15 wins (out of 17 tries).\n"
 
   ;; Format tests with directives
-  (cl-format nil "Max ~D: ~[Blue team ~D~;Red team ~D~:;No team ~A~].~%" 15, 0, 7)
-  "Max 15: Blue team 7.\n"
-  (cl-format nil "Max ~D: ~[Blue team ~D~;Red team ~D~:;No team ~A~].~%" 15, 1, 12)
-  "Max 15: Red team 12.\n"
-  (cl-format nil "Max ~D: ~[Blue team ~D~;Red team ~D~:;No team ~A~].~%" 
-             15, -1, "(system failure)")
-  "Max 15: No team (system failure).\n"
+                                                                                                                                                                                                                                                        (cl-format nil "Max ~D: ~[Blue team ~D~;Red team ~D~:;No team ~A~].~%" 15, 0, 7)
+                                                                                                                                                                                                                                                        "Max 15: Blue team 7.\n"
+                                                                                                                                                                                                                                                        (cl-format nil "Max ~D: ~[Blue team ~D~;Red team ~D~:;No team ~A~].~%" 15, 1, 12)
+                                                                                                                                                                                                                                                        "Max 15: Red team 12.\n"
+                                                                                                                                                                                                                                                        (cl-format nil "Max ~D: ~[Blue team ~D~;Red team ~D~:;No team ~A~].~%"
+                                                                                                                                                                                                                                                                   15, -1, "(system failure)")
+                                                                                                                                                                                                                                                        "Max 15: No team (system failure).\n"
 
   ;; Nested format tests
-  (cl-format nil "Max ~D: ~[Blue team ~D~:[~; (complete success)~]~;Red team ~D~:;No team ~].~%" 
-             15, 0, 7, true)
-  "Max 15: Blue team 7 (complete success).\n"
-  (cl-format nil "Max ~D: ~[Blue team ~D~:[~; (complete success)~]~;Red team ~D~:;No team ~].~%" 
-             15, 0, 7, false)
-  "Max 15: Blue team 7.\n"
+                                                                                                                                                                                                                                                        (cl-format nil "Max ~D: ~[Blue team ~D~:[~; (complete success)~]~;Red team ~D~:;No team ~].~%"
+                                                                                                                                                                                                                                                                   15, 0, 7, true)
+                                                                                                                                                                                                                                                        "Max 15: Blue team 7 (complete success).\n"
+                                                                                                                                                                                                                                                        (cl-format nil "Max ~D: ~[Blue team ~D~:[~; (complete success)~]~;Red team ~D~:;No team ~].~%"
+                                                                                                                                                                                                                                                                   15, 0, 7, false)
+                                                                                                                                                                                                                                                        "Max 15: Blue team 7.\n"
 
   ;; Test the selector as part of the argument
-  (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~].")
-  "The answer is nothing."
-  (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~]." 4)
-  "The answer is 4."
-  (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~]." 7 22)
-  "The answer is 7 out of 22."
-  (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~]." 1 2 3 4)
-  "The answer is something crazy."
-)
-
-(simple-tests curly-brace-plain-tests
+                                                                                                                                                                                                                                                        (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~].")
+                                                                                                                                                                                                                                                        "The answer is nothing."
+                                                                                                                                                                                                                                                        (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~]." 4)
+                                                                                                                                                                                                                                                        "The answer is 4."
+                                                                                                                                                                                                                                                        (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~]." 7 22)
+                                                                                                                                                                                                                                                        "The answer is 7 out of 22."
+                                                                                                                                                                                                                                                        (cl-format nil "The answer is ~#[nothing~;~D~;~D out of ~D~:;something crazy~]." 1 2 3 4)
+                                                                                                                                                                                                                                                        "The answer is something crazy.") (simple-tests curly-brace-plain-tests
   ;; Iteration from sublist
-  (cl-format nil "Coordinates are~{ [~D,~D]~}~%" [ 0, 1, 1, 0, 3, 5, 2, 1 ])
-  "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~{ [~D,~D]~}~%" [0, 1, 1, 0, 3, 5, 2, 1])
+                                                                                                                                                                                                                                                                                                        "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
 
-  (cl-format nil "Coordinates are~2{ [~D,~D]~}~%" [ 0, 1, 1, 0, 3, 5, 2, 1 ])
-  "Coordinates are [0,1] [1,0]\n"
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~2{ [~D,~D]~}~%" [0, 1, 1, 0, 3, 5, 2, 1])
+                                                                                                                                                                                                                                                                                                        "Coordinates are [0,1] [1,0]\n"
 
-  (cl-format nil "Coordinates are~{ ~#[none~;<~D>~:;[~D,~D]~]~}~%" [ ])
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~{ ~#[none~;<~D>~:;[~D,~D]~]~}~%" [])
+                                                                                                                                                                                                                                                                                                        "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [ ])
-  "Coordinates are none\n"
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [])
+                                                                                                                                                                                                                                                                                                        "Coordinates are none\n"
 
-  (cl-format nil "Coordinates are~{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [2 3 1])
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [2 3 1])
+                                                                                                                                                                                                                                                                                                        "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~{~:}~%" "" [])
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~{~:}~%" "" [])
+                                                                                                                                                                                                                                                                                                        "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [2 3 1])
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [2 3 1])
+                                                                                                                                                                                                                                                                                                        "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [ ])
-  "Coordinates are none\n"
-)
-
-
-(simple-tests curly-brace-colon-tests
+                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [])
+                                                                                                                                                                                                                                                                                                        "Coordinates are none\n") (simple-tests curly-brace-colon-tests
   ;; Iteration from list of sublists
-  (cl-format nil "Coordinates are~:{ [~D,~D]~}~%" [ [0, 1], [1, 0], [3, 5], [2, 1] ])
-  "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{ [~D,~D]~}~%" [[0, 1], [1, 0], [3, 5], [2, 1]])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
 
-  (cl-format nil "Coordinates are~:{ [~D,~D]~}~%" [ [0, 1, 0], [1, 0, 12], [3, 5], [2, 1] ])
-  "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{ [~D,~D]~}~%" [[0, 1, 0], [1, 0, 12], [3, 5], [2, 1]])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
 
-  (cl-format nil "Coordinates are~2:{ [~D,~D]~}~%" [ [0, 1], [1, 0], [3, 5], [2, 1] ])
-  "Coordinates are [0,1] [1,0]\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~2:{ [~D,~D]~}~%" [[0, 1], [1, 0], [3, 5], [2, 1]])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are [0,1] [1,0]\n"
 
-  (cl-format nil "Coordinates are~:{ ~#[none~;<~D>~:;[~D,~D]~]~}~%" [ ])
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{ ~#[none~;<~D>~:;[~D,~D]~]~}~%" [])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [ ])
-  "Coordinates are none\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are none\n"
 
-  (cl-format nil "Coordinates are~:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [[2 3] [1]])
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [[2 3] [1]])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~:{~:}~%" "" [])
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{~:}~%" "" [])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [[2 3] [1]])
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [[2 3] [1]])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [ ])
-  "Coordinates are none\n"
-)
-
-(simple-tests curly-brace-at-tests
+                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [])
+                                                                                                                                                                                                                                                                                                                                                "Coordinates are none\n") (simple-tests curly-brace-at-tests
   ;; Iteration from main list
-  (cl-format nil "Coordinates are~@{ [~D,~D]~}~%"  0, 1, 1, 0, 3, 5, 2, 1)
-  "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~@{ [~D,~D]~}~%"  0, 1, 1, 0, 3, 5, 2, 1)
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
 
-  (cl-format nil "Coordinates are~2@{ [~D,~D]~}~%" 0, 1, 1, 0, 3, 5, 2, 1)
-  "Coordinates are [0,1] [1,0]\n"
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~2@{ [~D,~D]~}~%" 0, 1, 1, 0, 3, 5, 2, 1)
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are [0,1] [1,0]\n"
 
-  (cl-format nil "Coordinates are~@{ ~#[none~;<~D>~:;[~D,~D]~]~}~%")
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~@{ ~#[none~;<~D>~:;[~D,~D]~]~}~%")
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~@{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%")
-  "Coordinates are none\n"
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~@{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%")
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are none\n"
 
-  (cl-format nil "Coordinates are~@{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" 2 3 1)
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~@{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" 2 3 1)
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~@{~:}~%" "")
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~@{~:}~%" "")
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~@{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" 2 3 1)
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~@{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" 2 3 1)
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~@{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]")
-  "Coordinates are none\n"
-)
-
-(simple-tests curly-brace-colon-at-tests
+                                                                                                                                                                                                                                                                                                                                                                                        (cl-format nil "Coordinates are~@{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]")
+                                                                                                                                                                                                                                                                                                                                                                                        "Coordinates are none\n") (simple-tests curly-brace-colon-at-tests
   ;; Iteration from sublists on the main arg list
-  (cl-format nil "Coordinates are~@:{ [~D,~D]~}~%"  [0, 1], [1, 0], [3, 5], [2, 1] )
-  "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{ [~D,~D]~}~%"  [0, 1], [1, 0], [3, 5], [2, 1])
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
 
-  (cl-format nil "Coordinates are~@:{ [~D,~D]~}~%" [0, 1, 0], [1, 0, 12], [3, 5], [2, 1] )
-  "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{ [~D,~D]~}~%" [0, 1, 0], [1, 0, 12], [3, 5], [2, 1])
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are [0,1] [1,0] [3,5] [2,1]\n"
 
-  (cl-format nil "Coordinates are~2@:{ [~D,~D]~}~%" [0, 1], [1, 0], [3, 5], [2, 1])
-  "Coordinates are [0,1] [1,0]\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~2@:{ [~D,~D]~}~%" [0, 1], [1, 0], [3, 5], [2, 1])
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are [0,1] [1,0]\n"
 
-  (cl-format nil "Coordinates are~@:{ ~#[none~;<~D>~:;[~D,~D]~]~}~%")
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{ ~#[none~;<~D>~:;[~D,~D]~]~}~%")
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~@:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%")
-  "Coordinates are none\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%")
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are none\n"
 
-  (cl-format nil "Coordinates are~@:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [2 3] [1])
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{ ~#[none~;<~D>~:;[~D,~D]~]~:}~%" [2 3] [1])
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~@:{~:}~%" "")
-  "Coordinates are\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{~:}~%" "")
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are\n"
 
-  (cl-format nil "Coordinates are~@:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [2 3] [1])
-  "Coordinates are [2,3] <1>\n"
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]" [2 3] [1])
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are [2,3] <1>\n"
 
-  (cl-format nil "Coordinates are~@:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]")
-  "Coordinates are none\n"
-)
-
-;; TODO tests for ~^ in ~[ constructs and other brackets
+                                                                                                                                                                                                                                                                                                                                                                                                                                (cl-format nil "Coordinates are~@:{~:}~%" " ~#[none~;<~D>~:;[~D,~D]~]")
+                                                                                                                                                                                                                                                                                                                                                                                                                                "Coordinates are none\n");; TODO tests for ~^ in ~[ constructs and other brackets
 ;; TODO test ~:^ generates an error when used improperly
 ;; TODO test ~:^ works in ~@:{...~}
 (let [aseq '(a quick brown fox jumped over the lazy dog)
       lseq (mapcat identity (for [x aseq] [x (.length (name x))]))]
   (simple-tests up-tests
-    (cl-format nil "~{~a~^, ~}" aseq) "a, quick, brown, fox, jumped, over, the, lazy, dog"
-    (cl-format nil "~{~a~0^, ~}" aseq) "a"
-    (cl-format nil "~{~a~#,3^, ~}" aseq) "a, quick, brown, fox, jumped, over"
-    (cl-format nil "~{~a~v,3^, ~}" lseq) "a, quick, brown, fox"
-    (cl-format nil "~{~a~3,v,4^, ~}" lseq) "a, quick, brown, fox"
-))
-
-(simple-tests angle-bracket-tests
-  (cl-format nil "~<foo~;bar~;baz~>") "foobarbaz"
-  (cl-format nil "~20<foo~;bar~;baz~>") "foo      bar     baz"
-  (cl-format nil "~,,2<foo~;bar~;baz~>") "foo  bar  baz"
-  (cl-format nil "~20<~A~;~A~;~A~>" "foo" "bar" "baz") "foo      bar     baz"
-  (cl-format nil "~20:<~A~;~A~;~A~>" "foo" "bar" "baz") "    foo    bar   baz"
-  (cl-format nil "~20@<~A~;~A~;~A~>" "foo" "bar" "baz") "foo    bar    baz   "
-  (cl-format nil "~20@:<~A~;~A~;~A~>" "foo" "bar" "baz") "   foo   bar   baz  "
-  (cl-format nil "~10,,2<~A~;~A~;~A~>" "foo" "bar" "baz") "foo  bar  baz"
-  (cl-format nil "~10,10,2<~A~;~A~;~A~>" "foo" "bar" "baz") "foo      bar     baz"
-  (cl-format nil "~10,10<~A~;~A~;~A~>" "foo" "bar" "baz") "foo barbaz"
-  (cl-format nil "~20<~A~;~^~A~;~^~A~>" "foo" "bar" "baz") "foo      bar     baz"
-  (cl-format nil "~20<~A~;~^~A~;~^~A~>" "foo" "bar") "foo              bar"
-  (cl-format nil "~20@<~A~;~^~A~;~^~A~>" "foo") "foo                 "
-  (cl-format nil "~20:<~A~;~^~A~;~^~A~>" "foo") "                 foo"
-)
-
-(simple-tests angle-bracket-max-column-tests
-  (cl-format nil "~%;; ~{~<~%;; ~1,50:; ~A~>~}.~%" (into [] (.split "This function computes the circular thermodynamic coefficient of the thrombulator angle for use in determining the reaction distance" "\\s")))
-  "\n;;  This function computes the circular\n;;  thermodynamic coefficient of the thrombulator\n;;  angle for use in determining the reaction\n;;  distance.\n"
-(cl-format true "~%;; ~{~<~%;; ~:; ~A~>~}.~%" (into [] (.split "This function computes the circular thermodynamic coefficient of the thrombulator angle for use in determining the reaction distance." "\\s"))))
+                (cl-format nil "~{~a~^, ~}" aseq) "a, quick, brown, fox, jumped, over, the, lazy, dog"
+                (cl-format nil "~{~a~0^, ~}" aseq) "a"
+                (cl-format nil "~{~a~#,3^, ~}" aseq) "a, quick, brown, fox, jumped, over"
+                (cl-format nil "~{~a~v,3^, ~}" lseq) "a, quick, brown, fox"
+                (cl-format nil "~{~a~3,v,4^, ~}" lseq) "a, quick, brown, fox")) (simple-tests angle-bracket-tests
+                                                                                              (cl-format nil "~<foo~;bar~;baz~>") "foobarbaz"
+                                                                                              (cl-format nil "~20<foo~;bar~;baz~>") "foo      bar     baz"
+                                                                                              (cl-format nil "~,,2<foo~;bar~;baz~>") "foo  bar  baz"
+                                                                                              (cl-format nil "~20<~A~;~A~;~A~>" "foo" "bar" "baz") "foo      bar     baz"
+                                                                                              (cl-format nil "~20:<~A~;~A~;~A~>" "foo" "bar" "baz") "    foo    bar   baz"
+                                                                                              (cl-format nil "~20@<~A~;~A~;~A~>" "foo" "bar" "baz") "foo    bar    baz   "
+                                                                                              (cl-format nil "~20@:<~A~;~A~;~A~>" "foo" "bar" "baz") "   foo   bar   baz  "
+                                                                                              (cl-format nil "~10,,2<~A~;~A~;~A~>" "foo" "bar" "baz") "foo  bar  baz"
+                                                                                              (cl-format nil "~10,10,2<~A~;~A~;~A~>" "foo" "bar" "baz") "foo      bar     baz"
+                                                                                              (cl-format nil "~10,10<~A~;~A~;~A~>" "foo" "bar" "baz") "foo barbaz"
+                                                                                              (cl-format nil "~20<~A~;~^~A~;~^~A~>" "foo" "bar" "baz") "foo      bar     baz"
+                                                                                              (cl-format nil "~20<~A~;~^~A~;~^~A~>" "foo" "bar") "foo              bar"
+                                                                                              (cl-format nil "~20@<~A~;~^~A~;~^~A~>" "foo") "foo                 "
+                                                                                              (cl-format nil "~20:<~A~;~^~A~;~^~A~>" "foo") "                 foo") (simple-tests angle-bracket-max-column-tests
+                                                                                                                                                                                  (cl-format nil "~%;; ~{~<~%;; ~1,50:; ~A~>~}.~%" (into [] (.split "This function computes the circular thermodynamic coefficient of the thrombulator angle for use in determining the reaction distance" "\\s")))
+                                                                                                                                                                                  "\n;;  This function computes the circular\n;;  thermodynamic coefficient of the thrombulator\n;;  angle for use in determining the reaction\n;;  distance.\n"
+                                                                                                                                                                                  (cl-format true "~%;; ~{~<~%;; ~:; ~A~>~}.~%" (into [] (.split "This function computes the circular thermodynamic coefficient of the thrombulator angle for use in determining the reaction distance." "\\s"))))
 
 (defn list-to-table [aseq column-width]
   (let [stream (get-pretty-writer (java.io.StringWriter.))]
     (binding [*out* stream]
-     (doseq [row aseq]
-       (doseq [col row]
-         (cl-format true "~4D~7,vT" col column-width))
-       (prn)))
+      (doseq [row aseq]
+        (doseq [col row]
+          (cl-format true "~4D~7,vT" col column-width))
+        (prn)))
     (.flush stream)
     (.toString (:base @@(:base @@stream)))))
 
 (simple-tests column-writer-test
-  (list-to-table (map #(vector % (* % %) (* % % %)) (range 1 21)) 8)
-  "   1      1       1    \n   2      4       8    \n   3      9      27    \n   4     16      64    \n   5     25     125    \n   6     36     216    \n   7     49     343    \n   8     64     512    \n   9     81     729    \n  10    100    1000    \n  11    121    1331    \n  12    144    1728    \n  13    169    2197    \n  14    196    2744    \n  15    225    3375    \n  16    256    4096    \n  17    289    4913    \n  18    324    5832    \n  19    361    6859    \n  20    400    8000    \n")
+              (list-to-table (map #(vector % (* % %) (* % % %)) (range 1 21)) 8)
+              "   1      1       1    \n   2      4       8    \n   3      9      27    \n   4     16      64    \n   5     25     125    \n   6     36     216    \n   7     49     343    \n   8     64     512    \n   9     81     729    \n  10    100    1000    \n  11    121    1331    \n  12    144    1728    \n  13    169    2197    \n  14    196    2744    \n  15    225    3375    \n  16    256    4096    \n  17    289    4913    \n  18    324    5832    \n  19    361    6859    \n  20    400    8000    \n")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; The following tests are the various examples from the format
 ;; documentation in Common Lisp, the Language, 2nd edition, Chapter 22.3
@@ -557,36 +522,36 @@
 
 (let [x 5, y "elephant", n 3]
   (simple-tests cltl-intro-tests
-   (format nil "foo")  "foo" 
-   (format nil "The answer is ~D." x)  "The answer is 5." 
-   (format nil "The answer is ~3D." x)  "The answer is   5." 
-   (format nil "The answer is ~3,'0D." x)  "The answer is 005." 
-   (format nil "The answer is ~:D." (expt 47 x)) "The answer is 229,345,007."
-   (format nil "Look at the ~A!" y)  "Look at the elephant!" 
-   (format nil "Type ~:C to ~A." (char 4) "delete all your files") 
-   "Type Control-D to delete all your files."
-   (format nil "~D item~:P found." n)  "3 items found."
-   (format nil "~R dog~:[s are~; is~] here." n (= n 1)) "three dogs are here."
-   (format nil "~R dog~:*~[s are~; is~:;s are~] here." n) "three dogs are here."
-   (format nil "Here ~[are~;is~:;are~] ~:*~R pupp~:@P." n) "Here are three puppies."))
- 
+                (format nil "foo")  "foo"
+                (format nil "The answer is ~D." x)  "The answer is 5."
+                (format nil "The answer is ~3D." x)  "The answer is   5."
+                (format nil "The answer is ~3,'0D." x)  "The answer is 005."
+                (format nil "The answer is ~:D." (expt 47 x)) "The answer is 229,345,007."
+                (format nil "Look at the ~A!" y)  "Look at the elephant!"
+                (format nil "Type ~:C to ~A." (char 4) "delete all your files")
+                "Type Control-D to delete all your files."
+                (format nil "~D item~:P found." n)  "3 items found."
+                (format nil "~R dog~:[s are~; is~] here." n (= n 1)) "three dogs are here."
+                (format nil "~R dog~:*~[s are~; is~:;s are~] here." n) "three dogs are here."
+                (format nil "Here ~[are~;is~:;are~] ~:*~R pupp~:@P." n) "Here are three puppies."))
+
 (simple-tests cltl-B-tests
   ;; CLtL didn't have the colons here, but the spec requires them
-  (format nil "~,,' ,4:B" 0xFACE) "1111 1010 1100 1110" 
-  (format nil "~,,' ,4:B" 0x1CE) "1 1100 1110" 
-  (format nil "~19,,' ,4:B" 0xFACE) "1111 1010 1100 1110" 
+              (format nil "~,,' ,4:B" 0xFACE) "1111 1010 1100 1110"
+              (format nil "~,,' ,4:B" 0x1CE) "1 1100 1110"
+              (format nil "~19,,' ,4:B" 0xFACE) "1111 1010 1100 1110"
   ;; This one was a nice idea, but nothing in the spec supports it working this way
   ;; (and SBCL doesn't work this way either)
   ;(format nil "~19,,' ,4:B" 0x1CE) "0000 0001 1100 1110")
-  )
+)
 
 (simple-tests cltl-P-tests
-  (format nil "~D tr~:@P/~D win~:P" 7 1) "7 tries/1 win" 
-  (format nil "~D tr~:@P/~D win~:P" 1 0) "1 try/0 wins" 
-  (format nil "~D tr~:@P/~D win~:P" 1 3) "1 try/3 wins")
+              (format nil "~D tr~:@P/~D win~:P" 7 1) "7 tries/1 win"
+              (format nil "~D tr~:@P/~D win~:P" 1 0) "1 try/0 wins"
+              (format nil "~D tr~:@P/~D win~:P" 1 3) "1 try/3 wins")
 
-(defn foo [x] 
-  (format nil "~6,2F|~6,2,1,'*F|~6,2,,'?F|~6F|~,2F|~F" 
+(defn foo [x]
+  (format nil "~6,2F|~6,2,1,'*F|~6,2,,'?F|~6F|~,2F|~F"
           x x x x x x))
 
 ;; big-pos-ratio is a ratio value that is larger than
@@ -599,101 +564,101 @@
 (def tiny-neg-ratio (- tiny-pos-ratio))
 
 (simple-tests cltl-F-tests
-  (cl-format false "~10,3f" 4/5) "     0.800"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3f" big-pos-ratio)) "239692417981642093333333333333333300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3f" big-neg-ratio)) "-239692417981642093333333333333333300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3f" tiny-pos-ratio)) "     0.000"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3f" tiny-neg-ratio)) "    -0.000"
-  (foo 3.14159)  "  3.14| 31.42|  3.14|3.1416|3.14|3.14159" 
-  (foo 314159/100000)
-                 "  3.14| 31.42|  3.14|3.1416|3.14|3.14159"
-  (foo -3.14159) " -3.14|-31.42| -3.14|-3.142|-3.14|-3.14159" 
-  (foo 100.0)    "100.00|******|100.00| 100.0|100.00|100.0" 
-  (foo 1234.0)   "1234.00|******|??????|1234.0|1234.00|1234.0" 
-  (foo 0.006)    "  0.01|  0.06|  0.01| 0.006|0.01|0.006")
+              (cl-format false "~10,3f" 4/5) "     0.800"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3f" big-pos-ratio)) "239692417981642093333333333333333300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3f" big-neg-ratio)) "-239692417981642093333333333333333300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3f" tiny-pos-ratio)) "     0.000"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3f" tiny-neg-ratio)) "    -0.000"
+              (foo 3.14159)  "  3.14| 31.42|  3.14|3.1416|3.14|3.14159"
+              (foo 314159/100000)
+              "  3.14| 31.42|  3.14|3.1416|3.14|3.14159"
+              (foo -3.14159) " -3.14|-31.42| -3.14|-3.142|-3.14|-3.14159"
+              (foo 100.0)    "100.00|******|100.00| 100.0|100.00|100.0"
+              (foo 1234.0)   "1234.00|******|??????|1234.0|1234.00|1234.0"
+              (foo 0.006)    "  0.01|  0.06|  0.01| 0.006|0.01|0.006")
 
-(defn foo-e [x] 
-  (format nil 
-          "~9,2,1,,'*E|~10,3,2,2,'?,,'$E|~9,3,2,-2,'%@E|~9,2E" 
-          x x x x)) 
+(defn foo-e [x]
+  (format nil
+          "~9,2,1,,'*E|~10,3,2,2,'?,,'$E|~9,3,2,-2,'%@E|~9,2E"
+          x x x x))
 
 ;; Clojure doesn't support float/double differences in representation
 (simple-tests cltl-E-tests
-  (cl-format false "~10,3e" 4/5) "  8.000E-1"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3e" big-pos-ratio)) "2.397E+308"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3e" big-neg-ratio)) "-2.397E+308"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3e" tiny-pos-ratio)) "1.000E-340"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3e" tiny-neg-ratio)) "-1.000E-340"
-  (foo-e 0.0314159) "  3.14E-2| 31.42$-03|+.003E+01|  3.14E-2"  ; Added this one 
-  (foo-e 314159/10000000)
-                    "  3.14E-2| 31.42$-03|+.003E+01|  3.14E-2"
-  (foo-e 3.14159)  "  3.14E+0| 31.42$-01|+.003E+03|  3.14E+0" 
-  (foo-e -3.14159) " -3.14E+0|-31.42$-01|-.003E+03| -3.14E+0"
-  (foo-e 1100.0)   "  1.10E+3| 11.00$+02|+.001E+06|  1.10E+3" 
-; In Clojure, this is identical to the above
-;  (foo-e 1100.0L0) "  1.10L+3| 11.00$+02|+.001L+06|  1.10L+3" 
-  (foo-e 1.1E13)   "*********| 11.00$+12|+.001E+16| 1.10E+13" 
-  (foo-e 1.1E120)  "*********|??????????|%%%%%%%%%|1.10E+120" 
-; Clojure doesn't support real numbers this large
+              (cl-format false "~10,3e" 4/5) "  8.000E-1"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3e" big-pos-ratio)) "2.397E+308"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3e" big-neg-ratio)) "-2.397E+308"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3e" tiny-pos-ratio)) "1.000E-340"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3e" tiny-neg-ratio)) "-1.000E-340"
+              (foo-e 0.0314159) "  3.14E-2| 31.42$-03|+.003E+01|  3.14E-2"  ; Added this one
+              (foo-e 314159/10000000)
+              "  3.14E-2| 31.42$-03|+.003E+01|  3.14E-2"
+              (foo-e 3.14159)  "  3.14E+0| 31.42$-01|+.003E+03|  3.14E+0"
+              (foo-e -3.14159) " -3.14E+0|-31.42$-01|-.003E+03| -3.14E+0"
+              (foo-e 1100.0)   "  1.10E+3| 11.00$+02|+.001E+06|  1.10E+3"
+;; In Clojure, this is identical to the above
+;  (foo-e 1100.0L0) "  1.10L+3| 11.00$+02|+.001L+06|  1.10L+3"
+              (foo-e 1.1E13)   "*********| 11.00$+12|+.001E+16| 1.10E+13"
+              (foo-e 1.1E120)  "*********|??????????|%%%%%%%%%|1.10E+120"
+;; Clojure doesn't support real numbers this large
 ;  (foo-e 1.1L1200) "*********|??????????|%%%%%%%%%|1.10L+1200"
 )
 
 (simple-tests cltl-E-scale-tests
-  (map
-    (fn [k] (format nil "Scale factor ~2D~:*: |~13,6,2,VE|" 
-                    (- k 5) 3.14159))              ;Prints 13 lines 
-    (range 13))
-  '("Scale factor -5: | 0.000003E+06|"
-    "Scale factor -4: | 0.000031E+05|"
-    "Scale factor -3: | 0.000314E+04|"
-    "Scale factor -2: | 0.003142E+03|"
-    "Scale factor -1: | 0.031416E+02|"
-    "Scale factor  0: | 0.314159E+01|"
-    "Scale factor  1: | 3.141590E+00|"
-    "Scale factor  2: | 31.41590E-01|"
-    "Scale factor  3: | 314.1590E-02|"
-    "Scale factor  4: | 3141.590E-03|"
-    "Scale factor  5: | 31415.90E-04|"
-    "Scale factor  6: | 314159.0E-05|"
-    "Scale factor  7: | 3141590.E-06|"))
+              (map
+               (fn [k] (format nil "Scale factor ~2D~:*: |~13,6,2,VE|"
+                               (- k 5) 3.14159))              ;Prints 13 lines
+               (range 13))
+              '("Scale factor -5: | 0.000003E+06|"
+                "Scale factor -4: | 0.000031E+05|"
+                "Scale factor -3: | 0.000314E+04|"
+                "Scale factor -2: | 0.003142E+03|"
+                "Scale factor -1: | 0.031416E+02|"
+                "Scale factor  0: | 0.314159E+01|"
+                "Scale factor  1: | 3.141590E+00|"
+                "Scale factor  2: | 31.41590E-01|"
+                "Scale factor  3: | 314.1590E-02|"
+                "Scale factor  4: | 3141.590E-03|"
+                "Scale factor  5: | 31415.90E-04|"
+                "Scale factor  6: | 314159.0E-05|"
+                "Scale factor  7: | 3141590.E-06|"))
 
-(defn foo-g [x] 
-  (format nil 
-          "~9,2,1,,'*G|~9,3,2,3,'?,,'$G|~9,3,2,0,'%G|~9,2G" 
-          x x x x)) 
+(defn foo-g [x]
+  (format nil
+          "~9,2,1,,'*G|~9,3,2,3,'?,,'$G|~9,3,2,0,'%G|~9,2G"
+          x x x x))
 
 ;; Clojure doesn't support float/double differences in representation
 (simple-tests cltl-G-tests
-  (cl-format false "~10,3g" 4/5)  " 0.800    "
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3g" big-pos-ratio)) "2.397E+308"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3g" big-neg-ratio)) "-2.397E+308"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3g" tiny-pos-ratio)) "1.000E-340"
-  (binding [*math-context* java.math.MathContext/DECIMAL128]
-    (cl-format false "~10,3g" tiny-neg-ratio)) "-1.000E-340"
-  (foo-g 0.0314159) "  3.14E-2|314.2$-04|0.314E-01|  3.14E-2" 
-  (foo-g 314159/10000000)
-                    "  3.14E-2|314.2$-04|0.314E-01|  3.14E-2"
-  (foo-g 0.314159)  "  0.31   |0.314    |0.314    | 0.31    " 
-  (foo-g 3.14159)   "   3.1   | 3.14    | 3.14    |  3.1    " 
-  (foo-g 31.4159)   "   31.   | 31.4    | 31.4    |  31.    " 
-  (foo-g 314.159)   "  3.14E+2| 314.    | 314.    |  3.14E+2" 
-  (foo-g 3141.59)   "  3.14E+3|314.2$+01|0.314E+04|  3.14E+3" 
-; In Clojure, this is identical to the above
-;  (foo-g 3141.59L0) "  3.14L+3|314.2$+01|0.314L+04|  3.14L+3" 
-  (foo-g 3.14E12)   "*********|314.0$+10|0.314E+13| 3.14E+12" 
-  (foo-g 3.14E120)  "*********|?????????|%%%%%%%%%|3.14E+120" 
-; Clojure doesn't support real numbers this large
+              (cl-format false "~10,3g" 4/5)  " 0.800    "
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3g" big-pos-ratio)) "2.397E+308"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3g" big-neg-ratio)) "-2.397E+308"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3g" tiny-pos-ratio)) "1.000E-340"
+              (binding [*math-context* java.math.MathContext/DECIMAL128]
+                (cl-format false "~10,3g" tiny-neg-ratio)) "-1.000E-340"
+              (foo-g 0.0314159) "  3.14E-2|314.2$-04|0.314E-01|  3.14E-2"
+              (foo-g 314159/10000000)
+              "  3.14E-2|314.2$-04|0.314E-01|  3.14E-2"
+              (foo-g 0.314159)  "  0.31   |0.314    |0.314    | 0.31    "
+              (foo-g 3.14159)   "   3.1   | 3.14    | 3.14    |  3.1    "
+              (foo-g 31.4159)   "   31.   | 31.4    | 31.4    |  31.    "
+              (foo-g 314.159)   "  3.14E+2| 314.    | 314.    |  3.14E+2"
+              (foo-g 3141.59)   "  3.14E+3|314.2$+01|0.314E+04|  3.14E+3"
+;; In Clojure, this is identical to the above
+;  (foo-g 3141.59L0) "  3.14L+3|314.2$+01|0.314L+04|  3.14L+3"
+              (foo-g 3.14E12)   "*********|314.0$+10|0.314E+13| 3.14E+12"
+              (foo-g 3.14E120)  "*********|?????????|%%%%%%%%%|3.14E+120"
+;; Clojure doesn't support real numbers this large
 ;  (foo-g 3.14L1200) "*********|?????????|%%%%%%%%%|3.14L+1200"
 )
 
@@ -701,143 +666,141 @@
   (format nil ;; CLtL has this format string slightly wrong
           "~&Function ~S requires its ~:[~:R ~;~*~]~
            argument to be of type ~S,~%but it was called ~
-           with an argument of type ~S.~%" 
-          fun (= nargs 1) argnum right-type wrong-type)) 
+           with an argument of type ~S.~%"
+          fun (= nargs 1) argnum right-type wrong-type))
 
 (simple-tests cltl-Newline-tests
-  (type-clash-error 'aref nil 2 'integer 'vector)
-"Function aref requires its second argument to be of type integer,
+              (type-clash-error 'aref nil 2 'integer 'vector)
+              "Function aref requires its second argument to be of type integer,
 but it was called with an argument of type vector.\n"
-  (type-clash-error 'car 1 1 'list 'short-float)
-"Function car requires its argument to be of type list,
+              (type-clash-error 'car 1 1 'list 'short-float)
+              "Function car requires its argument to be of type list,
 but it was called with an argument of type short-float.\n")
 
 (simple-tests cltl-?-tests
-  (format nil "~? ~D" "<~A ~D>" '("Foo" 5) 7) "<Foo 5> 7" 
-  (format nil "~? ~D" "<~A ~D>" '("Foo" 5 14) 7) "<Foo 5> 7"
-  (format nil "~@? ~D" "<~A ~D>" "Foo" 5 7) "<Foo 5> 7" 
-  (format nil "~@? ~D" "<~A ~D>" "Foo" 5 14 7) "<Foo 5> 14")
+              (format nil "~? ~D" "<~A ~D>" '("Foo" 5) 7) "<Foo 5> 7"
+              (format nil "~? ~D" "<~A ~D>" '("Foo" 5 14) 7) "<Foo 5> 7"
+              (format nil "~@? ~D" "<~A ~D>" "Foo" 5 7) "<Foo 5> 7"
+              (format nil "~@? ~D" "<~A ~D>" "Foo" 5 14 7) "<Foo 5> 14")
 
-(defn f [n] (format nil "~@(~R~) error~:P detected." n)) 
+(defn f [n] (format nil "~@(~R~) error~:P detected." n))
 
 (simple-tests cltl-paren-tests
-  (format nil "~@R ~(~@R~)" 14 14) "XIV xiv" 
-  (f 0) "Zero errors detected." 
-  (f 1) "One error detected." 
-  (f 23) "Twenty-three errors detected.")
+              (format nil "~@R ~(~@R~)" 14 14) "XIV xiv"
+              (f 0) "Zero errors detected."
+              (f 1) "One error detected."
+              (f 23) "Twenty-three errors detected.")
 
-(let [*print-level* nil *print-length* 5] 
+(let [*print-level* nil *print-length* 5]
   (simple-tests cltl-bracket-tests
-    (format nil "~@[ print level = ~D~]~@[ print length = ~D~]" 
-            *print-level* *print-length*) 
-    " print length = 5"))
+                (format nil "~@[ print level = ~D~]~@[ print length = ~D~]"
+                        *print-level* *print-length*)
+                " print length = 5"))
 
 (let [foo "Items:~#[ none~; ~S~; ~S and ~S~
            ~:;~@{~#[~; and~] ~
            ~S~^,~}~]."]
   (simple-tests cltl-bracket1-tests
-    (format nil foo) "Items: none." 
-    (format nil foo 'foo) "Items: foo." 
-    (format nil foo 'foo 'bar) "Items: foo and bar." 
-    (format nil foo 'foo 'bar 'baz) "Items: foo, bar, and baz." 
-    (format nil foo 'foo 'bar 'baz 'quux) "Items: foo, bar, baz, and quux."))
+                (format nil foo) "Items: none."
+                (format nil foo 'foo) "Items: foo."
+                (format nil foo 'foo 'bar) "Items: foo and bar."
+                (format nil foo 'foo 'bar 'baz) "Items: foo, bar, and baz."
+                (format nil foo 'foo 'bar 'baz 'quux) "Items: foo, bar, baz, and quux."))
 
 (simple-tests cltl-curly-bracket-tests
-  (format nil 
-        "The winners are:~{ ~S~}." 
-        '(fred harry jill)) 
-  "The winners are: fred harry jill." 
+              (format nil
+                      "The winners are:~{ ~S~}."
+                      '(fred harry jill))
+              "The winners are: fred harry jill."
 
-  (format nil "Pairs:~{ <~S,~S>~}." '(a 1 b 2 c 3)) 
-  "Pairs: <a,1> <b,2> <c,3>."
+              (format nil "Pairs:~{ <~S,~S>~}." '(a 1 b 2 c 3))
+              "Pairs: <a,1> <b,2> <c,3>."
 
-  (format nil "Pairs:~:{ <~S,~S>~}." '((a 1) (b 2) (c 3))) 
-  "Pairs: <a,1> <b,2> <c,3>."
+              (format nil "Pairs:~:{ <~S,~S>~}." '((a 1) (b 2) (c 3)))
+              "Pairs: <a,1> <b,2> <c,3>."
 
-  (format nil "Pairs:~@{ <~S,~S>~}." 'a 1 'b 2 'c 3) 
-  "Pairs: <a,1> <b,2> <c,3>."
+              (format nil "Pairs:~@{ <~S,~S>~}." 'a 1 'b 2 'c 3)
+              "Pairs: <a,1> <b,2> <c,3>."
 
-  (format nil "Pairs:~:@{ <~S,~S>~}." '(a 1) '(b 2) '(c 3)) 
-  "Pairs: <a,1> <b,2> <c,3>.")
+              (format nil "Pairs:~:@{ <~S,~S>~}." '(a 1) '(b 2) '(c 3))
+              "Pairs: <a,1> <b,2> <c,3>.")
 
 (simple-tests cltl-angle-bracket-tests
-  (format nil "~10<foo~;bar~>")           "foo    bar" 
-  (format nil "~10:<foo~;bar~>")          "  foo  bar" 
-  (format nil "~10:@<foo~;bar~>")         "  foo bar " 
-  (format nil "~10<foobar~>")             "    foobar" 
-  (format nil "~10:<foobar~>")            "    foobar" 
-  (format nil "~10@<foobar~>")            "foobar    " 
-  (format nil "~10:@<foobar~>")           "  foobar  ")
+              (format nil "~10<foo~;bar~>")           "foo    bar"
+              (format nil "~10:<foo~;bar~>")          "  foo  bar"
+              (format nil "~10:@<foo~;bar~>")         "  foo bar "
+              (format nil "~10<foobar~>")             "    foobar"
+              (format nil "~10:<foobar~>")            "    foobar"
+              (format nil "~10@<foobar~>")            "foobar    "
+              (format nil "~10:@<foobar~>")           "  foobar  ")
 
 (let [donestr "Done.~^  ~D warning~:P.~^  ~D error~:P."
       tellstr "~@{~@(~@[~R~^ ~]~A~)~}."] ;; The CLtL example is a little wrong here
 
   (simple-tests cltl-up-tests
-    (format nil donestr) "Done." 
-    (format nil donestr 3) "Done.  3 warnings." 
-    (format nil donestr 1 5) "Done.  1 warning.  5 errors."
-    (format nil tellstr 23) "Twenty-three." 
-    (format nil tellstr nil "losers") "Losers." 
-    (format nil tellstr 23 "losers") "Twenty-three losers."
-    (format nil "~15<~S~;~^~S~;~^~S~>" 'foo) 
-    "            foo" 
-    (format nil "~15<~S~;~^~S~;~^~S~>" 'foo 'bar) 
-    "foo         bar" 
-    (format nil "~15<~S~;~^~S~;~^~S~>" 'foo 'bar 'baz) 
-    "foo   bar   baz"))
+                (format nil donestr) "Done."
+                (format nil donestr 3) "Done.  3 warnings."
+                (format nil donestr 1 5) "Done.  1 warning.  5 errors."
+                (format nil tellstr 23) "Twenty-three."
+                (format nil tellstr nil "losers") "Losers."
+                (format nil tellstr 23 "losers") "Twenty-three losers."
+                (format nil "~15<~S~;~^~S~;~^~S~>" 'foo)
+                "            foo"
+                (format nil "~15<~S~;~^~S~;~^~S~>" 'foo 'bar)
+                "foo         bar"
+                (format nil "~15<~S~;~^~S~;~^~S~>" 'foo 'bar 'baz)
+                "foo   bar   baz"))
 
 (simple-tests cltl-up-x3j13-tests
-  (format nil 
-          "~:{/~S~^ ...~}" 
-          '((hot dog) (hamburger) (ice cream) (french fries))) 
-  "/hot .../hamburger/ice .../french ..."
-  (format nil 
-          "~:{/~S~:^ ...~}" 
-          '((hot dog) (hamburger) (ice cream) (french fries))) 
-  "/hot .../hamburger .../ice .../french"
+              (format nil
+                      "~:{/~S~^ ...~}"
+                      '((hot dog) (hamburger) (ice cream) (french fries)))
+              "/hot .../hamburger/ice .../french ..."
+              (format nil
+                      "~:{/~S~:^ ...~}"
+                      '((hot dog) (hamburger) (ice cream) (french fries)))
+              "/hot .../hamburger .../ice .../french"
 
-  (format nil 
-          "~:{/~S~#:^ ...~}"  ;; This is wrong in CLtL
-          '((hot dog) (hamburger) (ice cream) (french fries))) 
-  "/hot .../hamburger")
+              (format nil
+                      "~:{/~S~#:^ ...~}"  ;; This is wrong in CLtL
+                      '((hot dog) (hamburger) (ice cream) (french fries)))
+              "/hot .../hamburger")
 
 (simple-tests pprint-table-tests
-  (with-out-str
-    (print-table [:b :a]
-                 [{:a 1 :b {:a 'is-a} :c ["hi" "there"]}
-                  {:b 5 :a 7 :c "dog" :d -700}]))
-  "
+              (with-out-str
+                (print-table [:b :a]
+                             [{:a 1 :b {:a 'is-a} :c ["hi" "there"]}
+                              {:b 5 :a 7 :c "dog" :d -700}]))
+              "
 |        :b | :a |
 |-----------+----|
 | {:a is-a} |  1 |
 |         5 |  7 |
 "
-  (with-out-str
-    (print-table [:a :e :d :c]
-                 [{:a 54.7e17 :b {:a 'is-a} :c ["hi" "there"]}
-                  {:b 5 :a -2/3 :c "dog" :d 'panda}]))
-  "
+              (with-out-str
+                (print-table [:a :e :d :c]
+                             [{:a 54.7e17 :b {:a 'is-a} :c ["hi" "there"]}
+                              {:b 5 :a -2/3 :c "dog" :d 'panda}]))
+              "
 |      :a | :e |    :d |             :c |
 |---------+----+-------+----------------|
 | 5.47E18 |    |       | [\"hi\" \"there\"] |
 |    -2/3 |    | panda |            dog |
-"
-  )
+")
 
 (simple-tests *-at-tests
-  (format nil "~*~c defaults to ~D, so ~~@* goes ~A to the ~@*~A arg."
-          'first \n 0 'back)
-  "n defaults to 0, so ~@* goes back to the first arg."
-  (format nil "~~n@* is an ~1@*~A ~0@*~A rather than a ~2@*~A ~0@*~A."
-             'goto 'absolute 'relative)
-  "~n@* is an absolute goto rather than a relative goto."
-  (format nil "We will see no numbers: ~6@*~S"
-             0 1 2 3 4 5 :see?) "We will see no numbers: :see?"
-  (format nil "~4@*~D ~3@*~D ~2@*~D ~1@*~D ~0@*~D"
-             0 1 2 3 4) "4 3 2 1 0"
-  (format nil "~{~A a ~~{ ~3@*~A, the ~1@*~A is ~A to the ~4@*~A of ~A~}[...]"
-            '("Within" goto relative construct list arguments))
-  "Within a ~{ construct, the goto is relative to the list of arguments[...]"
-  (format nil "~{~2@*~S ~1@*~S ~4@*~S ~3@*~S ~S~}"
-          '(:a :b :c :d :e)) ":c :b :e :d :e"
-          )
+              (format nil "~*~c defaults to ~D, so ~~@* goes ~A to the ~@*~A arg."
+                      'first \n 0 'back)
+              "n defaults to 0, so ~@* goes back to the first arg."
+              (format nil "~~n@* is an ~1@*~A ~0@*~A rather than a ~2@*~A ~0@*~A."
+                      'goto 'absolute 'relative)
+              "~n@* is an absolute goto rather than a relative goto."
+              (format nil "We will see no numbers: ~6@*~S"
+                      0 1 2 3 4 5 :see?) "We will see no numbers: :see?"
+              (format nil "~4@*~D ~3@*~D ~2@*~D ~1@*~D ~0@*~D"
+                      0 1 2 3 4) "4 3 2 1 0"
+              (format nil "~{~A a ~~{ ~3@*~A, the ~1@*~A is ~A to the ~4@*~A of ~A~}[...]"
+                      '("Within" goto relative construct list arguments))
+              "Within a ~{ construct, the goto is relative to the list of arguments[...]"
+              (format nil "~{~2@*~S ~1@*~S ~4@*~S ~3@*~S ~S~}"
+                      '(:a :b :c :d :e)) ":c :b :e :d :e")

--- a/test/clojure/test_clojure/pprint/test_helper.clj
+++ b/test/clojure/test_clojure/pprint/test_helper.clj
@@ -1,12 +1,12 @@
 ;;; test_helper.clj -- part of the pretty printer for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -23,9 +23,9 @@
 (defmacro simple-tests [name & test-pairs]
   `(deftest ~name
      ~@(for [[x y] (partition 2 test-pairs)]
-         (cond 
-          (instance? java.util.regex.Pattern y)
-          `(is (#'clojure.test-clojure.pprint.test-helper/back-match ~x ~y))
-          (instance? java.lang.String y) `(is (= ~x (platform-newlines ~y)))
-          :else `(is (= ~x ~y))))))
+         (cond
+           (instance? java.util.regex.Pattern y)
+           `(is (#'clojure.test-clojure.pprint.test-helper/back-match ~x ~y))
+           (instance? java.lang.String y) `(is (= ~x (platform-newlines ~y)))
+           :else `(is (= ~x ~y))))))
 

--- a/test/clojure/test_clojure/pprint/test_pretty.clj
+++ b/test/clojure/test_clojure/pprint/test_pretty.clj
@@ -1,12 +1,12 @@
 ;;; test_pretty.clj -- part of the pretty printer for Clojure
 
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tom Faulhaber
 ;; April 3, 2009
@@ -21,57 +21,57 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (simple-tests xp-fill-test
-  (binding [*print-pprint-dispatch* simple-dispatch
-            *print-right-margin* 38
-            *print-miser-width* nil]
-    (cl-format nil "(let ~:<~@{~:<~w ~_~w~:>~^ ~:_~}~:>~_ ...)~%"
-               '((x 4) (*print-length* nil) (z 2) (list nil))))
-  "(let ((x 4) (*print-length* nil)\n      (z 2) (list nil))\n ...)\n"
+              (binding [*print-pprint-dispatch* simple-dispatch
+                        *print-right-margin* 38
+                        *print-miser-width* nil]
+                (cl-format nil "(let ~:<~@{~:<~w ~_~w~:>~^ ~:_~}~:>~_ ...)~%"
+                           '((x 4) (*print-length* nil) (z 2) (list nil))))
+              "(let ((x 4) (*print-length* nil)\n      (z 2) (list nil))\n ...)\n"
 
-  (binding [*print-pprint-dispatch* simple-dispatch
-            *print-right-margin* 22]
-    (cl-format nil "(let ~:<~@{~:<~w ~_~w~:>~^ ~:_~}~:>~_ ...)~%"
-               '((x 4) (*print-length* nil) (z 2) (list nil))))
-  "(let ((x 4)\n      (*print-length*\n       nil)\n      (z 2)\n      (list nil))\n ...)\n")
+              (binding [*print-pprint-dispatch* simple-dispatch
+                        *print-right-margin* 22]
+                (cl-format nil "(let ~:<~@{~:<~w ~_~w~:>~^ ~:_~}~:>~_ ...)~%"
+                           '((x 4) (*print-length* nil) (z 2) (list nil))))
+              "(let ((x 4)\n      (*print-length*\n       nil)\n      (z 2)\n      (list nil))\n ...)\n")
 
 (simple-tests xp-miser-test
-  (binding [*print-pprint-dispatch* simple-dispatch
-            *print-right-margin* 10, *print-miser-width* 9]
-    (cl-format nil "~:<LIST ~@_~W ~@_~W ~@_~W~:>" '(first second third)))
-  "(LIST\n first\n second\n third)"
+              (binding [*print-pprint-dispatch* simple-dispatch
+                        *print-right-margin* 10, *print-miser-width* 9]
+                (cl-format nil "~:<LIST ~@_~W ~@_~W ~@_~W~:>" '(first second third)))
+              "(LIST\n first\n second\n third)"
 
-  (binding [*print-pprint-dispatch* simple-dispatch
-            *print-right-margin* 10, *print-miser-width* 8]
-    (cl-format nil "~:<LIST ~@_~W ~@_~W ~@_~W~:>" '(first second third)))
-  "(LIST first second third)")
+              (binding [*print-pprint-dispatch* simple-dispatch
+                        *print-right-margin* 10, *print-miser-width* 8]
+                (cl-format nil "~:<LIST ~@_~W ~@_~W ~@_~W~:>" '(first second third)))
+              "(LIST first second third)")
 
 (simple-tests mandatory-fill-test
-  (cl-format nil
-             "<pre>~%~<Usage: ~:I~@{*~a*~^~:@_~}~:>~%</pre>~%"
-             [ "hello" "gooodbye" ])
-  "<pre>
+              (cl-format nil
+                         "<pre>~%~<Usage: ~:I~@{*~a*~^~:@_~}~:>~%</pre>~%"
+                         ["hello" "gooodbye"])
+              "<pre>
 Usage: *hello*
        *gooodbye*
 </pre>
 ")
 
 (simple-tests prefix-suffix-test
-  (binding [*print-pprint-dispatch* simple-dispatch
-            *print-right-margin* 10, *print-miser-width* 10]
-    (cl-format nil "~<{~;LIST ~@_~W ~@_~W ~@_~W~;}~:>" '(first second third)))
-  "{LIST\n first\n second\n third}")
+              (binding [*print-pprint-dispatch* simple-dispatch
+                        *print-right-margin* 10, *print-miser-width* 10]
+                (cl-format nil "~<{~;LIST ~@_~W ~@_~W ~@_~W~;}~:>" '(first second third)))
+              "{LIST\n first\n second\n third}")
 
 (defprotocol Foo (foo-you [this]))
 
 (simple-tests pprint-test
-  (binding [*print-pprint-dispatch* simple-dispatch]
-    (write '(defn foo [x y] 
-              (let [result (* x y)] 
-                (if (> result 400) 
-                  (cl-format true "That number is too big")
-                  (cl-format true "The  result of ~d x ~d is ~d" x y result))))
-           :stream nil))
-  "(defn
+              (binding [*print-pprint-dispatch* simple-dispatch]
+                (write '(defn foo [x y]
+                          (let [result (* x y)]
+                            (if (> result 400)
+                              (cl-format true "That number is too big")
+                              (cl-format true "The  result of ~d x ~d is ~d" x y result))))
+                       :stream nil))
+              "(defn
  foo
  [x y]
  (let
@@ -81,69 +81,61 @@ Usage: *hello*
    (cl-format true \"That number is too big\")
    (cl-format true \"The  result of ~d x ~d is ~d\" x y result))))"
 
-  (with-pprint-dispatch code-dispatch
-    (write '(defn foo [x y] 
-              (let [result (* x y)] 
-                (if (> result 400) 
-                  (cl-format true "That number is too big")
-                  (cl-format true "The  result of ~d x ~d is ~d" x y result))))
-           :stream nil))
-  "(defn foo [x y]
+              (with-pprint-dispatch code-dispatch
+                (write '(defn foo [x y]
+                          (let [result (* x y)]
+                            (if (> result 400)
+                              (cl-format true "That number is too big")
+                              (cl-format true "The  result of ~d x ~d is ~d" x y result))))
+                       :stream nil))
+              "(defn foo [x y]
   (let [result (* x y)]
     (if (> result 400)
       (cl-format true \"That number is too big\")
       (cl-format true \"The  result of ~d x ~d is ~d\" x y result))))"
 
-  (binding [*print-pprint-dispatch* simple-dispatch
-            *print-right-margin* 15] 
-    (write '(fn (cons (car x) (cdr y))) :stream nil))
-  "(fn\n (cons\n  (car x)\n  (cdr y)))"
+              (binding [*print-pprint-dispatch* simple-dispatch
+                        *print-right-margin* 15]
+                (write '(fn (cons (car x) (cdr y))) :stream nil))
+              "(fn\n (cons\n  (car x)\n  (cdr y)))"
 
-  (with-pprint-dispatch code-dispatch
-    (binding [*print-right-margin* 52] 
-      (write 
-       '(add-to-buffer this (make-buffer-blob (str (char c)) nil))
-       :stream nil)))
-  "(add-to-buffer\n  this\n  (make-buffer-blob (str (char c)) nil))"
+              (with-pprint-dispatch code-dispatch
+                (binding [*print-right-margin* 52]
+                  (write
+                   '(add-to-buffer this (make-buffer-blob (str (char c)) nil))
+                   :stream nil)))
+              "(add-to-buffer\n  this\n  (make-buffer-blob (str (char c)) nil))"
 
-  (binding [*print-pprint-dispatch* simple-dispatch]
-    (write (var Foo) :stream nil))
-  "#'clojure.test-clojure.pprint/Foo"
-)
+              (binding [*print-pprint-dispatch* simple-dispatch]
+                (write (var Foo) :stream nil))
+              "#'clojure.test-clojure.pprint/Foo") (simple-tests pprint-reader-macro-test
+                                                                 (with-pprint-dispatch code-dispatch
+                                                                   (write (read-string "(map #(first %) [[1 2 3] [4 5 6] [7]])")
+                                                                          :stream nil))
+                                                                 "(map #(first %) [[1 2 3] [4 5 6] [7]])"
 
+                                                                 (with-pprint-dispatch code-dispatch
+                                                                   (write (read-string "@@(ref (ref 1))")
+                                                                          :stream nil))
+                                                                 "@@(ref (ref 1))"
 
-
-(simple-tests pprint-reader-macro-test
-  (with-pprint-dispatch code-dispatch
-    (write (read-string "(map #(first %) [[1 2 3] [4 5 6] [7]])")
-	   :stream nil))
-  "(map #(first %) [[1 2 3] [4 5 6] [7]])"
-
-  (with-pprint-dispatch code-dispatch
-    (write (read-string "@@(ref (ref 1))")
-	   :stream nil))
-  "@@(ref (ref 1))"
-
-  (with-pprint-dispatch code-dispatch
-    (write (read-string "'foo")
-	   :stream nil))
-  "'foo"
-)
-
-(defmacro code-block
-  "Read a string then print it with code-dispatch and succeed if it comes out the same"
-  [test-name & blocks]
-  `(simple-tests ~test-name
-     ~@(apply concat
-              (for [block blocks]
-                `[(str/split-lines
-                   (with-out-str
-                     (with-pprint-dispatch code-dispatch
-                       (pprint (read-string ~block)))))
-                  (str/split-lines ~block)]))))
+                                                                 (with-pprint-dispatch code-dispatch
+                                                                   (write (read-string "'foo")
+                                                                          :stream nil))
+                                                                 "'foo") (defmacro code-block
+                                                                           "Read a string then print it with code-dispatch and succeed if it comes out the same"
+                                                                           [test-name & blocks]
+                                                                           `(simple-tests ~test-name
+                                                                                          ~@(apply concat
+                                                                                                   (for [block blocks]
+                                                                                                     `[(str/split-lines
+                                                                                                        (with-out-str
+                                                                                                          (with-pprint-dispatch code-dispatch
+                                                                                                            (pprint (read-string ~block)))))
+                                                                                                       (str/split-lines ~block)]))))
 
 (code-block code-block-tests
-  "(defn cl-format
+            "(defn cl-format
   \"An implementation of a Common Lisp compatible format function\"
   [stream format-in & args]
   (let [compiled-format (if (string? format-in)
@@ -152,7 +144,7 @@ Usage: *hello*
         navigator (init-navigator args)]
     (execute-format stream compiled-format navigator)))"
 
- "(defn pprint-defn [writer alis]
+            "(defn pprint-defn [writer alis]
   (if (next alis)
     (let [[defn-sym defn-name & stuff] alis
           [doc-str stuff] (if (string? (first stuff))
@@ -178,18 +170,18 @@ Usage: *hello*
     (pprint-simple-code-list writer alis)))")
 
 (code-block ns-macro-test
-  "(ns foobarbaz)"
-  "(ns slam.hound.stitch
+            "(ns foobarbaz)"
+            "(ns slam.hound.stitch
   (:use [slam.hound.prettify :only [prettify]]))"
-  
-  "(ns slam.hound.prettify
+
+            "(ns slam.hound.prettify
   \"Format a namespace declaration using pretty print with custom dispatch.\"
   (:use [clojure.pprint :only [cl-format code-dispatch formatter-out
                                pprint pprint-logical-block
                                pprint-newline with-pprint-dispatch
                                write-out]]))"
 
-  "(ns autodoc.build-html
+            "(ns autodoc.build-html
   \"This is the namespace that builds the HTML pages themselves.
 It is implemented with a number of custom enlive templates.\"
   {:skip-wiki true, :author \"Tom Faulhaber\"}
@@ -235,110 +227,100 @@ It is implemented with a number of custom enlive templates.\"
 (defrecord pprint-test-rec [a b c])
 
 (simple-tests pprint-datastructures-tests
- (tst-pprint 20 future-filled) #"#<Future@[0-9a-f]+: \r?\n  100>"
- (tst-pprint 20 future-unfilled) #"#<Future@[0-9a-f]+: \r?\n  :pending>"
- (tst-pprint 20 promise-filled) #"#<Promise@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
+              (tst-pprint 20 future-filled) #"#<Future@[0-9a-f]+: \r?\n  100>"
+              (tst-pprint 20 future-unfilled) #"#<Future@[0-9a-f]+: \r?\n  :pending>"
+              (tst-pprint 20 promise-filled) #"#<Promise@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
  ;; This hangs currently, cause we can't figure out whether a promise is filled
  ;;(tst-pprint 20 promise-unfilled) #"#<Promise@[0-9a-f]+: \r?\n  :pending>"
- (tst-pprint 20 basic-agent) #"#<Agent@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
- (tst-pprint 20 basic-atom) #"#<Atom@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\r?\)>"
- (tst-pprint 20 basic-ref) #"#<Ref@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
- (tst-pprint 20 delay-forced) #"#<Delay@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
+              (tst-pprint 20 basic-agent) #"#<Agent@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
+              (tst-pprint 20 basic-atom) #"#<Atom@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\r?\)>"
+              (tst-pprint 20 basic-ref) #"#<Ref@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
+              (tst-pprint 20 delay-forced) #"#<Delay@[0-9a-f]+: \r?\n  \(first\r?\n   second\r?\n   third\)>"
  ;; Currently no way not to force the delay
  ;;(tst-pprint 20 delay-unforced) #"#<Delay@[0-9a-f]+: \n  :pending>"
- (tst-pprint 20 (pprint-test-rec. 'first 'second 'third)) "{:a first,\n :b second,\n :c third}"
+              (tst-pprint 20 (pprint-test-rec. 'first 'second 'third)) "{:a first,\n :b second,\n :c third}"
 
  ;; basic java arrays: fails owing to assembla ticket #346
  ;;(tst-pprint 10 (int-array (range 7))) "[0,\n 1,\n 2,\n 3,\n 4,\n 5,\n 6]"
- (tst-pprint 15 (reduce conj clojure.lang.PersistentQueue/EMPTY (range 10)))
- "<-(0\n   1\n   2\n   3\n   4\n   5\n   6\n   7\n   8\n   9)-<"
- )
-
+              (tst-pprint 15 (reduce conj clojure.lang.PersistentQueue/EMPTY (range 10)))
+              "<-(0\n   1\n   2\n   3\n   4\n   5\n   6\n   7\n   8\n   9)-<")
 
 ;;; Some simple tests of dispatch
 
-(defmulti 
+(defmulti
   test-dispatch
   "A test dispatch method"
-  {:added "1.2" :arglists '[[object]]} 
+  {:added "1.2" :arglists '[[object]]}
   #(and (seq %) (not (string? %))))
 
 (defmethod test-dispatch true [avec]
   (pprint-logical-block :prefix "[" :suffix "]"
-    (loop [aseq (seq avec)]
-      (when aseq
-	(write-out (first aseq))
-	(when (next aseq)
-	  (.write ^java.io.Writer *out* " ")
-	  (pprint-newline :linear)
-	  (recur (next aseq)))))))
+                        (loop [aseq (seq avec)]
+                          (when aseq
+                            (write-out (first aseq))
+                            (when (next aseq)
+                              (.write ^java.io.Writer *out* " ")
+                              (pprint-newline :linear)
+                              (recur (next aseq)))))))
 
 (defmethod test-dispatch false [aval] (pr aval))
 
 (simple-tests dispatch-tests
-  (with-pprint-dispatch test-dispatch
-    (with-out-str 
-      (pprint '("hello" "there"))))
-  "[\"hello\" \"there\"]\n"
-)
+              (with-pprint-dispatch test-dispatch
+                (with-out-str
+                  (pprint '("hello" "there"))))
+              "[\"hello\" \"there\"]\n") (simple-tests print-length-tests
+                                                       (binding [*print-length* 1] (with-out-str (pprint '(a b c d e f))))
+                                                       "(a ...)\n"
+                                                       (binding [*print-length* 2] (with-out-str (pprint '(a b c d e f))))
+                                                       "(a b ...)\n"
+                                                       (binding [*print-length* 6] (with-out-str (pprint '(a b c d e f))))
+                                                       "(a b c d e f)\n"
+                                                       (binding [*print-length* 8] (with-out-str (pprint '(a b c d e f))))
+                                                       "(a b c d e f)\n"
 
-(simple-tests print-length-tests
-  (binding [*print-length* 1] (with-out-str (pprint '(a b c d e f))))
-  "(a ...)\n"
-  (binding [*print-length* 2] (with-out-str (pprint '(a b c d e f))))
-  "(a b ...)\n"
-  (binding [*print-length* 6] (with-out-str (pprint '(a b c d e f))))
-  "(a b c d e f)\n"
-  (binding [*print-length* 8] (with-out-str (pprint '(a b c d e f))))
-  "(a b c d e f)\n"
+                                                       (binding [*print-length* 1] (with-out-str (pprint [1 2 3 4 5 6])))
+                                                       "[1 ...]\n"
+                                                       (binding [*print-length* 2] (with-out-str (pprint [1 2 3 4 5 6])))
+                                                       "[1 2 ...]\n"
+                                                       (binding [*print-length* 6] (with-out-str (pprint [1 2 3 4 5 6])))
+                                                       "[1 2 3 4 5 6]\n"
+                                                       (binding [*print-length* 8] (with-out-str (pprint [1 2 3 4 5 6])))
+                                                       "[1 2 3 4 5 6]\n"
 
-  (binding [*print-length* 1] (with-out-str (pprint [1 2 3 4 5 6])))
-  "[1 ...]\n"
-  (binding [*print-length* 2] (with-out-str (pprint [1 2 3 4 5 6])))
-  "[1 2 ...]\n"
-  (binding [*print-length* 6] (with-out-str (pprint [1 2 3 4 5 6])))
-  "[1 2 3 4 5 6]\n"
-  (binding [*print-length* 8] (with-out-str (pprint [1 2 3 4 5 6])))
-  "[1 2 3 4 5 6]\n"
+                                                       (binding [*print-length* 1] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
+                                                       "#{1 ...}\n"
+                                                       (binding [*print-length* 2] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
+                                                       "#{1 2 ...}\n"
+                                                       (binding [*print-length* 6] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
+                                                       "#{1 2 3 4 5 6}\n"
+                                                       (binding [*print-length* 8] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
+                                                       "#{1 2 3 4 5 6}\n"
 
-  (binding [*print-length* 1] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
-  "#{1 ...}\n"
-  (binding [*print-length* 2] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
-  "#{1 2 ...}\n"
-  (binding [*print-length* 6] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
-  "#{1 2 3 4 5 6}\n"
-  (binding [*print-length* 8] (with-out-str (pprint (sorted-set 1 2 3 4 5 6))))
-  "#{1 2 3 4 5 6}\n"
-
-  (binding [*print-length* 1] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
-  "{1 2, ...}\n"
-  (binding [*print-length* 2] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
-  "{1 2, 3 4, ...}\n"
-  (binding [*print-length* 6] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
-  "{1 2, 3 4, 5 6, 7 8, 9 10, 11 12}\n"
-  (binding [*print-length* 8] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
-  "{1 2, 3 4, 5 6, 7 8, 9 10, 11 12}\n"
-
-
-  (binding [*print-length* 1] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
-  "[1, ...]\n"
-  (binding [*print-length* 2] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
-  "[1, 2, ...]\n"
-  (binding [*print-length* 6] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
-  "[1, 2, 3, 4, 5, 6]\n"
-  (binding [*print-length* 8] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
-  "[1, 2, 3, 4, 5, 6]\n"
-  )
+                                                       (binding [*print-length* 1] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
+                                                       "{1 2, ...}\n"
+                                                       (binding [*print-length* 2] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
+                                                       "{1 2, 3 4, ...}\n"
+                                                       (binding [*print-length* 6] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
+                                                       "{1 2, 3 4, 5 6, 7 8, 9 10, 11 12}\n"
+                                                       (binding [*print-length* 8] (with-out-str (pprint (sorted-map 1 2, 3 4, 5 6, 7 8, 9 10, 11 12))))
+                                                       "{1 2, 3 4, 5 6, 7 8, 9 10, 11 12}\n" (binding [*print-length* 1] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
+                                                       "[1, ...]\n"
+                                                       (binding [*print-length* 2] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
+                                                       "[1, 2, ...]\n"
+                                                       (binding [*print-length* 6] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
+                                                       "[1, 2, 3, 4, 5, 6]\n"
+                                                       (binding [*print-length* 8] (with-out-str (pprint (int-array [1 2 3 4 5 6]))))
+                                                       "[1, 2, 3, 4, 5, 6]\n")
 
 (defn- flush-alerting-writer
   [o]
   (let [flush-count-atom (atom 0)]
-    [
-      (proxy [java.io.BufferedWriter] [o]
-        (flush []
-          (proxy-super flush)
-          (swap! flush-count-atom inc)))
-      flush-count-atom]))
+    [(proxy [java.io.BufferedWriter] [o]
+       (flush []
+         (proxy-super flush)
+         (swap! flush-count-atom inc)))
+     flush-count-atom]))
 
 (deftest test-flush-underlying-prn
   []

--- a/test/clojure/test_clojure/predicates.clj
+++ b/test/clojure/test_clojure/predicates.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 ;;
 ;;  Created 1/28/2009
@@ -14,14 +14,12 @@
 (ns clojure.test-clojure.predicates
   (:use clojure.test))
 
-
 ;; *** Type predicates ***
 
 (def myvar 42)
 
 (def sample-data
-  {
-   :nil            nil
+  {:nil            nil
 
    :bool-true      true
    :bool-false     false
@@ -66,13 +64,10 @@
 
    :var            (var myvar)
    :delay          (delay (+ 1 2))
-   :ns             (the-ns 'clojure.core)
-   })
-
+   :ns             (the-ns 'clojure.core)})
 
 (def type-preds
-  {
-   nil?      [:nil]
+  {nil?      [:nil]
 
    true?     [:bool-true]
    false?    [:bool-false]
@@ -115,27 +110,24 @@
    class?    [:class]
    var?      [:var]
    delay?    [:delay]
-   ns?       [:ns]
-   })
-
+   ns?       [:ns]})
 
 ;; Test all type predicates against all data types
 ;;
 (defn- get-fn-name [f]
   (str
-    (apply str (nthnext (first (.split (str f) "_"))
-                        (count "clojure.core$")))
-    "?"))
+   (apply str (nthnext (first (.split (str f) "_"))
+                       (count "clojure.core$")))
+   "?"))
 
 (deftest test-type-preds
   (doseq [tp type-preds]
     (doseq [dt sample-data]
       (if (some #(= % (first dt)) (second tp))
         (is ((first tp) (second dt))
-          (pr-str (list (get-fn-name (first tp)) (second dt))))
+            (pr-str (list (get-fn-name (first tp)) (second dt))))
         (is (not ((first tp) (second dt)))
-          (pr-str (list 'not (list (get-fn-name (first tp)) (second dt)))))))))
-
+            (pr-str (list 'not (list (get-fn-name (first tp)) (second dt)))))))))
 
 ;; Additional tests:
 ;; http://groups.google.com/group/clojure/browse_thread/thread/537761a06edb4b06/bfd4f0705b746a38

--- a/test/clojure/test_clojure/printer.clj
+++ b/test/clojure/test_clojure/printer.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stephen C. Gilardi
+;; Author: Stephen C. Gilardi
 
 ;;  clojure.test-clojure.printer
 ;;
@@ -84,40 +84,40 @@
 
 (deftest print-dup-expected
   (are [x s] (= s (binding [*print-dup* true] (print-str x)))
-       1 "1"
-       1.0 "1.0"
-       1N "1N"
-       (java.math.BigInteger. "1") "#=(java.math.BigInteger. \"1\")"
-       1M "1M"
-       "hi" "\"hi\""))
+    1 "1"
+    1.0 "1.0"
+    1N "1N"
+    (java.math.BigInteger. "1") "#=(java.math.BigInteger. \"1\")"
+    1M "1M"
+    "hi" "\"hi\""))
 
 (deftest print-dup-readable
   (are [form] (let [x form]
                 (= x (read-string (binding [*print-dup* true] (print-str x)))))
-       1
-       1.0
-       1N
-       1M
-       "hi"))
+    1
+    1.0
+    1N
+    1M
+    "hi"))
 
 (def ^{:foo :anything} var-with-meta 42)
 (def ^{:type :anything} var-with-type 666)
 
 (deftest print-var
   (are [x s] (= s (pr-str x))
-       #'pr-str  "#'clojure.core/pr-str"
-       #'var-with-meta "#'clojure.test-clojure.printer/var-with-meta"
-       #'var-with-type "#'clojure.test-clojure.printer/var-with-type"))
+    #'pr-str  "#'clojure.core/pr-str"
+    #'var-with-meta "#'clojure.test-clojure.printer/var-with-meta"
+    #'var-with-type "#'clojure.test-clojure.printer/var-with-type"))
 
 (deftest print-meta
-  (are [x s] (binding [*print-meta* true] 
+  (are [x s] (binding [*print-meta* true]
                (let [pstr (pr-str x)]
                  (and (.endsWith pstr s)
                       (.startsWith pstr "^")
                       (.contains pstr (pr-str (meta x))))))
-       #'pr-str  "#'clojure.core/pr-str"
-       #'var-with-meta "#'clojure.test-clojure.printer/var-with-meta"
-       #'var-with-type "#'clojure.test-clojure.printer/var-with-type"))
+    #'pr-str  "#'clojure.core/pr-str"
+    #'var-with-meta "#'clojure.test-clojure.printer/var-with-meta"
+    #'var-with-type "#'clojure.test-clojure.printer/var-with-type"))
 
 (defn ^:private ednize-stack-trace-element
   [^StackTraceElement ste]
@@ -141,13 +141,13 @@
   (binding [*data-readers* {'error identity}]
     (are [e] (= (-> e Throwable->map ednize-throwable-data)
                 (-> e pr-str read-string))
-         (Exception. "heyo")
-         (Throwable. "I can a throwable"
-                     (Exception. "chain 1"
-                                 (Exception. "chan 2")))
-         (ex-info "an ex-info" {:with "its" :data 29})
-         (Exception. "outer"
-                     (ex-info "an ex-info" {:with "data"}
-                              (Error. "less outer"
-                                      (ex-info "the root"
-                                               {:with "even" :more 'data})))))))
+      (Exception. "heyo")
+      (Throwable. "I can a throwable"
+                  (Exception. "chain 1"
+                              (Exception. "chan 2")))
+      (ex-info "an ex-info" {:with "its" :data 29})
+      (Exception. "outer"
+                  (ex-info "an ex-info" {:with "data"}
+                           (Error. "less outer"
+                                   (ex-info "the root"
+                                            {:with "even" :more 'data})))))))

--- a/test/clojure/test_clojure/protocols.clj
+++ b/test/clojure/test_clojure/protocols.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stuart Halloway
+;; Author: Stuart Halloway
 
 (ns clojure.test-clojure.protocols
   (:use clojure.test clojure.test-clojure.protocols.examples)
@@ -31,8 +31,8 @@
   "return sorted list of method names on a class"
   [c]
   (->> (.getMethods c)
-     (map #(.getName %))
-     (sort)))
+       (map #(.getName %))
+       (sort)))
 
 (defrecord EmptyRecord [])
 (defrecord TestRecord [a b])
@@ -50,15 +50,15 @@
                        :protocol #'ExampleProtocol}]
       (are [m f] (= (merge (quote m) common-meta)
                     (meta (var f)))
-           {:name foo :arglists ([a]) :doc "method with one arg"} foo
-           {:name bar :arglists ([a b]) :doc "method with two args"} bar
-           {:name baz :arglists ([a] [a b]) :doc "method with multiple arities" :tag String} baz
-           {:name with-quux :arglists ([a]) :doc "method name with a hyphen"} with-quux)))
+        {:name foo :arglists ([a]) :doc "method with one arg"} foo
+        {:name bar :arglists ([a b]) :doc "method with two args"} bar
+        {:name baz :arglists ([a] [a b]) :doc "method with multiple arities" :tag String} baz
+        {:name with-quux :arglists ([a]) :doc "method name with a hyphen"} with-quux)))
   (testing "protocol fns throw IllegalArgumentException if no impl matches"
     (is (thrown-with-msg?
-          IllegalArgumentException
-          #"No implementation of method: :foo of protocol: #'clojure.test-clojure.protocols.examples/ExampleProtocol found for class: java.lang.Long"
-          (foo 10))))
+         IllegalArgumentException
+         #"No implementation of method: :foo of protocol: #'clojure.test-clojure.protocols.examples/ExampleProtocol found for class: java.lang.Long"
+         (foo 10))))
   (testing "protocols generate a corresponding interface using _ instead of - for method names"
     (is (= ["bar" "baz" "baz" "foo" "with_quux"] (method-names clojure.test_clojure.protocols.examples.ExampleProtocol))))
   (testing "protocol will work with instances of its interface (use for interop, not in Clojure!)"
@@ -68,7 +68,7 @@
       (is (= "foo!" (foo obj)) "call through protocol")))
   (testing "you can implement just part of a protocol if you want"
     (let [obj (reify ExampleProtocol
-                     (baz [a b] "two-arg baz!"))]
+                (baz [a b] "two-arg baz!"))]
       (is (= "two-arg baz!" (baz obj nil)))
       (is (thrown? AbstractMethodError (baz obj)))))
   (testing "error conditions checked when defining protocols"
@@ -85,7 +85,7 @@
     (eval '(defprotocol Elusive (new-method [x])))
     (is (= :new-method (eval '(new-method (reify Elusive (new-method [x] :new-method))))))
     (is (fails-with-cause? IllegalArgumentException #"No method of interface: .*\.Elusive found for function: old-method of protocol: Elusive \(The protocol method may have been defined before and removed\.\)"
-          (eval '(old-method (reify Elusive (new-method [x] :new-method))))))))
+                           (eval '(old-method (reify Elusive (new-method [x] :new-method))))))))
 
 (deftype HasMarkers []
   ExampleProtocol
@@ -120,13 +120,13 @@
     (is (= "pow" (foo "pow"))))
   (testing "you can have two methods with the same name. Just use namespaces!"
     (extend String other/SimpleProtocol
-     {:foo (fn [s] (.toUpperCase s))})
+            {:foo (fn [s] (.toUpperCase s))})
     (is (= "POW" (other/foo "pow"))))
   (testing "you can extend deftype types"
     (extend
      ExtendTestWidget
-     ExampleProtocol
-     {:foo (fn [this] (str "widget " (.name this)))})
+      ExampleProtocol
+      {:foo (fn [this] (str "widget " (.name this)))})
     (is (= "widget z" (foo (ExtendTestWidget. "z"))))))
 
 (deftest record-marker-interfaces
@@ -137,77 +137,77 @@
 (deftest illegal-extending
   (testing "you cannot extend a protocol to a type that implements the protocol inline"
     (is (fails-with-cause? IllegalArgumentException #".*HasProtocolInline already directly implements interface"
-          (eval '(extend clojure.test_clojure.protocols.HasProtocolInline
-                         clojure.test-clojure.protocols.examples/ExampleProtocol
-                         {:foo (fn [_] :extended)})))))
+                           (eval '(extend clojure.test_clojure.protocols.HasProtocolInline
+                                    clojure.test-clojure.protocols.examples/ExampleProtocol
+                                    {:foo (fn [_] :extended)})))))
   (testing "you cannot extend to an interface"
     (is (fails-with-cause? IllegalArgumentException #"interface clojure.test_clojure.protocols.examples.ExampleProtocol is not a protocol"
-          (eval '(extend clojure.test_clojure.protocols.HasProtocolInline
-                         clojure.test_clojure.protocols.examples.ExampleProtocol
-                         {:foo (fn [_] :extended)}))))))
+                           (eval '(extend clojure.test_clojure.protocols.HasProtocolInline
+                                    clojure.test_clojure.protocols.examples.ExampleProtocol
+                                    {:foo (fn [_] :extended)}))))))
 
 (deftype ExtendsTestWidget []
   ExampleProtocol)
 #_(deftest extends?-test
-  (reload-example-protocols)
-  (testing "returns false if a type does not implement the protocol at all"
-    (is (false? (extends? other/SimpleProtocol ExtendsTestWidget))))
-  (testing "returns true if a type implements the protocol directly" ;; semantics changed 4/15/2010
-    (is (true? (extends? ExampleProtocol ExtendsTestWidget))))
-  (testing "returns true if a type explicitly extends protocol"
-    (extend
-     ExtendsTestWidget
-     other/SimpleProtocol
-     {:foo identity})
-    (is (true? (extends? other/SimpleProtocol ExtendsTestWidget)))))
+    (reload-example-protocols)
+    (testing "returns false if a type does not implement the protocol at all"
+      (is (false? (extends? other/SimpleProtocol ExtendsTestWidget))))
+    (testing "returns true if a type implements the protocol directly" ;; semantics changed 4/15/2010
+      (is (true? (extends? ExampleProtocol ExtendsTestWidget))))
+    (testing "returns true if a type explicitly extends protocol"
+      (extend
+       ExtendsTestWidget
+        other/SimpleProtocol
+        {:foo identity})
+      (is (true? (extends? other/SimpleProtocol ExtendsTestWidget)))))
 
 (deftype ExtendersTestWidget [])
 #_(deftest extenders-test
-  (reload-example-protocols)
-  (testing "a fresh protocol has no extenders"
-    (is (nil? (extenders ExampleProtocol))))
-  (testing "extending with no methods doesn't count!"
-    (deftype Something [])
-    (extend ::Something ExampleProtocol)
-    (is (nil? (extenders ExampleProtocol))))
-  (testing "extending a protocol (and including an impl) adds an entry to extenders"
-    (extend ExtendersTestWidget ExampleProtocol {:foo identity})
-    (is (= [ExtendersTestWidget] (extenders ExampleProtocol)))))
+    (reload-example-protocols)
+    (testing "a fresh protocol has no extenders"
+      (is (nil? (extenders ExampleProtocol))))
+    (testing "extending with no methods doesn't count!"
+      (deftype Something [])
+      (extend ::Something ExampleProtocol)
+      (is (nil? (extenders ExampleProtocol))))
+    (testing "extending a protocol (and including an impl) adds an entry to extenders"
+      (extend ExtendersTestWidget ExampleProtocol {:foo identity})
+      (is (= [ExtendersTestWidget] (extenders ExampleProtocol)))))
 
 (deftype SatisfiesTestWidget []
   ExampleProtocol)
 #_(deftest satisifies?-test
-  (reload-example-protocols)
-  (let [whatzit (SatisfiesTestWidget.)]
-    (testing "returns false if a type does not implement the protocol at all"
-      (is (false? (satisfies? other/SimpleProtocol whatzit))))
-    (testing "returns true if a type implements the protocol directly"
-      (is (true? (satisfies? ExampleProtocol whatzit))))
-    (testing "returns true if a type explicitly extends protocol"
-      (extend
-       SatisfiesTestWidget
-       other/SimpleProtocol
-       {:foo identity})
-      (is (true? (satisfies? other/SimpleProtocol whatzit)))))  )
+    (reload-example-protocols)
+    (let [whatzit (SatisfiesTestWidget.)]
+      (testing "returns false if a type does not implement the protocol at all"
+        (is (false? (satisfies? other/SimpleProtocol whatzit))))
+      (testing "returns true if a type implements the protocol directly"
+        (is (true? (satisfies? ExampleProtocol whatzit))))
+      (testing "returns true if a type explicitly extends protocol"
+        (extend
+         SatisfiesTestWidget
+          other/SimpleProtocol
+          {:foo identity})
+        (is (true? (satisfies? other/SimpleProtocol whatzit))))))
 
 (deftype ReExtendingTestWidget [])
 #_(deftest re-extending-test
-  (reload-example-protocols)
-  (extend
-   ReExtendingTestWidget
-   ExampleProtocol
-   {:foo (fn [_] "first foo")
-    :baz (fn [_] "first baz")})
-  (testing "if you re-extend, the old implementation is replaced (not merged!)"
+    (reload-example-protocols)
     (extend
      ReExtendingTestWidget
-     ExampleProtocol
-     {:baz (fn [_] "second baz")
-      :bar (fn [_ _] "second bar")})
-    (let [whatzit (ReExtendingTestWidget.)]
-      (is (thrown? IllegalArgumentException (foo whatzit)))
-      (is (= "second bar" (bar whatzit nil)))
-      (is (= "second baz" (baz whatzit))))))
+      ExampleProtocol
+      {:foo (fn [_] "first foo")
+       :baz (fn [_] "first baz")})
+    (testing "if you re-extend, the old implementation is replaced (not merged!)"
+      (extend
+       ReExtendingTestWidget
+        ExampleProtocol
+        {:baz (fn [_] "second baz")
+         :bar (fn [_ _] "second bar")})
+      (let [whatzit (ReExtendingTestWidget.)]
+        (is (thrown? IllegalArgumentException (foo whatzit)))
+        (is (= "second bar" (bar whatzit nil)))
+        (is (= "second baz" (baz whatzit))))))
 
 (defrecord DefrecordObjectMethodsWidgetA [a])
 (defrecord DefrecordObjectMethodsWidgetB [a])
@@ -246,14 +246,12 @@
       (is (thrown? UnsupportedOperationException (.clear rec)))
       (is (= #{:a :b} (.keySet rec)))
       (is (= #{1 2} (set (.values rec))))
-      (is (= #{[:a 1] [:b 2]} (.entrySet rec)))
-      
-      ))
+      (is (= #{[:a 1] [:b 2]} (.entrySet rec)))))
   (testing "IPersistentCollection"
     (testing ".cons"
       (let [rec (r 1 2)]
         (are [x] (= rec (.cons rec x))
-             nil {})
+          nil {})
         (is (= (r 1 3) (.cons rec {:b 3})))
         (is (= (r 1 4) (.cons rec [:b 4])))
         (is (= (r 1 5) (.cons rec (MapEntry. :b 5))))))))
@@ -288,11 +286,11 @@
         (is (= r3    (RecordToTestStatics3/create {:a 1 :b 2 :c 3})))
         (is (= rn    (RecordToTestStatics3/create {:a 1}))))
       (testing "that a literal record equals one by the static factory method"
-        (is (= #clojure.test_clojure.protocols.RecordToTestStatics1{:a 1} (RecordToTestStatics1/create {:a 1})))
-        (is (= #clojure.test_clojure.protocols.RecordToTestStatics2{:a 1 :b 2} (RecordToTestStatics2/create {:a 1 :b 2})))
-        (is (= #clojure.test_clojure.protocols.RecordToTestStatics3{:a 1 :b 2 :c 3} (RecordToTestStatics3/create {:a 1 :b 2 :c 3})))
-        (is (= #clojure.test_clojure.protocols.RecordToTestStatics3{:a 1} (RecordToTestStatics3/create {:a 1})))
-        (is (= #clojure.test_clojure.protocols.RecordToTestStatics3{:a 1 :b nil :c nil} (RecordToTestStatics3/create {:a 1}))))))
+        (is (= #clojure.test_clojure.protocols.RecordToTestStatics1 {:a 1} (RecordToTestStatics1/create {:a 1})))
+        (is (= #clojure.test_clojure.protocols.RecordToTestStatics2 {:a 1 :b 2} (RecordToTestStatics2/create {:a 1 :b 2})))
+        (is (= #clojure.test_clojure.protocols.RecordToTestStatics3 {:a 1 :b 2 :c 3} (RecordToTestStatics3/create {:a 1 :b 2 :c 3})))
+        (is (= #clojure.test_clojure.protocols.RecordToTestStatics3 {:a 1} (RecordToTestStatics3/create {:a 1})))
+        (is (= #clojure.test_clojure.protocols.RecordToTestStatics3 {:a 1 :b nil :c nil} (RecordToTestStatics3/create {:a 1}))))))
   (testing "that records and types have a sane generated basis method"
     (let [rb  (clojure.test_clojure.protocols.RecordToTestBasis/getBasis)
           rbh (clojure.test_clojure.protocols.RecordToTestBasisHinted/getBasis)
@@ -342,7 +340,7 @@
                                                                {:a 1 :b 2 :c 3 :xxx 42}))))
         (is (= (assoc r-n :xxx 42) (map->RecordToTestFactories {:xxx 42})))
         (is (= (assoc r-n :xxx 42) (map->RecordToTestFactories (map->RecordToTestFactories
-  {:xxx 42}))))
+                                                                {:xxx 42}))))
         (is (= (assoc r-d :xxx 42) (map->RecordToTestDegenerateFactories {:xxx 42})))
         (is (= (assoc r-d :xxx 42) (map->RecordToTestDegenerateFactories
                                     (map->RecordToTestDegenerateFactories {:xxx 42})))))
@@ -370,13 +368,13 @@
         (is (false? (-> ->RecordToTestFactories var meta :doc nil?)))
         (is (false? (->  map->RecordToTestFactories var meta :doc nil?))))
       (testing "that a literal record equals one by the positional factory fn"
-        (is (= #clojure.test_clojure.protocols.RecordToTestFactories{:a 1 :b 2 :c 3} (->RecordToTestFactories 1 2 3)))
-        (is (= #clojure.test_clojure.protocols.RecordToTestFactories{:a 1 :b nil :c nil} (->RecordToTestFactories 1 nil nil)))
-        (is (= #clojure.test_clojure.protocols.RecordToTestFactories{:a [] :b {} :c ()} (->RecordToTestFactories [] {} ()))))      
+        (is (= #clojure.test_clojure.protocols.RecordToTestFactories {:a 1 :b 2 :c 3} (->RecordToTestFactories 1 2 3)))
+        (is (= #clojure.test_clojure.protocols.RecordToTestFactories {:a 1 :b nil :c nil} (->RecordToTestFactories 1 nil nil)))
+        (is (= #clojure.test_clojure.protocols.RecordToTestFactories {:a [] :b {} :c ()} (->RecordToTestFactories [] {} ()))))
       (testing "that a literal record equals one by the map-> factory fn"
-        (is (= #clojure.test_clojure.protocols.RecordToTestFactories{:a 1 :b 2 :c 3} (map->RecordToTestFactories {:a 1 :b 2 :c 3})))
-        (is (= #clojure.test_clojure.protocols.RecordToTestFactories{:a 1 :b nil :c nil} (map->RecordToTestFactories {:a 1})))
-        (is (= #clojure.test_clojure.protocols.RecordToTestFactories{:a nil :b nil :c nil} (map->RecordToTestFactories {})))))))
+        (is (= #clojure.test_clojure.protocols.RecordToTestFactories {:a 1 :b 2 :c 3} (map->RecordToTestFactories {:a 1 :b 2 :c 3})))
+        (is (= #clojure.test_clojure.protocols.RecordToTestFactories {:a 1 :b nil :c nil} (map->RecordToTestFactories {:a 1})))
+        (is (= #clojure.test_clojure.protocols.RecordToTestFactories {:a nil :b nil :c nil} (map->RecordToTestFactories {})))))))
 
 (defn compare-huge-types
   [hugeL hugeR]
@@ -423,17 +421,17 @@
 
 (deftest test-ctor-literals
   (testing "that constructor calls to print-dup'able classes are supported as literals"
-    (is (= "Hi" #java.lang.String["Hi"]))
-    (is (= 42 #java.lang.Long[42]))
-    (is (= 42 #java.lang.Long["42"]))
-    (is (= [:a 42] #clojure.lang.MapEntry[:a 42])))
+    (is (= "Hi" #java.lang.String ["Hi"]))
+    (is (= 42 #java.lang.Long [42]))
+    (is (= 42 #java.lang.Long ["42"]))
+    (is (= [:a 42] #clojure.lang.MapEntry [:a 42])))
   (testing "that constructor literals are embeddable"
-    (is (= 42 #java.lang.Long[#java.lang.String["42"]])))
+    (is (= 42 #java.lang.Long [#java.lang.String ["42"]])))
   (testing "that constructor literals work for deftypes too"
-    (is (= (.a (TypeToTestFactory. 42)) (.a #clojure.test_clojure.protocols.TypeToTestFactory[42])))
+    (is (= (.a (TypeToTestFactory. 42)) (.a #clojure.test_clojure.protocols.TypeToTestFactory [42])))
     (is (compare-huge-types
          (TypeToTestHugeFactories.  1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26)
-         #clojure.test_clojure.protocols.TypeToTestHugeFactories[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26]))))
+         #clojure.test_clojure.protocols.TypeToTestHugeFactories [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26]))))
 
 (defrecord RecordToTestLiterals [a])
 (defrecord TestNode [v l r])
@@ -441,13 +439,13 @@
 (def lang-str "en")
 (deftest exercise-literals
   (testing "that ctor literals can be used in common 'places'"
-    (is (= (RecordToTestLiterals. ()) #clojure.test_clojure.protocols.RecordToTestLiterals[()]))
-    (is (= (.a (TypeToTestLiterals. ())) (.a #clojure.test_clojure.protocols.TypeToTestLiterals[()])))
-    (is (= (RecordToTestLiterals. 42) (into #clojure.test_clojure.protocols.RecordToTestLiterals[0] {:a 42})))
-    (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))  (RecordToTestLiterals. #clojure.test_clojure.protocols.RecordToTestLiterals[42])))
-    (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))  (->RecordToTestLiterals #clojure.test_clojure.protocols.RecordToTestLiterals[42])))
+    (is (= (RecordToTestLiterals. ()) #clojure.test_clojure.protocols.RecordToTestLiterals [()]))
+    (is (= (.a (TypeToTestLiterals. ())) (.a #clojure.test_clojure.protocols.TypeToTestLiterals [()])))
+    (is (= (RecordToTestLiterals. 42) (into #clojure.test_clojure.protocols.RecordToTestLiterals [0] {:a 42})))
+    (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))  (RecordToTestLiterals. #clojure.test_clojure.protocols.RecordToTestLiterals [42])))
+    (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))  (->RecordToTestLiterals #clojure.test_clojure.protocols.RecordToTestLiterals [42])))
     (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))
-           #clojure.test_clojure.protocols.RecordToTestLiterals[#clojure.test_clojure.protocols.RecordToTestLiterals[42]]))
+           #clojure.test_clojure.protocols.RecordToTestLiterals [#clojure.test_clojure.protocols.RecordToTestLiterals [42]]))
     (is (= (TestNode. 1
                       (TestNode. 2
                                  (TestNode. 3
@@ -463,46 +461,46 @@
                                  (TestNode. 7
                                             nil
                                             nil)))
-           #clojure.test_clojure.protocols.TestNode{:v 1
-                                                    :l #clojure.test_clojure.protocols.TestNode{:v 2
-                                                                                                :l #clojure.test_clojure.protocols.TestNode{:v 3 :l nil :r nil}
-                                                                                                :r nil}
-                                                    :r #clojure.test_clojure.protocols.TestNode{:v 4
-                                                                                                :l #clojure.test_clojure.protocols.TestNode{:v 5
-                                                                                                                                            :l #clojure.test_clojure.protocols.TestNode{:v 6 :l nil :r nil}
-                                                                                                                                            :r nil}
-                                                                                                :r #clojure.test_clojure.protocols.TestNode{:v 7 :l nil :r nil}}})))
+           #clojure.test_clojure.protocols.TestNode {:v 1
+                                                     :l #clojure.test_clojure.protocols.TestNode {:v 2
+                                                                                                  :l #clojure.test_clojure.protocols.TestNode {:v 3 :l nil :r nil}
+                                                                                                  :r nil}
+                                                     :r #clojure.test_clojure.protocols.TestNode {:v 4
+                                                                                                  :l #clojure.test_clojure.protocols.TestNode {:v 5
+                                                                                                                                               :l #clojure.test_clojure.protocols.TestNode {:v 6 :l nil :r nil}
+                                                                                                                                               :r nil}
+                                                                                                  :r #clojure.test_clojure.protocols.TestNode {:v 7 :l nil :r nil}}})))
 
   (testing "that records and types are evalable"
-    (is (= (RecordToTestLiterals. 42) (eval #clojure.test_clojure.protocols.RecordToTestLiterals[42])))
-    (is (= (RecordToTestLiterals. 42) (eval #clojure.test_clojure.protocols.RecordToTestLiterals{:a 42})))
+    (is (= (RecordToTestLiterals. 42) (eval #clojure.test_clojure.protocols.RecordToTestLiterals [42])))
+    (is (= (RecordToTestLiterals. 42) (eval #clojure.test_clojure.protocols.RecordToTestLiterals {:a 42})))
     (is (= (RecordToTestLiterals. 42) (eval (RecordToTestLiterals. 42))))
     (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))
-           (eval #clojure.test_clojure.protocols.RecordToTestLiterals[#clojure.test_clojure.protocols.RecordToTestLiterals[42]])))
+           (eval #clojure.test_clojure.protocols.RecordToTestLiterals [#clojure.test_clojure.protocols.RecordToTestLiterals [42]])))
     (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))
-           (eval #clojure.test_clojure.protocols.RecordToTestLiterals[#clojure.test_clojure.protocols.RecordToTestLiterals{:a 42}])))
+           (eval #clojure.test_clojure.protocols.RecordToTestLiterals [#clojure.test_clojure.protocols.RecordToTestLiterals {:a 42}])))
     (is (= (RecordToTestLiterals. (RecordToTestLiterals. 42))
-           (eval #clojure.test_clojure.protocols.RecordToTestLiterals{:a #clojure.test_clojure.protocols.RecordToTestLiterals[42]})))
-    (is (= 42 (.a (eval #clojure.test_clojure.protocols.TypeToTestLiterals[42])))))
-  
+           (eval #clojure.test_clojure.protocols.RecordToTestLiterals {:a #clojure.test_clojure.protocols.RecordToTestLiterals [42]})))
+    (is (= 42 (.a (eval #clojure.test_clojure.protocols.TypeToTestLiterals [42])))))
+
   (testing "that ctor literals only work with constants or statics"
     (is (thrown? Exception (read-string "#java.util.Locale[(str 'en)]")))
     (is (thrown? Exception (read-string "(let [s \"en\"] #java.util.Locale[(str 'en)])")))
     (is (thrown? Exception (read-string "#clojure.test_clojure.protocols.RecordToTestLiterals{(keyword \"a\") 42}"))))
-  
+
   (testing "that ctors can have whitespace after class name but before {"
     (is (= (RecordToTestLiterals. 42)
            (read-string "#clojure.test_clojure.protocols.RecordToTestLiterals   {:a 42}"))))
 
   (testing "that the correct errors are thrown with malformed literals"
     (is (thrown-with-msg?
-          Exception
-          #"Unreadable constructor form.*"
-          (read-string "#java.util.Locale(\"en\")")))
+         Exception
+         #"Unreadable constructor form.*"
+         (read-string "#java.util.Locale(\"en\")")))
     (is (thrown-with-msg?
-          Exception
-          #"Unexpected number of constructor arguments.*"
-          (read-string "#java.util.Locale[\"\" \"\" \"\" \"\"]")))
+         Exception
+         #"Unexpected number of constructor arguments.*"
+         (read-string "#java.util.Locale[\"\" \"\" \"\" \"\"]")))
     (is (thrown? Exception (read-string "#java.util.Nachos(\"en\")")))))
 
 (defrecord RecordToTestPrinting [a b])
@@ -525,10 +523,10 @@
     (let [r (RecordToTest__. 1 2)
           t (TypeToTest__. 3 4)]
       (are [x y] (= x y)
-           1 (:__a r)
-           2 (:___b r)
-           3 (.__a t)
-           4 (.___b t)))))
+        1 (:__a r)
+        2 (:___b r)
+        3 (.__a t)
+        4 (.___b t)))))
 
 (defrecord RecordToTestLongHint [^long a])
 (defrecord RecordToTestByteHint [^byte a])
@@ -539,39 +537,39 @@
 
 (deftest hinting-test
   (testing "that primitive hinting requiring no coercion works as expected"
-    (is (= (RecordToTestLongHint. 42) #clojure.test_clojure.protocols.RecordToTestLongHint{:a 42}))
-    (is (= (RecordToTestLongHint. 42) #clojure.test_clojure.protocols.RecordToTestLongHint[42]))
+    (is (= (RecordToTestLongHint. 42) #clojure.test_clojure.protocols.RecordToTestLongHint {:a 42}))
+    (is (= (RecordToTestLongHint. 42) #clojure.test_clojure.protocols.RecordToTestLongHint [42]))
     (is (= (RecordToTestLongHint. 42) (clojure.test_clojure.protocols.RecordToTestLongHint/create {:a 42})))
     (is (= (RecordToTestLongHint. 42) (map->RecordToTestLongHint {:a 42})))
     (is (= (RecordToTestLongHint. 42) (->RecordToTestLongHint 42)))
     (is (= (.a (TypeToTestLongHint. 42)) (.a (->TypeToTestLongHint (long 42)))))
     (testing "that invalid primitive types on hinted defrecord fields fails"
       (is (thrown?
-            ClassCastException
-            (read-string "#clojure.test_clojure.protocols.RecordToTestLongHint{:a \"\"}")))
+           ClassCastException
+           (read-string "#clojure.test_clojure.protocols.RecordToTestLongHint{:a \"\"}")))
       (is (thrown?
-            IllegalArgumentException
-            (read-string "#clojure.test_clojure.protocols.RecordToTestLongHint[\"\"]")))
+           IllegalArgumentException
+           (read-string "#clojure.test_clojure.protocols.RecordToTestLongHint[\"\"]")))
       (is (thrown?
-            IllegalArgumentException
-            (read-string "#clojure.test_clojure.protocols.TypeToTestLongHint[\"\"]")))
+           IllegalArgumentException
+           (read-string "#clojure.test_clojure.protocols.TypeToTestLongHint[\"\"]")))
       (is (thrown?
-            ClassCastException
-            (clojure.test_clojure.protocols.RecordToTestLongHint/create {:a ""})))
+           ClassCastException
+           (clojure.test_clojure.protocols.RecordToTestLongHint/create {:a ""})))
       (is (thrown?
-            ClassCastException
-            (map->RecordToTestLongHint {:a ""})))
+           ClassCastException
+           (map->RecordToTestLongHint {:a ""})))
       (is (thrown?
-            ClassCastException
-            (->RecordToTestLongHint "")))))
+           ClassCastException
+           (->RecordToTestLongHint "")))))
   (testing "that primitive hinting requiring coercion works as expected"
     (is (= (RecordToTestByteHint. 42) (clojure.test_clojure.protocols.RecordToTestByteHint/create {:a (byte 42)})))
     (is (= (RecordToTestByteHint. 42) (map->RecordToTestByteHint {:a (byte 42)})))
     (is (= (RecordToTestByteHint. 42) (->RecordToTestByteHint (byte 42))))
     (is (= (.a (TypeToTestByteHint. 42)) (.a (->TypeToTestByteHint (byte 42))))))
   (testing "that primitive hinting for non-numerics works as expected"
-    (is (= (RecordToTestBoolHint. true) #clojure.test_clojure.protocols.RecordToTestBoolHint{:a true}))
-    (is (= (RecordToTestBoolHint. true) #clojure.test_clojure.protocols.RecordToTestBoolHint[true]))
+    (is (= (RecordToTestBoolHint. true) #clojure.test_clojure.protocols.RecordToTestBoolHint {:a true}))
+    (is (= (RecordToTestBoolHint. true) #clojure.test_clojure.protocols.RecordToTestBoolHint [true]))
     (is (= (RecordToTestBoolHint. true) (clojure.test_clojure.protocols.RecordToTestBoolHint/create {:a true})))
     (is (= (RecordToTestBoolHint. true) (map->RecordToTestBoolHint {:a true})))
     (is (= (RecordToTestBoolHint. true) (->RecordToTestBoolHint true))))
@@ -581,8 +579,8 @@
   (testing "of an interface"
     (let [s :foo
           r (reify
-             java.util.List
-             (contains [_ o] (= s o)))]
+              java.util.List
+              (contains [_ o] (= s o)))]
       (testing "implemented methods"
         (is (true? (.contains r :foo)))
         (is (false? (.contains r :bar))))
@@ -590,60 +588,59 @@
         (is (thrown? AbstractMethodError (.add r :baz))))))
   (testing "of two interfaces"
     (let [r (reify
-             java.util.List
-             (contains [_ o] (= :foo o))
-             java.util.Collection
-             (isEmpty [_] false))]
+              java.util.List
+              (contains [_ o] (= :foo o))
+              java.util.Collection
+              (isEmpty [_] false))]
       (is (true? (.contains r :foo)))
       (is (false? (.contains r :bar)))
       (is (false? (.isEmpty r)))))
   (testing "you can't define a method twice"
     (is (thrown? Exception
-         (eval '(reify
-                 java.util.List
-                 (size [_] 10)
-                 java.util.Collection
-                 (size [_] 20))))))
+                 (eval '(reify
+                          java.util.List
+                          (size [_] 10)
+                          java.util.Collection
+                          (size [_] 20))))))
   (testing "you can't define a method not on an interface/protocol/j.l.Object"
     (is (thrown? Exception
-         (eval '(reify java.util.List (foo [_]))))))
+                 (eval '(reify java.util.List (foo [_]))))))
   (testing "of a protocol"
     (let [r (reify
-             ExampleProtocol
-             (bar [this o] o)
-             (baz [this] 1)
-             (baz [this o] 2))]
+              ExampleProtocol
+              (bar [this o] o)
+              (baz [this] 1)
+              (baz [this o] 2))]
       (= :foo (.bar r :foo))
       (= 1 (.baz r))
       (= 2 (.baz r nil))))
   (testing "destructuring in method def"
     (let [r (reify
-             ExampleProtocol
-             (bar [this [_ _ item]] item))]
+              ExampleProtocol
+              (bar [this [_ _ item]] item))]
       (= :c (.bar r [:a :b :c]))))
   (testing "methods can recur"
     (let [r (reify
-             java.util.List
-             (get [_ index]
-                  (if (zero? index)
-                    :done
-                    (recur (dec index)))))]
+              java.util.List
+              (get [_ index]
+                (if (zero? index)
+                  :done
+                  (recur (dec index)))))]
       (is (= :done (.get r 0)))
       (is (= :done (.get r 1)))))
   (testing "disambiguating with type hints"
     (testing "you must hint an overloaded method"
       (is (thrown? Exception
-            (eval '(reify clojure.test_clojure.protocols.examples.ExampleInterface (hinted [_ o]))))))
+                   (eval '(reify clojure.test_clojure.protocols.examples.ExampleInterface (hinted [_ o]))))))
     (testing "hinting"
       (let [r (reify
-               ExampleInterface
-               (hinted [_ ^int i] (inc i))
-               (hinted [_ ^String s] (str s s)))]
+                ExampleInterface
+                (hinted [_ ^int i] (inc i))
+                (hinted [_ ^String s] (str s s)))]
         (is (= 2 (.hinted r 1)))
         (is (= "xoxo" (.hinted r "xo")))))))
 
-
-; see CLJ-845
+;; see CLJ-845
 (defprotocol SyntaxQuoteTestProtocol
   (sqtp [p]))
 
@@ -663,7 +660,6 @@
 (deftest test-no-ns-capture
   (is (= "foo" (sqtp "foo")))
   (is (= :foo (sqtp :foo))))
-
 
 (defprotocol Dasherizer
   (-do-dashed [this]))

--- a/test/clojure/test_clojure/protocols/hash_collisions.clj
+++ b/test/clojure/test_clojure/protocols/hash_collisions.clj
@@ -47,22 +47,22 @@
   else."
   [x]
   (cond
-   (= x TestType1) 1
-   (= x TestType2) 2
-   (= x TestType3) 4
-   (= x TestType4) 8
-   (= x TestType5) 16
-   (= x TestType6) 32
-   (= x TestType7) 64
-   (= x TestType8) 128
-   (= x TestType9) 256
-   (= x TestType10) 512
-   (= x TestType11) 1024
-   (= x TestType12) 2048
-   (= x TestType13) 4096
-   (= x TestType14) 8192
-   (= x TestType15) 16384
-   :else (original-hash x)))
+    (= x TestType1) 1
+    (= x TestType2) 2
+    (= x TestType3) 4
+    (= x TestType4) 8
+    (= x TestType5) 16
+    (= x TestType6) 32
+    (= x TestType7) 64
+    (= x TestType8) 128
+    (= x TestType9) 256
+    (= x TestType10) 512
+    (= x TestType11) 1024
+    (= x TestType12) 2048
+    (= x TestType13) 4096
+    (= x TestType14) 8192
+    (= x TestType15) 16384
+    :else (original-hash x)))
 
 (deftest protocols-with-no-min-hash-in-13-bits
   (with-redefs [hash no-min-hash-in-13-bits]

--- a/test/clojure/test_clojure/reader.cljc
+++ b/test/clojure/test_clojure/reader.cljc
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stephen C. Gilardi
+;; Author: Stephen C. Gilardi
 
 ;;
 ;;  Tests for the Clojure functions documented at the URL:

--- a/test/clojure/test_clojure/reducers.clj
+++ b/test/clojure/test_clojure/reducers.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Tassilo Horn
 
@@ -36,10 +36,10 @@
 
 (deftest test-mapcat-obeys-reduced
   (is (= [1 "0" 2 "1" 3]
-        (->> (concat (range 100) (lazy-seq (throw (Exception. "Too eager"))))
-          (r/mapcat (juxt inc str))
-          (r/take 5)
-          (into [])))))
+         (->> (concat (range 100) (lazy-seq (throw (Exception. "Too eager"))))
+              (r/mapcat (juxt inc str))
+              (r/take 5)
+              (into [])))))
 
 (defequivtest test-reduce
   [reduce r/reduce identity]
@@ -48,7 +48,6 @@
 (defequivtest test-filter
   [filter r/filter #(into [] %)]
   [even? odd? #(< 200 %) identity])
-
 
 (deftest test-sorted-maps
   (let [m (into (sorted-map)

--- a/test/clojure/test_clojure/reflect.clj
+++ b/test/clojure/test_clojure/reflect.clj
@@ -12,27 +12,27 @@
                                        :common common}))))))
 
 #_(deftest compare-reflect-and-asm
-  (let [cl (.getContextClassLoader (Thread/currentThread))
-        asm-reflector (AsmReflector. cl)
-        java-reflector (JavaReflector. cl)]
-    (doseq [classname '[java.lang.Runnable
-                        java.lang.Object
-                        java.io.FileInputStream
-                        clojure.lang.Compiler
-                        clojure.lang.PersistentVector
-                        java.lang.SuppressWarnings]]
-      (nodiff (type-reflect classname :reflector asm-reflector)
-              (type-reflect classname :reflector java-reflector)))))
+    (let [cl (.getContextClassLoader (Thread/currentThread))
+          asm-reflector (AsmReflector. cl)
+          java-reflector (JavaReflector. cl)]
+      (doseq [classname '[java.lang.Runnable
+                          java.lang.Object
+                          java.io.FileInputStream
+                          clojure.lang.Compiler
+                          clojure.lang.PersistentVector
+                          java.lang.SuppressWarnings]]
+        (nodiff (type-reflect classname :reflector asm-reflector)
+                (type-reflect classname :reflector java-reflector)))))
 
 (deftest field-descriptor->class-symbol-test
   (are [s d] (= s (@#'reflect/field-descriptor->class-symbol d))
-       'clojure.asm.Type<><> "[[Lclojure/asm/Type;"
-       'int "I"
-       'java.lang.Object "Ljava.lang.Object;"))
+    'clojure.asm.Type<><> "[[Lclojure/asm/Type;"
+    'int "I"
+    'java.lang.Object "Ljava.lang.Object;"))
 
 (deftest internal-name->class-symbol-test
   (are [s n] (= s (@#'reflect/internal-name->class-symbol n))
-       'java.lang.Exception "java/lang/Exception"))
+    'java.lang.Exception "java/lang/Exception"))
 
 (def inst (IBar$Factory/get))
 (deftest invoking-nonpublic-super

--- a/test/clojure/test_clojure/refs.clj
+++ b/test/clojure/test_clojure/refs.clj
@@ -1,22 +1,22 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 
 (ns clojure.test-clojure.refs
   (:use clojure.test))
 
-; http://clojure.org/refs
+;; http://clojure.org/refs
 
-; ref
-; deref, @-reader-macro
-; dosync io!
-; ensure ref-set alter commute
-; set-validator get-validator
+;; ref
+;; deref, @-reader-macro
+;; dosync io!
+;; ensure ref-set alter commute
+;; set-validator get-validator
 

--- a/test/clojure/test_clojure/repl.clj
+++ b/test/clojure/test_clojure/repl.clj
@@ -43,16 +43,15 @@
     (is (some #{'clojure.core/defmacro} (apropos 'efmac)))
     (is (= [] (apropos 'nothing-has-this-name)))))
 
-
-(defmacro call-ns 
+(defmacro call-ns
   "Call ns with a unique namespace name. Return the result of calling ns"
   []  `(ns a#))
-(defmacro call-ns-sym 
+(defmacro call-ns-sym
   "Call ns wih a unique namespace name. Return the namespace symbol."
   [] `(do (ns a#) 'a#))
 
 (deftest test-dynamic-ns
   (testing "a call to ns returns nil"
-   (is (= nil (call-ns))))
+    (is (= nil (call-ns))))
   (testing "requiring a dynamically created ns should not throw an exception"
     (is (= nil (let [a (call-ns-sym)] (require a))))))

--- a/test/clojure/test_clojure/rt.clj
+++ b/test/clojure/test_clojure/rt.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stuart Halloway
+;; Author: Stuart Halloway
 
 (ns clojure.test-clojure.rt
   (:require clojure.set)
@@ -17,10 +17,10 @@
   [x]
   (with-out-str
     (try
-     (push-thread-bindings {#'clojure.core/print-initialized false})
-     (clojure.lang.RT/print x *out*)
-     (finally
-      (pop-thread-bindings)))))
+      (push-thread-bindings {#'clojure.core/print-initialized false})
+      (clojure.lang.RT/print x *out*)
+      (finally
+        (pop-thread-bindings)))))
 
 (deftest rt-print-prior-to-print-initialize
   (testing "pattern literals"
@@ -78,7 +78,7 @@
 (deftest last-var-wins-for-core
   (testing "you can replace a core name, with warning"
     (let [ns (temp-ns)
-        replacement (gensym)]
+          replacement (gensym)]
       (with-err-string-writer (intern ns 'prefers replacement))
       (is (= replacement @('prefers (ns-publics ns))))))
   (testing "you can replace a name you defined before"

--- a/test/clojure/test_clojure/sequences.clj
+++ b/test/clojure/test_clojure/sequences.clj
@@ -1,13 +1,13 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
-; Contributors: Stuart Halloway
+;; Author: Frantisek Sodomka
+;; Contributors: Stuart Halloway
 
 (ns clojure.test-clojure.sequences
   (:require [clojure.test :refer :all]
@@ -18,13 +18,13 @@
 
 ;; *** Tests ***
 
-; TODO:
-; apply, map, filter, remove
-; and more...
+;; TODO:
+;; apply, map, filter, remove
+;; and more...
 
 (deftest test-reduce-from-chunked-into-unchunked
   (is (= [1 2 \a \b] (into [] (concat [1 2] "ab")))))
- 
+
 (deftest test-reduce
   (let [int+ (fn [a b] (+ (int a) (int b)))
         arange (range 1 100) ;; enough to cross nodes
@@ -45,41 +45,41 @@
         byte-vec (into (vector-of :byte) (map byte arange))
         all-true (into-array Boolean/TYPE (repeat 10 true))]
     (is (== 4950
-           (reduce + arange)
-           (reduce + avec)
-           (.reduce ^IReduce avec +)
-           (reduce + alist)
-           (reduce + obj-array)
-           (reduce + int-array)
-           (reduce + long-array)
-           (reduce + float-array)
-           (reduce int+ char-array)
-           (reduce + double-array)
-           (reduce int+ byte-array)
-           (reduce + int-vec)
-           (reduce + long-vec)
-           (reduce + float-vec)
-           (reduce int+ char-vec)
-           (reduce + double-vec)
-           (reduce int+ byte-vec)))
+            (reduce + arange)
+            (reduce + avec)
+            (.reduce ^IReduce avec +)
+            (reduce + alist)
+            (reduce + obj-array)
+            (reduce + int-array)
+            (reduce + long-array)
+            (reduce + float-array)
+            (reduce int+ char-array)
+            (reduce + double-array)
+            (reduce int+ byte-array)
+            (reduce + int-vec)
+            (reduce + long-vec)
+            (reduce + float-vec)
+            (reduce int+ char-vec)
+            (reduce + double-vec)
+            (reduce int+ byte-vec)))
     (is (== 4951
-           (reduce + 1 arange)
-           (reduce + 1 avec)
-           (.reduce ^IReduce avec + 1)
-           (reduce + 1 alist)
-           (reduce + 1 obj-array)
-           (reduce + 1 int-array)
-           (reduce + 1 long-array)
-           (reduce + 1 float-array)
-           (reduce int+ 1 char-array)
-           (reduce + 1 double-array)
-           (reduce int+ 1 byte-array)
-           (reduce + 1 int-vec)
-           (reduce + 1 long-vec)
-           (reduce + 1 float-vec)
-           (reduce int+ 1 char-vec)
-           (reduce + 1 double-vec)
-           (reduce int+ 1 byte-vec)))
+            (reduce + 1 arange)
+            (reduce + 1 avec)
+            (.reduce ^IReduce avec + 1)
+            (reduce + 1 alist)
+            (reduce + 1 obj-array)
+            (reduce + 1 int-array)
+            (reduce + 1 long-array)
+            (reduce + 1 float-array)
+            (reduce int+ 1 char-array)
+            (reduce + 1 double-array)
+            (reduce int+ 1 byte-array)
+            (reduce + 1 int-vec)
+            (reduce + 1 long-vec)
+            (reduce + 1 float-vec)
+            (reduce int+ 1 char-vec)
+            (reduce + 1 double-vec)
+            (reduce int+ 1 byte-vec)))
     (is (= true
            (reduce #(and %1 %2) all-true)
            (reduce #(and %1 %2) true all-true)))))
@@ -107,48 +107,46 @@
   (are [x y] (= x y)
       ; fixed SVN 1288 - LazySeq and EmptyList equals/equiv
       ; http://groups.google.com/group/clojure/browse_frm/thread/286d807be9cae2a5#
-      (map inc nil) ()
-      (map inc ()) ()
-      (map inc []) ()
-      (map inc #{}) ()
-      (map inc {}) ()
-      (sequence (map inc) (range 10)) (range 1 11)
-      (range 1 11) (sequence (map inc) (range 10))))
-
+    (map inc nil) ()
+    (map inc ()) ()
+    (map inc []) ()
+    (map inc #{}) ()
+    (map inc {}) ()
+    (sequence (map inc) (range 10)) (range 1 11)
+    (range 1 11) (sequence (map inc) (range 10))))
 
 (deftest test-lazy-seq
   (are [x] (seq? x)
-      (lazy-seq nil)
-      (lazy-seq [])
-      (lazy-seq [1 2]))
+    (lazy-seq nil)
+    (lazy-seq [])
+    (lazy-seq [1 2]))
 
   (is (not (.equals (lazy-seq [3]) (lazy-seq [3N]))))
 
   (are [x y] (= x y)
-      (lazy-seq nil) ()
-      (lazy-seq [nil]) '(nil)
+    (lazy-seq nil) ()
+    (lazy-seq [nil]) '(nil)
 
-      (lazy-seq ()) ()
-      (lazy-seq []) ()
-      (lazy-seq #{}) ()
-      (lazy-seq {}) ()
-      (lazy-seq "") ()
-      (lazy-seq (into-array [])) ()
+    (lazy-seq ()) ()
+    (lazy-seq []) ()
+    (lazy-seq #{}) ()
+    (lazy-seq {}) ()
+    (lazy-seq "") ()
+    (lazy-seq (into-array [])) ()
 
-      (lazy-seq [3]) [3N]
-      (lazy-seq (list 1 2)) '(1 2)
-      (lazy-seq [1 2]) '(1 2)
-      (lazy-seq (sorted-set 1 2)) '(1 2)
-      (lazy-seq (sorted-map :a 1 :b 2)) '([:a 1] [:b 2])
-      (lazy-seq "abc") '(\a \b \c)
-      (lazy-seq (into-array [1 2])) '(1 2) ))
-
+    (lazy-seq [3]) [3N]
+    (lazy-seq (list 1 2)) '(1 2)
+    (lazy-seq [1 2]) '(1 2)
+    (lazy-seq (sorted-set 1 2)) '(1 2)
+    (lazy-seq (sorted-map :a 1 :b 2)) '([:a 1] [:b 2])
+    (lazy-seq "abc") '(\a \b \c)
+    (lazy-seq (into-array [1 2])) '(1 2)))
 
 (deftest test-seq
   (is (not (seq? (seq []))))
   (is (seq? (seq [1 2])))
   (is (not (.equals (seq [3]) (seq [3N]))))
-  
+
   (are [x y] (= x y)
     (seq nil) nil
     (seq [nil]) '(nil)
@@ -166,8 +164,7 @@
     (seq (sorted-set 1 2)) '(1 2)
     (seq (sorted-map :a 1 :b 2)) '([:a 1] [:b 2])
     (seq "abc") '(\a \b \c)
-    (seq (into-array [1 2])) '(1 2) ))
-
+    (seq (into-array [1 2])) '(1 2)))
 
 (deftest test-cons
   (is (thrown? IllegalArgumentException (cons 1 2)))
@@ -189,89 +186,86 @@
     (cons 1 (sorted-set 2 3)) '(1 2 3)
 
     (cons 1 (into-array [])) '(1)
-    (cons 1 (into-array [2 3])) '(1 2 3) ))
-
+    (cons 1 (into-array [2 3])) '(1 2 3)))
 
 (deftest test-empty
   (are [x y] (and (= (empty x) y)
                   #_(= (class (empty x)) (class y)))
-      nil nil
+    nil nil
 
-      () ()
-      '(1 2) ()
+    () ()
+    '(1 2) ()
 
-      [] []
-      [1 2] []
+    [] []
+    [1 2] []
 
-      {} {}
-      {:a 1 :b 2} {}
+    {} {}
+    {:a 1 :b 2} {}
 
-      (sorted-map) (sorted-map)
-      (sorted-map :a 1 :b 2) (sorted-map)
+    (sorted-map) (sorted-map)
+    (sorted-map :a 1 :b 2) (sorted-map)
 
-      #{} #{}
-      #{1 2} #{}
+    #{} #{}
+    #{1 2} #{}
 
-      (sorted-set) (sorted-set)
-      (sorted-set 1 2) (sorted-set)
+    (sorted-set) (sorted-set)
+    (sorted-set 1 2) (sorted-set)
 
-      (seq ()) nil      ; (seq ()) => nil
-      (seq '(1 2)) ()
+    (seq ()) nil      ; (seq ()) => nil
+    (seq '(1 2)) ()
 
-      (seq []) nil      ; (seq []) => nil
-      (seq [1 2]) ()
+    (seq []) nil      ; (seq []) => nil
+    (seq [1 2]) ()
 
-      (seq "") nil      ; (seq "") => nil
-      (seq "ab") ()
+    (seq "") nil      ; (seq "") => nil
+    (seq "ab") ()
 
-      (lazy-seq ()) ()
-      (lazy-seq '(1 2)) ()
+    (lazy-seq ()) ()
+    (lazy-seq '(1 2)) ()
 
-      (lazy-seq []) ()
-      (lazy-seq [1 2]) ()
+    (lazy-seq []) ()
+    (lazy-seq [1 2]) ()
 
       ; non-coll, non-seq => nil
-      42 nil
-      1.2 nil
-      "abc" nil ))
+    42 nil
+    1.2 nil
+    "abc" nil))
 
 ;Tests that the comparator is preserved
 ;The first element should be the same in each set if preserved.
 (deftest test-empty-sorted
   (let [inv-compare (comp - compare)]
-    (are [x y] (= (first (into (empty x) x)) 
-		  (first y))
-	 (sorted-set 1 2 3) (sorted-set 1 2 3)
-	 (sorted-set-by inv-compare 1 2 3) (sorted-set-by inv-compare 1 2 3)
+    (are [x y] (= (first (into (empty x) x))
+                  (first y))
+      (sorted-set 1 2 3) (sorted-set 1 2 3)
+      (sorted-set-by inv-compare 1 2 3) (sorted-set-by inv-compare 1 2 3)
 
-	 (sorted-map 1 :a 2 :b 3 :c) (sorted-map 1 :a 2 :b 3 :c)
-	 (sorted-map-by inv-compare 1 :a 2 :b 3 :c) (sorted-map-by inv-compare 1 :a 2 :b 3 :c))))
-
+      (sorted-map 1 :a 2 :b 3 :c) (sorted-map 1 :a 2 :b 3 :c)
+      (sorted-map-by inv-compare 1 :a 2 :b 3 :c) (sorted-map-by inv-compare 1 :a 2 :b 3 :c))))
 
 (deftest test-not-empty
   ; empty coll/seq => nil
   (are [x] (= (not-empty x) nil)
-      ()
-      []
-      {}
-      #{}
-      (seq ())
-      (seq [])
-      (lazy-seq ())
-      (lazy-seq []) )
+    ()
+    []
+    {}
+    #{}
+    (seq ())
+    (seq [])
+    (lazy-seq ())
+    (lazy-seq []))
 
   ; non-empty coll/seq => identity
   (are [x] (and (= (not-empty x) x)
                 (= (class (not-empty x)) (class x)))
-      '(1 2)
-      [1 2]
-      {:a 1}
-      #{1 2}
-      (seq '(1 2))
-      (seq [1 2])
-      (lazy-seq '(1 2))
-      (lazy-seq [1 2]) ))
-
+    '(1 2)
+    [1 2]
+    {:a 1}
+    #{1 2}
+    (seq '(1 2))
+    (seq [1 2])
+    (lazy-seq '(1 2))
+    (lazy-seq [1 2])))
 
 (deftest test-first
   ;(is (thrown? Exception (first)))
@@ -337,8 +331,7 @@
     (first (into-array [1 2 3])) 1
     (first (to-array [nil])) nil
     (first (to-array [1 nil])) 1
-    (first (to-array [nil 2])) nil ))
-
+    (first (to-array [nil 2])) nil))
 
 (deftest test-next
  ; (is (thrown? IllegalArgumentException (next)))
@@ -411,67 +404,65 @@
     (next (to-array [nil 2])) '(2)
     (next (to-array [(into-array [])])) nil
     (next (to-array [(into-array []) nil])) '(nil)
-    (next (to-array [(into-array []) 2 nil])) '(2 nil) ))
-
+    (next (to-array [(into-array []) 2 nil])) '(2 nil)))
 
 (deftest test-last
   (are [x y] (= x y)
-      (last nil) nil
+    (last nil) nil
 
       ; list
-      (last ()) nil
-      (last '(1)) 1
-      (last '(1 2 3)) 3
+    (last ()) nil
+    (last '(1)) 1
+    (last '(1 2 3)) 3
 
-      (last '(nil)) nil
-      (last '(1 nil)) nil
-      (last '(nil 2)) 2
-      (last '(())) ()
-      (last '(() nil)) nil
-      (last '(() 2 nil)) nil
+    (last '(nil)) nil
+    (last '(1 nil)) nil
+    (last '(nil 2)) 2
+    (last '(())) ()
+    (last '(() nil)) nil
+    (last '(() 2 nil)) nil
 
       ; vector
-      (last []) nil
-      (last [1]) 1
-      (last [1 2 3]) 3
+    (last []) nil
+    (last [1]) 1
+    (last [1 2 3]) 3
 
-      (last [nil]) nil
-      (last [1 nil]) nil
-      (last [nil 2]) 2
-      (last [[]]) []
-      (last [[] nil]) nil
-      (last [[] 2 nil]) nil
+    (last [nil]) nil
+    (last [1 nil]) nil
+    (last [nil 2]) 2
+    (last [[]]) []
+    (last [[] nil]) nil
+    (last [[] 2 nil]) nil
 
       ; set
-      (last #{}) nil
-      (last #{1}) 1
-      (last (sorted-set 1 2 3)) 3
+    (last #{}) nil
+    (last #{1}) 1
+    (last (sorted-set 1 2 3)) 3
 
-      (last #{nil}) nil
-      (last (sorted-set 1 nil)) 1
-      (last (sorted-set nil 2)) 2
-      (last #{#{}}) #{}
-      (last (sorted-set #{} nil)) #{}
+    (last #{nil}) nil
+    (last (sorted-set 1 nil)) 1
+    (last (sorted-set nil 2)) 2
+    (last #{#{}}) #{}
+    (last (sorted-set #{} nil)) #{}
       ;(last (sorted-set #{} 2 nil)) nil
 
       ; map
-      (last {}) nil
-      (last (sorted-map :a 1)) [:a 1]
-      (last (sorted-map :a 1 :b 2 :c 3)) [:c 3]
+    (last {}) nil
+    (last (sorted-map :a 1)) [:a 1]
+    (last (sorted-map :a 1 :b 2 :c 3)) [:c 3]
 
       ; string
-      (last "") nil
-      (last "a") \a
-      (last "abc") \c
+    (last "") nil
+    (last "a") \a
+    (last "abc") \c
 
       ; array
-      (last (into-array [])) nil
-      (last (into-array [1])) 1
-      (last (into-array [1 2 3])) 3
-      (last (to-array [nil])) nil
-      (last (to-array [1 nil])) nil
-      (last (to-array [nil 2])) 2 ))
-
+    (last (into-array [])) nil
+    (last (into-array [1])) 1
+    (last (into-array [1 2 3])) 3
+    (last (to-array [nil])) nil
+    (last (to-array [1 nil])) nil
+    (last (to-array [nil 2])) 2))
 
 ;; (ffirst coll) = (first (first coll))
 ;;
@@ -490,8 +481,7 @@
     (ffirst {:a 1}) :a
 
     (ffirst #{}) nil
-    (ffirst #{[1 2]}) 1 ))
-
+    (ffirst #{[1 2]}) 1))
 
 ;; (fnext coll) = (first (next coll)) = (second coll)
 ;;
@@ -514,8 +504,7 @@
 
     (fnext #{}) nil
     (fnext #{1}) nil
-    (fnext (sorted-set 1 2 3 4)) 2 ))
-
+    (fnext (sorted-set 1 2 3 4)) 2))
 
 ;; (nfirst coll) = (next (first coll))
 ;;
@@ -534,8 +523,7 @@
     (nfirst {:a 1}) '(1)
 
     (nfirst #{}) nil
-    (nfirst #{[1 2]}) '(2) ))
-
+    (nfirst #{[1 2]}) '(2)))
 
 ;; (nnext coll) = (next (next coll))
 ;;
@@ -562,8 +550,7 @@
     (nnext #{}) nil
     (nnext #{1}) nil
     (nnext (sorted-set 1 2)) nil
-    (nnext (sorted-set 1 2 3 4)) '(3 4) ))
-
+    (nnext (sorted-set 1 2 3 4)) '(3 4)))
 
 (deftest test-nth
   ; maps, sets are not supported
@@ -599,110 +586,107 @@
   (is (thrown? IndexOutOfBoundsException (nth (java.util.ArrayList. [1 2 3]) -1)))  ; ???
 
   (are [x y] (= x y)
-      (nth '(1) 0) 1
-      (nth '(1 2 3) 0) 1
-      (nth '(1 2 3 4 5) 1) 2
-      (nth '(1 2 3 4 5) 4) 5
-      (nth '(1 2 3) 5 :not-found) :not-found
+    (nth '(1) 0) 1
+    (nth '(1 2 3) 0) 1
+    (nth '(1 2 3 4 5) 1) 2
+    (nth '(1 2 3 4 5) 4) 5
+    (nth '(1 2 3) 5 :not-found) :not-found
 
-      (nth [1] 0) 1
-      (nth [1 2 3] 0) 1
-      (nth [1 2 3 4 5] 1) 2
-      (nth [1 2 3 4 5] 4) 5
-      (nth [1 2 3] 5 :not-found) :not-found
+    (nth [1] 0) 1
+    (nth [1 2 3] 0) 1
+    (nth [1 2 3 4 5] 1) 2
+    (nth [1 2 3 4 5] 4) 5
+    (nth [1 2 3] 5 :not-found) :not-found
 
-      (nth (into-array [1]) 0) 1
-      (nth (into-array [1 2 3]) 0) 1
-      (nth (into-array [1 2 3 4 5]) 1) 2
-      (nth (into-array [1 2 3 4 5]) 4) 5
-      (nth (into-array [1 2 3]) 5 :not-found) :not-found
+    (nth (into-array [1]) 0) 1
+    (nth (into-array [1 2 3]) 0) 1
+    (nth (into-array [1 2 3 4 5]) 1) 2
+    (nth (into-array [1 2 3 4 5]) 4) 5
+    (nth (into-array [1 2 3]) 5 :not-found) :not-found
 
-      (nth "a" 0) \a
-      (nth "abc" 0) \a
-      (nth "abcde" 1) \b
-      (nth "abcde" 4) \e
-      (nth "abc" 5 :not-found) :not-found
+    (nth "a" 0) \a
+    (nth "abc" 0) \a
+    (nth "abcde" 1) \b
+    (nth "abcde" 4) \e
+    (nth "abc" 5 :not-found) :not-found
 
-      (nth (java.util.ArrayList. [1]) 0) 1
-      (nth (java.util.ArrayList. [1 2 3]) 0) 1
-      (nth (java.util.ArrayList. [1 2 3 4 5]) 1) 2
-      (nth (java.util.ArrayList. [1 2 3 4 5]) 4) 5
-      (nth (java.util.ArrayList. [1 2 3]) 5 :not-found) :not-found )
+    (nth (java.util.ArrayList. [1]) 0) 1
+    (nth (java.util.ArrayList. [1 2 3]) 0) 1
+    (nth (java.util.ArrayList. [1 2 3 4 5]) 1) 2
+    (nth (java.util.ArrayList. [1 2 3 4 5]) 4) 5
+    (nth (java.util.ArrayList. [1 2 3]) 5 :not-found) :not-found)
 
   ; regex Matchers
   (let [m (re-matcher #"(a)(b)" "ababaa")]
     (re-find m) ; => ["ab" "a" "b"]
     (are [x y] (= x y)
-        (nth m 0) "ab"
-        (nth m 1) "a"
-        (nth m 2) "b"
-        (nth m 3 :not-found) :not-found
-        (nth m -1 :not-found) :not-found )
+      (nth m 0) "ab"
+      (nth m 1) "a"
+      (nth m 2) "b"
+      (nth m 3 :not-found) :not-found
+      (nth m -1 :not-found) :not-found)
     (is (thrown? IndexOutOfBoundsException (nth m 3)))
     (is (thrown? IndexOutOfBoundsException (nth m -1))))
 
   (let [m (re-matcher #"c" "ababaa")]
     (re-find m) ; => nil
     (are [x y] (= x y)
-        (nth m 0 :not-found) :not-found
-        (nth m 2 :not-found) :not-found
-        (nth m -1 :not-found) :not-found )
+      (nth m 0 :not-found) :not-found
+      (nth m 2 :not-found) :not-found
+      (nth m -1 :not-found) :not-found)
     (is (thrown? IllegalStateException (nth m 0)))
     (is (thrown? IllegalStateException (nth m 2)))
     (is (thrown? IllegalStateException (nth m -1)))))
 
-
-; distinct was broken for nil & false:
-;   fixed in rev 1278:
-;   http://code.google.com/p/clojure/source/detail?r=1278
+;; distinct was broken for nil & false:
+;;    fixed in rev 1278:
+;;    http://code.google.com/p/clojure/source/detail?r=1278
 ;
 (deftest test-distinct
   (are [x y] (= x y)
-      (distinct ()) ()
-      (distinct '(1)) '(1)
-      (distinct '(1 2 3)) '(1 2 3)
-      (distinct '(1 2 3 1 1 1)) '(1 2 3)
-      (distinct '(1 1 1 2)) '(1 2)
-      (distinct '(1 2 1 2)) '(1 2)
+    (distinct ()) ()
+    (distinct '(1)) '(1)
+    (distinct '(1 2 3)) '(1 2 3)
+    (distinct '(1 2 3 1 1 1)) '(1 2 3)
+    (distinct '(1 1 1 2)) '(1 2)
+    (distinct '(1 2 1 2)) '(1 2)
 
-      (distinct []) ()
-      (distinct [1]) '(1)
-      (distinct [1 2 3]) '(1 2 3)
-      (distinct [1 2 3 1 2 2 1 1]) '(1 2 3)
-      (distinct [1 1 1 2]) '(1 2)
-      (distinct [1 2 1 2]) '(1 2)
+    (distinct []) ()
+    (distinct [1]) '(1)
+    (distinct [1 2 3]) '(1 2 3)
+    (distinct [1 2 3 1 2 2 1 1]) '(1 2 3)
+    (distinct [1 1 1 2]) '(1 2)
+    (distinct [1 2 1 2]) '(1 2)
 
-      (distinct "") ()
-      (distinct "a") '(\a)
-      (distinct "abc") '(\a \b \c)
-      (distinct "abcabab") '(\a \b \c)
-      (distinct "aaab") '(\a \b)
-      (distinct "abab") '(\a \b) )
+    (distinct "") ()
+    (distinct "a") '(\a)
+    (distinct "abc") '(\a \b \c)
+    (distinct "abcabab") '(\a \b \c)
+    (distinct "aaab") '(\a \b)
+    (distinct "abab") '(\a \b))
 
-  (are [x] (= (distinct [x x]) [x])   
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      () '(1 2)
-      [] [1 2]
-      {} {:a 1 :b 2}
-      #{} #{1 2} ))
-
+  (are [x] (= (distinct [x x]) [x])
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2}))
 
 (deftest test-interpose
   (are [x y] (= x y)
     (interpose 0 []) ()
     (interpose 0 [1]) '(1)
     (interpose 0 [1 2]) '(1 0 2)
-    (interpose 0 [1 2 3]) '(1 0 2 0 3) ))
-
+    (interpose 0 [1 2 3]) '(1 0 2 0 3)))
 
 (deftest test-interleave
   (are [x y] (= x y)
@@ -717,8 +701,7 @@
 
     (interleave [1]) '(1)
 
-    (interleave) () ))
-
+    (interleave) ()))
 
 (deftest test-zipmap
   (are [x y] (= x y)
@@ -729,8 +712,7 @@
 
     (zipmap [] [1 2]) {}
     (zipmap [:a :b] []) {}
-    (zipmap [] []) {} ))
-
+    (zipmap [] []) {}))
 
 (deftest test-concat
   (are [x y] (= x y)
@@ -744,8 +726,7 @@
     (concat [1 2] []) '(1 2)
     (concat [] []) ()
 
-    (concat [1 2] [3 4] [5 6]) '(1 2 3 4 5 6) ))
-
+    (concat [1 2] [3 4] [5 6]) '(1 2 3 4 5 6)))
 
 (deftest test-cycle
   (are [x y] (= x y)
@@ -765,7 +746,6 @@
     (first (next (cycle (map #(/ 42 %) '(2 1 0))))) 42
     (into [] (take 2) (cycle (map #(/ 42 %) '(2 1 0)))) '(21 42)))
 
-
 (deftest test-partition
   (are [x y] (= x y)
     (partition 2 [1 2 3]) '((1 2))
@@ -781,49 +761,46 @@
 
     (partition 5 [1 2 3]) ()
 
-;    (partition 0 [1 2 3]) (repeat nil)   ; infinite sequence of nil
+;;     (partition 0 [1 2 3]) (repeat nil)   ; infinite sequence of nil
     (partition -1 [1 2 3]) ()
-    (partition -2 [1 2 3]) () )
+    (partition -2 [1 2 3]) ())
 
     ;; reduce
-    (is (= [1 2 4 8 16] (map #(reduce * (repeat % 2)) (range 5))))
-    (is (= [3 6 12 24 48] (map #(reduce * 3 (repeat % 2)) (range 5))))
+  (is (= [1 2 4 8 16] (map #(reduce * (repeat % 2)) (range 5))))
+  (is (= [3 6 12 24 48] (map #(reduce * 3 (repeat % 2)) (range 5))))
 
     ;; equality and hashing
-    (is (= (repeat 5 :x) (repeat 5 :x)))
-    (is (= (repeat 5 :x) '(:x :x :x :x :x)))
-    (is (= (hash (repeat 5 :x)) (hash '(:x :x :x :x :x))))
-    (is (= (assoc (array-map (repeat 1 :x) :y) '(:x) :z) {'(:x) :z}))
-    (is (= (assoc (hash-map (repeat 1 :x) :y) '(:x) :z) {'(:x) :z})))
-
+  (is (= (repeat 5 :x) (repeat 5 :x)))
+  (is (= (repeat 5 :x) '(:x :x :x :x :x)))
+  (is (= (hash (repeat 5 :x)) (hash '(:x :x :x :x :x))))
+  (is (= (assoc (array-map (repeat 1 :x) :y) '(:x) :z) {'(:x) :z}))
+  (is (= (assoc (hash-map (repeat 1 :x) :y) '(:x) :z) {'(:x) :z})))
 
 (deftest test-iterate
-      (are [x y] (= x y)
-           (take 0 (iterate inc 0)) ()
-           (take 1 (iterate inc 0)) '(0)
-           (take 2 (iterate inc 0)) '(0 1)
-           (take 5 (iterate inc 0)) '(0 1 2 3 4) )
+  (are [x y] (= x y)
+    (take 0 (iterate inc 0)) ()
+    (take 1 (iterate inc 0)) '(0)
+    (take 2 (iterate inc 0)) '(0 1)
+    (take 5 (iterate inc 0)) '(0 1 2 3 4))
 
       ;; test other fns
-      (is (= '(:foo 42 :foo 42) (take 4 (iterate #(if (= % :foo) 42 :foo) :foo))))
-      (is (= '(1 false true true) (take 4 (iterate #(instance? Boolean %) 1))))
-      (is (= '(256 128 64 32 16 8 4 2 1 0) (take 10 (iterate #(quot % 2) 256))))
-      (is (= '(0 true) (take 2 (iterate zero? 0))))
-      (is (= 2 (first (next (next (iterate inc 0))))))
-      (is (= [1 2 3] (into [] (take 3) (next (iterate inc 0)))))
+  (is (= '(:foo 42 :foo 42) (take 4 (iterate #(if (= % :foo) 42 :foo) :foo))))
+  (is (= '(1 false true true) (take 4 (iterate #(instance? Boolean %) 1))))
+  (is (= '(256 128 64 32 16 8 4 2 1 0) (take 10 (iterate #(quot % 2) 256))))
+  (is (= '(0 true) (take 2 (iterate zero? 0))))
+  (is (= 2 (first (next (next (iterate inc 0))))))
+  (is (= [1 2 3] (into [] (take 3) (next (iterate inc 0)))))
 
       ;; reduce via transduce
-      (is (= (transduce (take 5) + (iterate #(* 2 %) 2)) 62))
-      (is (= (transduce (take 5) + 1 (iterate #(* 2 %) 2)) 63)) )
-
+  (is (= (transduce (take 5) + (iterate #(* 2 %) 2)) 62))
+  (is (= (transduce (take 5) + 1 (iterate #(* 2 %) 2)) 63)))
 
 (deftest test-reverse
   (are [x y] (= x y)
     (reverse nil) ()    ; since SVN 1294
     (reverse []) ()
     (reverse [1]) '(1)
-    (reverse [1 2 3]) '(3 2 1) ))
-
+    (reverse [1 2 3]) '(3 2 1)))
 
 (deftest test-take
   (are [x y] (= x y)
@@ -834,8 +811,7 @@
 
     (take 0 [1 2 3 4 5]) ()
     (take -1 [1 2 3 4 5]) ()
-    (take -2 [1 2 3 4 5]) () ))
-
+    (take -2 [1 2 3 4 5]) ()))
 
 (deftest test-drop
   (are [x y] (= x y)
@@ -846,24 +822,22 @@
 
     (drop 0 [1 2 3 4 5]) '(1 2 3 4 5)
     (drop -1 [1 2 3 4 5]) '(1 2 3 4 5)
-    (drop -2 [1 2 3 4 5]) '(1 2 3 4 5) ))
-
+    (drop -2 [1 2 3 4 5]) '(1 2 3 4 5)))
 
 (deftest test-take-nth
   (are [x y] (= x y)
-     (take-nth 1 [1 2 3 4 5]) '(1 2 3 4 5)
-     (take-nth 2 [1 2 3 4 5]) '(1 3 5)
-     (take-nth 3 [1 2 3 4 5]) '(1 4)
-     (take-nth 4 [1 2 3 4 5]) '(1 5)
-     (take-nth 5 [1 2 3 4 5]) '(1)
-     (take-nth 9 [1 2 3 4 5]) '(1)
+    (take-nth 1 [1 2 3 4 5]) '(1 2 3 4 5)
+    (take-nth 2 [1 2 3 4 5]) '(1 3 5)
+    (take-nth 3 [1 2 3 4 5]) '(1 4)
+    (take-nth 4 [1 2 3 4 5]) '(1 5)
+    (take-nth 5 [1 2 3 4 5]) '(1)
+    (take-nth 9 [1 2 3 4 5]) '(1)
 
      ; infinite seq of 1s = (repeat 1)
      ;(take-nth 0 [1 2 3 4 5])
      ;(take-nth -1 [1 2 3 4 5])
      ;(take-nth -2 [1 2 3 4 5])
-  ))
-
+))
 
 (deftest test-take-while
   (are [x y] (= x y)
@@ -872,8 +846,7 @@
     (take-while pos? [1 2 3 -1]) '(1 2 3)
     (take-while pos? [1 -1 2 3]) '(1)
     (take-while pos? [-1 1 2 3]) ()
-    (take-while pos? [-1 -2 -3]) () ))
-
+    (take-while pos? [-1 -2 -3]) ()))
 
 (deftest test-drop-while
   (are [x y] (= x y)
@@ -882,15 +855,13 @@
     (drop-while pos? [1 2 3 -1]) '(-1)
     (drop-while pos? [1 -1 2 3]) '(-1 2 3)
     (drop-while pos? [-1 1 2 3]) '(-1 1 2 3)
-    (drop-while pos? [-1 -2 -3]) '(-1 -2 -3) ))
-
+    (drop-while pos? [-1 -2 -3]) '(-1 -2 -3)))
 
 (deftest test-butlast
   (are [x y] (= x y)
     (butlast []) nil
     (butlast [1]) nil
-    (butlast [1 2 3]) '(1 2) ))
-
+    (butlast [1 2 3]) '(1 2)))
 
 (deftest test-drop-last
   (are [x y] (= x y)
@@ -922,8 +893,7 @@
 
     (drop-last -2 []) ()
     (drop-last -2 [1]) '(1)
-    (drop-last -2 [1 2 3]) '(1 2 3) ))
-
+    (drop-last -2 [1 2 3]) '(1 2 3)))
 
 (deftest test-split-at
   (is (vector? (split-at 2 [])))
@@ -936,8 +906,7 @@
     (split-at 5 [1 2 3]) [(list 1 2 3) ()]
     (split-at 0 [1 2 3]) [() (list 1 2 3)]
     (split-at -1 [1 2 3]) [() (list 1 2 3)]
-    (split-at -5 [1 2 3]) [() (list 1 2 3)] ))
-
+    (split-at -5 [1 2 3]) [() (list 1 2 3)]))
 
 (deftest test-split-with
   (is (vector? (split-with pos? [])))
@@ -948,45 +917,44 @@
     (split-with pos? [1 2 -1 0 3 4]) [(list 1 2) (list -1 0 3 4)]
 
     (split-with pos? [-1 2 3 4 5]) [() (list -1 2 3 4 5)]
-    (split-with number? [1 -2 "abc" \x]) [(list 1 -2) (list "abc" \x)] ))
-
+    (split-with number? [1 -2 "abc" \x]) [(list 1 -2) (list "abc" \x)]))
 
 (deftest test-repeat
   ;(is (thrown? IllegalArgumentException (repeat)))
 
   ; infinite sequence => use take
   (are [x y] (= x y)
-      (take 0 (repeat 7)) ()
-      (take 1 (repeat 7)) '(7)
-      (take 2 (repeat 7)) '(7 7)
-      (take 5 (repeat 7)) '(7 7 7 7 7) )
+    (take 0 (repeat 7)) ()
+    (take 1 (repeat 7)) '(7)
+    (take 2 (repeat 7)) '(7 7)
+    (take 5 (repeat 7)) '(7 7 7 7 7))
 
   ; limited sequence
   (are [x y] (= x y)
-      (repeat 0 7) ()
-      (repeat 1 7) '(7)
-      (repeat 2 7) '(7 7)
-      (repeat 5 7) '(7 7 7 7 7)
+    (repeat 0 7) ()
+    (repeat 1 7) '(7)
+    (repeat 2 7) '(7 7)
+    (repeat 5 7) '(7 7 7 7 7)
 
-      (repeat -1 7) ()
-      (repeat -3 7) () )
+    (repeat -1 7) ()
+    (repeat -3 7) ())
 
   ; test different data types
   (are [x] (= (repeat 3 x) (list x x x))
-      nil
-      false true
-      0 42
-      0.0 3.14
-      2/3
-      0M 1M
-      \c
-      "" "abc"
-      'sym
-      :kw
-      () '(1 2)
-      [] [1 2]
-      {} {:a 1 :b 2}
-      #{} #{1 2} ))
+    nil
+    false true
+    0 42
+    0.0 3.14
+    2/3
+    0M 1M
+    \c
+    "" "abc"
+    'sym
+    :kw
+    () '(1 2)
+    [] [1 2]
+    {} {:a 1 :b 2}
+    #{} #{1 2}))
 
 (defspec longrange-equals-range 100
   (prop/for-all [start gen/int
@@ -997,66 +965,66 @@
 
 (deftest test-range
   (are [x y] (= x y)
-      (take 100 (range)) (range 100)
+    (take 100 (range)) (range 100)
 
-      (range 0) ()   ; exclusive end!
-      (range 1) '(0)
-      (range 5) '(0 1 2 3 4)
+    (range 0) ()   ; exclusive end!
+    (range 1) '(0)
+    (range 5) '(0 1 2 3 4)
 
-      (range -1) ()
-      (range -3) ()
+    (range -1) ()
+    (range -3) ()
 
-      (range 2.5) '(0 1 2)
-      (range 7/3) '(0 1 2)
+    (range 2.5) '(0 1 2)
+    (range 7/3) '(0 1 2)
 
-      (range 0 3) '(0 1 2)
-      (range 0 1) '(0)
-      (range 0 0) ()
-      (range 0 -3) ()
+    (range 0 3) '(0 1 2)
+    (range 0 1) '(0)
+    (range 0 0) ()
+    (range 0 -3) ()
 
-      (range 3 6) '(3 4 5)
-      (range 3 4) '(3)
-      (range 3 3) ()
-      (range 3 1) ()
-      (range 3 0) ()
-      (range 3 -2) ()
+    (range 3 6) '(3 4 5)
+    (range 3 4) '(3)
+    (range 3 3) ()
+    (range 3 1) ()
+    (range 3 0) ()
+    (range 3 -2) ()
 
-      (range -2 5) '(-2 -1 0 1 2 3 4)
-      (range -2 0) '(-2 -1)
-      (range -2 -1) '(-2)
-      (range -2 -2) ()
-      (range -2 -5) ()
+    (range -2 5) '(-2 -1 0 1 2 3 4)
+    (range -2 0) '(-2 -1)
+    (range -2 -1) '(-2)
+    (range -2 -2) ()
+    (range -2 -5) ()
 
-      (take 3 (range 3 9 0)) '(3 3 3)
-      (take 3 (range 9 3 0)) '(9 9 9)
-      (range 0 0 0) ()
-      (range 3 9 1) '(3 4 5 6 7 8)
-      (range 3 9 2) '(3 5 7)
-      (range 3 9 3) '(3 6)
-      (range 3 9 10) '(3)
-      (range 3 9 -1) ()
-      (range 10 10 -1) ()
-      (range 10 9 -1) '(10)
-      (range 10 8 -1) '(10 9)
-      (range 10 7 -1) '(10 9 8)
-      (range 10 0 -2) '(10 8 6 4 2)
+    (take 3 (range 3 9 0)) '(3 3 3)
+    (take 3 (range 9 3 0)) '(9 9 9)
+    (range 0 0 0) ()
+    (range 3 9 1) '(3 4 5 6 7 8)
+    (range 3 9 2) '(3 5 7)
+    (range 3 9 3) '(3 6)
+    (range 3 9 10) '(3)
+    (range 3 9 -1) ()
+    (range 10 10 -1) ()
+    (range 10 9 -1) '(10)
+    (range 10 8 -1) '(10 9)
+    (range 10 7 -1) '(10 9 8)
+    (range 10 0 -2) '(10 8 6 4 2)
 
-      (take 100 (range)) (take 100 (iterate inc 0))
+    (take 100 (range)) (take 100 (iterate inc 0))
 
-      (range 1/2 5 1/3) '(1/2 5/6 7/6 3/2 11/6 13/6 5/2 17/6 19/6 7/2 23/6 25/6 9/2 29/6)
-      (range 0.5 8 1.2) '(0.5 1.7 2.9 4.1 5.3 6.5 7.7)
-      (range 0.5 -4 -2) '(0.5 -1.5 -3.5)
-      (take 3 (range Long/MAX_VALUE Double/POSITIVE_INFINITY)) '(9223372036854775807 9223372036854775808N 9223372036854775809N)
+    (range 1/2 5 1/3) '(1/2 5/6 7/6 3/2 11/6 13/6 5/2 17/6 19/6 7/2 23/6 25/6 9/2 29/6)
+    (range 0.5 8 1.2) '(0.5 1.7 2.9 4.1 5.3 6.5 7.7)
+    (range 0.5 -4 -2) '(0.5 -1.5 -3.5)
+    (take 3 (range Long/MAX_VALUE Double/POSITIVE_INFINITY)) '(9223372036854775807 9223372036854775808N 9223372036854775809N)
 
-      (reduce + (take 100 (range))) 4950
-      (reduce + 0 (take 100 (range))) 4950
-      (reduce + (range 100)) 4950
-      (reduce + 0 (range 100)) 4950
-      (reduce + (range 0.0 100.0)) 4950.0
-      (reduce + 0 (range 0.0 100.0)) 4950.0
+    (reduce + (take 100 (range))) 4950
+    (reduce + 0 (take 100 (range))) 4950
+    (reduce + (range 100)) 4950
+    (reduce + 0 (range 100)) 4950
+    (reduce + (range 0.0 100.0)) 4950.0
+    (reduce + 0 (range 0.0 100.0)) 4950.0
 
-      (reduce + (iterator-seq (.iterator (range 100)))) 4950
-      (reduce + (iterator-seq (.iterator (range 0.0 100.0 1.0)))) 4950.0 ))
+    (reduce + (iterator-seq (.iterator (range 100)))) 4950
+    (reduce + (iterator-seq (.iterator (range 0.0 100.0 1.0)))) 4950.0))
 
 (defn unlimited-range-create [& args]
   (let [[arg1 arg2 arg3] args]
@@ -1078,19 +1046,19 @@
         lmin+31 (+ Long/MIN_VALUE 31)
         lmin+32 (+ Long/MIN_VALUE 32)
         lmin+33 (+ Long/MIN_VALUE 33)]
-    (doseq [range-args [ [lmax-2 lmax]
-                         [lmax-33 lmax]
-                         [lmax-33 lmax-31]
-                         [lmin+2 lmin -1]
-                         [lmin+33 lmin -1]
-                         [lmin+33 lmin+31 -1]
-                         [lmin lmax lmax]
-                         [lmax lmin lmin]
-                         [-1 lmax lmax]
-                         [1 lmin lmin]]]
-    (is (= (apply unlimited-range-create range-args)
-           (apply range range-args))
-        (apply str "from (range " (concat (interpose " " range-args) ")"))))))
+    (doseq [range-args [[lmax-2 lmax]
+                        [lmax-33 lmax]
+                        [lmax-33 lmax-31]
+                        [lmin+2 lmin -1]
+                        [lmin+33 lmin -1]
+                        [lmin+33 lmin+31 -1]
+                        [lmin lmax lmax]
+                        [lmax lmin lmin]
+                        [-1 lmax lmax]
+                        [1 lmin lmin]]]
+      (is (= (apply unlimited-range-create range-args)
+             (apply range range-args))
+          (apply str "from (range " (concat (interpose " " range-args) ")"))))))
 
 (deftest test-empty?
   (are [x] (empty? x)
@@ -1101,7 +1069,7 @@
     {}
     #{}
     ""
-    (into-array []) )
+    (into-array []))
 
   (are [x] (not (empty? x))
     '(1 2)
@@ -1110,180 +1078,175 @@
     {:a 1 :b 2}
     #{1 2}
     "abc"
-    (into-array [1 2]) ))
-
+    (into-array [1 2])))
 
 (deftest test-every?
   ; always true for nil or empty coll/seq
   (are [x] (= (every? pos? x) true)
-      nil
-      () [] {} #{}
-      (lazy-seq [])
-      (into-array []) )
+    nil
+    () [] {} #{}
+    (lazy-seq [])
+    (into-array []))
 
   (are [x y] (= x y)
-      true (every? pos? [1])
-      true (every? pos? [1 2])
-      true (every? pos? [1 2 3 4 5])
+    true (every? pos? [1])
+    true (every? pos? [1 2])
+    true (every? pos? [1 2 3 4 5])
 
-      false (every? pos? [-1])
-      false (every? pos? [-1 -2])
-      false (every? pos? [-1 -2 3])
-      false (every? pos? [-1 2])
-      false (every? pos? [1 -2])
-      false (every? pos? [1 2 -3])
-      false (every? pos? [1 2 -3 4]) )
+    false (every? pos? [-1])
+    false (every? pos? [-1 -2])
+    false (every? pos? [-1 -2 3])
+    false (every? pos? [-1 2])
+    false (every? pos? [1 -2])
+    false (every? pos? [1 2 -3])
+    false (every? pos? [1 2 -3 4]))
 
   (are [x y] (= x y)
-      true (every? #{:a} [:a :a])
+    true (every? #{:a} [:a :a])
 ;!      false (every? #{:a} [:a :b])   ; Issue 68: every? returns nil instead of false
 ;!      false (every? #{:a} [:b :b])   ; http://code.google.com/p/clojure/issues/detail?id=68
-  ))
-
+))
 
 (deftest test-not-every?
   ; always false for nil or empty coll/seq
   (are [x] (= (not-every? pos? x) false)
-      nil
-      () [] {} #{}
-      (lazy-seq [])
-      (into-array []) )
+    nil
+    () [] {} #{}
+    (lazy-seq [])
+    (into-array []))
 
   (are [x y] (= x y)
-      false (not-every? pos? [1])
-      false (not-every? pos? [1 2])
-      false (not-every? pos? [1 2 3 4 5])
+    false (not-every? pos? [1])
+    false (not-every? pos? [1 2])
+    false (not-every? pos? [1 2 3 4 5])
 
-      true (not-every? pos? [-1])
-      true (not-every? pos? [-1 -2])
-      true (not-every? pos? [-1 -2 3])
-      true (not-every? pos? [-1 2])
-      true (not-every? pos? [1 -2])
-      true (not-every? pos? [1 2 -3])
-      true (not-every? pos? [1 2 -3 4]) )
+    true (not-every? pos? [-1])
+    true (not-every? pos? [-1 -2])
+    true (not-every? pos? [-1 -2 3])
+    true (not-every? pos? [-1 2])
+    true (not-every? pos? [1 -2])
+    true (not-every? pos? [1 2 -3])
+    true (not-every? pos? [1 2 -3 4]))
 
   (are [x y] (= x y)
-      false (not-every? #{:a} [:a :a])
-      true (not-every? #{:a} [:a :b])
-      true (not-every? #{:a} [:b :b]) ))
-
+    false (not-every? #{:a} [:a :a])
+    true (not-every? #{:a} [:a :b])
+    true (not-every? #{:a} [:b :b])))
 
 (deftest test-not-any?
   ; always true for nil or empty coll/seq
   (are [x] (= (not-any? pos? x) true)
-      nil
-      () [] {} #{}
-      (lazy-seq [])
-      (into-array []) )
+    nil
+    () [] {} #{}
+    (lazy-seq [])
+    (into-array []))
 
   (are [x y] (= x y)
-      false (not-any? pos? [1])
-      false (not-any? pos? [1 2])
-      false (not-any? pos? [1 2 3 4 5])
+    false (not-any? pos? [1])
+    false (not-any? pos? [1 2])
+    false (not-any? pos? [1 2 3 4 5])
 
-      true (not-any? pos? [-1])
-      true (not-any? pos? [-1 -2])
+    true (not-any? pos? [-1])
+    true (not-any? pos? [-1 -2])
 
-      false (not-any? pos? [-1 -2 3])
-      false (not-any? pos? [-1 2])
-      false (not-any? pos? [1 -2])
-      false (not-any? pos? [1 2 -3])
-      false (not-any? pos? [1 2 -3 4]) )
+    false (not-any? pos? [-1 -2 3])
+    false (not-any? pos? [-1 2])
+    false (not-any? pos? [1 -2])
+    false (not-any? pos? [1 2 -3])
+    false (not-any? pos? [1 2 -3 4]))
 
   (are [x y] (= x y)
-      false (not-any? #{:a} [:a :a])
-      false (not-any? #{:a} [:a :b])
-      true (not-any? #{:a} [:b :b]) ))
-
+    false (not-any? #{:a} [:a :a])
+    false (not-any? #{:a} [:a :b])
+    true (not-any? #{:a} [:b :b])))
 
 (deftest test-some
   ;; always nil for nil or empty coll/seq
   (are [x] (= (some pos? x) nil)
-       nil
-       () [] {} #{}
-       (lazy-seq [])
-       (into-array []))
-  
+    nil
+    () [] {} #{}
+    (lazy-seq [])
+    (into-array []))
+
   (are [x y] (= x y)
-       nil (some nil nil)
-       
-       true (some pos? [1])
-       true (some pos? [1 2])
-       
-       nil (some pos? [-1])
-       nil (some pos? [-1 -2])
-       true (some pos? [-1 2])
-       true (some pos? [1 -2])
-       
-       :a (some #{:a} [:a :a])
-       :a (some #{:a} [:b :a])
-       nil (some #{:a} [:b :b])
-       
-       :a (some #{:a} '(:a :b))
-       :a (some #{:a} #{:a :b})
-       ))
+    nil (some nil nil)
+
+    true (some pos? [1])
+    true (some pos? [1 2])
+
+    nil (some pos? [-1])
+    nil (some pos? [-1 -2])
+    true (some pos? [-1 2])
+    true (some pos? [1 -2])
+
+    :a (some #{:a} [:a :a])
+    :a (some #{:a} [:b :a])
+    nil (some #{:a} [:b :b])
+
+    :a (some #{:a} '(:a :b))
+    :a (some #{:a} #{:a :b})))
 
 (deftest test-flatten-present
   (are [expected nested-val] (= (flatten nested-val) expected)
        ;simple literals
-       [] nil
-       [] 1
-       [] 'test
-       [] :keyword
-       [] 1/2
-       [] #"[\r\n]"
-       [] true
-       [] false
+    [] nil
+    [] 1
+    [] 'test
+    [] :keyword
+    [] 1/2
+    [] #"[\r\n]"
+    [] true
+    [] false
        ;vectors
-       [1 2 3 4 5] [[1 2] [3 4 [5]]]
-       [1 2 3 4 5] [1 2 3 4 5]
-       [#{1 2} 3 4 5] [#{1 2} 3 4 5]
+    [1 2 3 4 5] [[1 2] [3 4 [5]]]
+    [1 2 3 4 5] [1 2 3 4 5]
+    [#{1 2} 3 4 5] [#{1 2} 3 4 5]
        ;sets
-       [] #{}
-       [] #{#{1 2} 3 4 5}
-       [] #{1 2 3 4 5}
-       [] #{#{1 2} 3 4 5}
+    [] #{}
+    [] #{#{1 2} 3 4 5}
+    [] #{1 2 3 4 5}
+    [] #{#{1 2} 3 4 5}
        ;lists
-       [] '()
-       [1 2 3 4 5] `(1 2 3 4 5)
+    [] '()
+    [1 2 3 4 5] `(1 2 3 4 5)
        ;maps
-       [] {:a 1 :b 2}
-       [:a 1 :b 2] (sort-by key {:a 1 :b 2})
-       [] {[:a :b] 1 :c 2}
-       [:a :b 1 :c 2] (sort-by val {[:a :b] 1 :c 2})
-       [:a 1 2 :b 3] (sort-by key {:a [1 2] :b 3})
+    [] {:a 1 :b 2}
+    [:a 1 :b 2] (sort-by key {:a 1 :b 2})
+    [] {[:a :b] 1 :c 2}
+    [:a :b 1 :c 2] (sort-by val {[:a :b] 1 :c 2})
+    [:a 1 2 :b 3] (sort-by key {:a [1 2] :b 3})
        ;Strings
-       [] "12345"
-       [\1 \2 \3 \4 \5] (seq "12345")
+    [] "12345"
+    [\1 \2 \3 \4 \5] (seq "12345")
        ;fns
-       [] count
-       [count even? odd?] [count even? odd?]))
+    [] count
+    [count even? odd?] [count even? odd?]))
 
 (deftest test-group-by
-  (is (= (group-by even? [1 2 3 4 5]) 
-	 {false [1 3 5], true [2 4]})))
+  (is (= (group-by even? [1 2 3 4 5])
+         {false [1 3 5], true [2 4]})))
 
 (deftest test-partition-by
   (are [test-seq] (= (partition-by (comp even? count) test-seq)
-		     [["a"] ["bb" "cccc" "dd"] ["eee" "f"] ["" "hh"]])
-       ["a" "bb" "cccc" "dd" "eee" "f" "" "hh"]
-       '("a" "bb" "cccc" "dd" "eee" "f" "" "hh"))
-  (is (=(partition-by #{\a \e \i \o \u} "abcdefghijklm")
-       [[\a] [\b \c \d] [\e] [\f \g \h] [\i] [\j \k \l \m]])))
+                     [["a"] ["bb" "cccc" "dd"] ["eee" "f"] ["" "hh"]])
+    ["a" "bb" "cccc" "dd" "eee" "f" "" "hh"]
+    '("a" "bb" "cccc" "dd" "eee" "f" "" "hh"))
+  (is (= (partition-by #{\a \e \i \o \u} "abcdefghijklm")
+         [[\a] [\b \c \d] [\e] [\f \g \h] [\i] [\j \k \l \m]])))
 
 (deftest test-frequencies
   (are [expected test-seq] (= (frequencies test-seq) expected)
-       {\p 2, \s 4, \i 4, \m 1} "mississippi"
-       {1 4 2 2 3 1} [1 1 1 1 2 2 3]
-       {1 4 2 2 3 1} '(1 1 1 1 2 2 3)))
+    {\p 2, \s 4, \i 4, \m 1} "mississippi"
+    {1 4 2 2 3 1} [1 1 1 1 2 2 3]
+    {1 4 2 2 3 1} '(1 1 1 1 2 2 3)))
 
 (deftest test-reductions
   (is (= (reductions + nil)
          [0]))
   (is (= (reductions + [1 2 3 4 5])
-	 [1 3 6 10 15]))
+         [1 3 6 10 15]))
   (is (= (reductions + 10 [1 2 3 4 5])
-	 [10 11 13 16 20 25])))
+         [10 11 13 16 20 25])))
 
 (deftest test-reductions-obeys-reduced
   (is (= [0 :x]
@@ -1306,9 +1269,9 @@
 
 (deftest test-partition-all
   (is (= (partition-all 4 [1 2 3 4 5 6 7 8 9])
-	 [[1 2 3 4] [5 6 7 8] [9]]))
+         [[1 2 3 4] [5 6 7 8] [9]]))
   (is (= (partition-all 4 2 [1 2 3 4 5 6 7 8 9])
-	 [[1 2 3 4] [3 4 5 6] [5 6 7 8] [7 8 9] [9]])))
+         [[1 2 3 4] [3 4 5 6] [5 6 7 8] [7 8 9] [9]])))
 
 (deftest test-shuffle-invariants
   (is (= (count (shuffle [1 2 3 4])) 4))
@@ -1317,11 +1280,11 @@
 
 (deftest test-ArrayIter
   (are [arr expected]
-    (let [iter (clojure.lang.ArrayIter/createFromObject arr)]
-      (loop [accum []]
-        (if (.hasNext iter)
-          (recur (conj accum (.next iter)))
-          (is (= expected accum)))))
+       (let [iter (clojure.lang.ArrayIter/createFromObject arr)]
+         (loop [accum []]
+           (if (.hasNext iter)
+             (recur (conj accum (.next iter)))
+             (is (= expected accum)))))
     nil []
     (object-array ["a" "b" "c"]) ["a" "b" "c"]
     (boolean-array [false true false]) [false true false]

--- a/test/clojure/test_clojure/serialization.clj
+++ b/test/clojure/test_clojure/serialization.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;; Author: Chas Emerick
 ;;         cemerick@snowtide.com
@@ -12,7 +12,7 @@
 (ns clojure.test-clojure.serialization
   (:use clojure.test)
   (:import (java.io ObjectOutputStream ObjectInputStream
-             ByteArrayOutputStream ByteArrayInputStream)))
+                    ByteArrayOutputStream ByteArrayInputStream)))
 
 (defn- serialize
   "Serializes a single object, returning a byte array."
@@ -35,17 +35,17 @@
 (defn- build-via-transient
   [coll]
   (persistent!
-    (reduce conj! (transient coll) (map vec (partition 2 (range 1000))))))
+   (reduce conj! (transient coll) (map vec (partition 2 (range 1000))))))
 
 (defn- roundtrip
   [v]
   (let [rt (-> v serialize deserialize)
         rt-seq (-> v seq serialize deserialize)]
     (and (= v rt)
-      (= (seq v) (seq rt))
-      (= (seq v) rt-seq)
-      (= (hash v) (hash rt))
-      (= (.hashCode v) (.hashCode rt)))))
+         (= (seq v) (seq rt))
+         (= (seq v) rt-seq)
+         (= (hash v) (hash rt))
+         (= (.hashCode v) (.hashCode rt)))))
 
 (deftest sequable-serialization
   (are [val] (roundtrip val)
@@ -143,7 +143,7 @@
 (deftest interned-serializations
   (are [v] (identical? v (-> v serialize deserialize))
     clojure.lang.RT/DEFAULT_COMPARATOR
-    
+
     ; namespaces just get deserialized back into the same-named ns in the present runtime
     ; (they're referred to by defrecord instances)
     *ns*))

--- a/test/clojure/test_clojure/server.clj
+++ b/test/clojure/test_clojure/server.clj
@@ -1,16 +1,16 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Alex Miller
+;; Author: Alex Miller
 
 (ns clojure.test-clojure.server
-    (:require [clojure.test :refer :all])
-    (:require [clojure.core.server :as s]))
+  (:require [clojure.test :refer :all])
+  (:require [clojure.core.server :as s]))
 
 (defn check-invalid-opts
   [opts msg]

--- a/test/clojure/test_clojure/special.clj
+++ b/test/clojure/test_clojure/special.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka
+;; Author: Frantisek Sodomka
 
 ;;
 ;;  Test special forms, macros and metadata
@@ -15,12 +15,12 @@
 (ns clojure.test-clojure.special
   (:use clojure.test))
 
-; http://clojure.org/special_forms
+;; http://clojure.org/special_forms
 
-; let, letfn
-; quote
-; var
-; fn
+;; let, letfn
+;; quote
+;; var
+;; fn
 
 (deftest multiple-keys-in-destructuring
   (let [foo (fn [& {:keys [x]}] x)

--- a/test/clojure/test_clojure/string.clj
+++ b/test/clojure/test_clojure/string.clj
@@ -47,15 +47,15 @@
 
 (deftest t-join
   (are [x coll] (= x (s/join coll))
-       "" nil
-       "" []
-       "1" [1]
-       "12" [1 2])
+    "" nil
+    "" []
+    "1" [1]
+    "12" [1 2])
   (are [x sep coll] (= x (s/join sep coll))
-       "1,2,3" \, [1 2 3]
-       "" \, []
-       "1" \, [1]
-       "1 and-a 2 and-a 3" " and-a " [1 2 3]))
+    "1,2,3" \, [1 2 3]
+    "" \, []
+    "1" \, [1]
+    "1 and-a 2 and-a 3" " and-a " [1 2 3]))
 
 (deftest t-trim-newline
   (is (= "foo" (s/trim-newline "foo\n")))
@@ -89,42 +89,42 @@
 
 (deftest nil-handling
   (are [f args] (thrown? NullPointerException (apply f args))
-       s/reverse [nil]
-       s/replace [nil #"foo" "bar"]
-       s/replace-first [nil #"foo" "bar"]
-       s/re-quote-replacement [nil]
-       s/capitalize [nil]
-       s/upper-case [nil]
-       s/lower-case [nil]
-       s/split [nil #"-"]
-       s/split [nil #"-" 1]
-       s/trim [nil]
-       s/triml [nil]
-       s/trimr [nil]
-       s/trim-newline [nil]))
+    s/reverse [nil]
+    s/replace [nil #"foo" "bar"]
+    s/replace-first [nil #"foo" "bar"]
+    s/re-quote-replacement [nil]
+    s/capitalize [nil]
+    s/upper-case [nil]
+    s/lower-case [nil]
+    s/split [nil #"-"]
+    s/split [nil #"-" 1]
+    s/trim [nil]
+    s/triml [nil]
+    s/trimr [nil]
+    s/trim-newline [nil]))
 
 (deftest char-sequence-handling
   (are [result f args] (let [[^CharSequence s & more] args]
                          (= result (apply f (StringBuffer. s) more)))
-       "paz" s/reverse ["zap"]
-       "foo:bar" s/replace ["foo-bar" \- \:]
-       "ABC" s/replace ["abc" #"\w" s/upper-case]
-       "faa" s/replace ["foo" #"o" (StringBuffer. "a")]
-       "baz::quux" s/replace-first ["baz--quux" #"--" "::"]
-       "baz::quux" s/replace-first ["baz--quux" (StringBuffer. "--") (StringBuffer. "::")]
-       "zim-zam" s/replace-first ["zim zam" #" " (StringBuffer. "-")]
-       "\\\\ \\$" s/re-quote-replacement ["\\ $"]
-       "Pow" s/capitalize ["POW"]
-       "BOOM" s/upper-case ["boom"]
-       "whimper" s/lower-case ["whimPER"]
-       ["foo" "bar"] s/split ["foo-bar" #"-"]
-       "calvino" s/trim ["  calvino  "]
-       "calvino  " s/triml ["  calvino  "]
-       "  calvino" s/trimr ["  calvino  "]
-       "the end" s/trim-newline ["the end\r\n\r\r\n"]
-       true s/blank? [" "]
-       ["a" "b"] s/split-lines ["a\nb"]
-       "fa la la" s/escape ["fo lo lo" {\o \a}]))
+    "paz" s/reverse ["zap"]
+    "foo:bar" s/replace ["foo-bar" \- \:]
+    "ABC" s/replace ["abc" #"\w" s/upper-case]
+    "faa" s/replace ["foo" #"o" (StringBuffer. "a")]
+    "baz::quux" s/replace-first ["baz--quux" #"--" "::"]
+    "baz::quux" s/replace-first ["baz--quux" (StringBuffer. "--") (StringBuffer. "::")]
+    "zim-zam" s/replace-first ["zim zam" #" " (StringBuffer. "-")]
+    "\\\\ \\$" s/re-quote-replacement ["\\ $"]
+    "Pow" s/capitalize ["POW"]
+    "BOOM" s/upper-case ["boom"]
+    "whimper" s/lower-case ["whimPER"]
+    ["foo" "bar"] s/split ["foo-bar" #"-"]
+    "calvino" s/trim ["  calvino  "]
+    "calvino  " s/triml ["  calvino  "]
+    "  calvino" s/trimr ["  calvino  "]
+    "the end" s/trim-newline ["the end\r\n\r\r\n"]
+    true s/blank? [" "]
+    ["a" "b"] s/split-lines ["a\nb"]
+    "fa la la" s/escape ["fo lo lo" {\o \a}]))
 
 (deftest t-escape
   (is (= "&lt;foo&amp;bar&gt;"
@@ -160,14 +160,14 @@
     (is (= nil (s/index-of sb "z" 2)))
     (is (= nil (s/index-of sb \z  2)))
     (is (= nil (s/index-of sb "z" 100))
-    (is (= nil (s/index-of sb "z" -10))))))
+        (is (= nil (s/index-of sb "z" -10))))))
 
 (deftest t-last-index-of
   (let [sb (StringBuffer. "banana")]
     (is (= 4 (s/last-index-of sb "n")))
     (is (= 4 (s/last-index-of sb \n)))
     (is (= 3 (s/last-index-of sb "an")))
-    (is (= 4 (s/last-index-of sb "n" )))
+    (is (= 4 (s/last-index-of sb "n")))
     (is (= 4 (s/last-index-of sb "n" 5)))
     (is (= 4 (s/last-index-of sb \n  5)))
     (is (= 4 (s/last-index-of sb "n" 500)))
@@ -175,7 +175,7 @@
     (is (= nil (s/last-index-of sb "z" 1)))
     (is (= nil (s/last-index-of sb \z  1)))
     (is (= nil (s/last-index-of sb "z" 100))
-    (is (= nil (s/last-index-of sb "z" -10))))))
+        (is (= nil (s/last-index-of sb "z" -10))))))
 
 (deftest t-starts-with?
   (is (s/starts-with? (StringBuffer. "clojure west") "clojure"))
@@ -183,7 +183,7 @@
 
 (deftest t-ends-with?
   (is (s/ends-with? (StringBuffer. "Clojure West") "West")
-  (is (not (s/ends-with? (StringBuffer. "Conj") "West")))))
+      (is (not (s/ends-with? (StringBuffer. "Conj") "West")))))
 
 (deftest t-includes?
   (let [sb (StringBuffer. "Clojure Applied Book")]

--- a/test/clojure/test_clojure/test.clj
+++ b/test/clojure/test_clojure/test.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;; test_clojure/test.clj: unit tests for test.clj
 
@@ -88,11 +88,10 @@
 (declare does-not-exist)
 
 #_(deftest can-test-unbound-symbol
-  (is (= nil does-not-exist) "Should error"))
+    (is (= nil does-not-exist) "Should error"))
 
 #_(deftest can-test-unbound-function
-  (is (does-not-exist) "Should error"))
-
+    (is (does-not-exist) "Should error"))
 
 ;; Here, we create an alternate version of test/report, that
 ;; compares the event with the message, then calls the original

--- a/test/clojure/test_clojure/test_fixtures.clj
+++ b/test/clojure/test_clojure/test_fixtures.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 ;
 ;;; test_fixtures.clj: unit tests for fixtures in test.clj
 

--- a/test/clojure/test_clojure/transducers.clj
+++ b/test/clojure/test_clojure/transducers.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Alex Miller
+;; Author: Alex Miller
 
 (ns clojure.test-clojure.transducers
   (:require [clojure.string :as s]
@@ -18,21 +18,21 @@
 
 (defmacro fbind [source-gen f]
   `(gen/fmap
-     (fn [s#]
-       {:desc (list '~f (:name s#))
-        :seq  (partial ~f (:val s#))
-        :xf   (~f (:val s#))})
-     ~source-gen))
+    (fn [s#]
+      {:desc (list '~f (:name s#))
+       :seq  (partial ~f (:val s#))
+       :xf   (~f (:val s#))})
+    ~source-gen))
 
 (defmacro pickfn [& fns]
   `(gen/elements
-     [~@(for [f fns] `{:val ~f :name '~f})]))
+    [~@(for [f fns] `{:val ~f :name '~f})]))
 
 (defn literal
   [g]
   (gen/fmap
-    (fn [s] {:val s :name s})
-    g))
+   (fn [s] {:val s :name s})
+   g))
 
 ;; These $ versions are "safe" when used with possibly mixed numbers, sequences, etc
 
@@ -101,11 +101,11 @@
 
 (defn apply-as-seq [coll actions]
   (doall
-    (loop [s coll
-           [action & actions'] actions]
-          (if action
-            (recur ((:seq action) s) actions')
-            s))))
+   (loop [s coll
+          [action & actions'] actions]
+     (if action
+       (recur ((:seq action) s) actions')
+       s))))
 
 (defn apply-as-xf-seq
   [coll actions]
@@ -143,8 +143,8 @@
 
 (def result-gen
   (gen/fmap
-    (fn [[c a]] (build-results c a))
-    (gen/tuple gen-coll gen-actions)))
+   (fn [[c a]] (build-results c a))
+   (gen/tuple gen-coll gen-actions)))
 
 (defn result-good?
   [{:keys [s xs xi xe xt]}]
@@ -152,18 +152,18 @@
 
 (deftest seq-and-transducer
   (let [res (chk/quick-check
-              200000
-              (prop/for-all* [result-gen] result-good?))]
+             200000
+             (prop/for-all* [result-gen] result-good?))]
     (when-not (:result res)
       (is
-        (:result res)
-        (->
-          res
-          :shrunk
-          :smallest
-          first
-          clojure.pprint/pprint
-          with-out-str)))))
+       (:result res)
+       (->
+        res
+        :shrunk
+        :smallest
+        first
+        clojure.pprint/pprint
+        with-out-str)))))
 
 (deftest test-transduce
   (let [long+ (fn ([a b] (+ (long a) (long b)))
@@ -203,8 +203,7 @@
             (transduce mapinc + float-vec)
             (transduce mapinclong + char-vec)
             (transduce mapinc + double-vec)
-            (transduce mapinclong + byte-vec)
-            ))
+            (transduce mapinclong + byte-vec)))
     (is (== 5051
             (transduce mapinc + 1 arange)
             (transduce mapinc + 1 avec)
@@ -225,88 +224,88 @@
 
 (deftest test-dedupe
   (are [x y] (= (transduce (dedupe) conj x) y)
-             [] []
-             [1] [1]
-             [1 2 3] [1 2 3]
-             [1 2 3 1 2 2 1 1] [1 2 3 1 2 1]
-             [1 1 1 2] [1 2]
-             [1 1 1 1] [1]
+    [] []
+    [1] [1]
+    [1 2 3] [1 2 3]
+    [1 2 3 1 2 2 1 1] [1 2 3 1 2 1]
+    [1 1 1 2] [1 2]
+    [1 1 1 1] [1]
 
-             "" []
-             "a" [\a]
-             "aaaa" [\a]
-             "aabaa" [\a \b \a]
-             "abba" [\a \b \a]
+    "" []
+    "a" [\a]
+    "aaaa" [\a]
+    "aabaa" [\a \b \a]
+    "abba" [\a \b \a]
 
-             [nil nil nil] [nil]
-             [1 1.0 1.0M 1N] [1 1.0 1.0M 1N]
-             [0.5 0.5] [0.5]))
+    [nil nil nil] [nil]
+    [1 1.0 1.0M 1N] [1 1.0 1.0M 1N]
+    [0.5 0.5] [0.5]))
 
 (deftest test-cat
   (are [x y] (= (transduce cat conj x) y)
-             [] []
-             [[1 2]] [1 2]
-             [[1 2] [3 4]] [1 2 3 4]
-             [[] [3 4]] [3 4]
-             [[1 2] []] [1 2]
-             [[] []] []
-             [[1 2] [3 4] [5 6]] [1 2 3 4 5 6]))
+    [] []
+    [[1 2]] [1 2]
+    [[1 2] [3 4]] [1 2 3 4]
+    [[] [3 4]] [3 4]
+    [[1 2] []] [1 2]
+    [[] []] []
+    [[1 2] [3 4] [5 6]] [1 2 3 4 5 6]))
 
 (deftest test-partition-all
   (are [n coll y] (= (transduce (partition-all n) conj coll) y)
-                  2 [1 2 3] '((1 2) (3))
-                  2 [1 2 3 4] '((1 2) (3 4))
-                  2 [] ()
-                  1 [] ()
-                  1 [1 2 3] '((1) (2) (3))
-                  5 [1 2 3] '((1 2 3))))
+    2 [1 2 3] '((1 2) (3))
+    2 [1 2 3 4] '((1 2) (3 4))
+    2 [] ()
+    1 [] ()
+    1 [1 2 3] '((1) (2) (3))
+    5 [1 2 3] '((1 2 3))))
 
 (deftest test-take
   (are [n y] (= (transduce (take n) conj [1 2 3 4 5]) y)
-             1 '(1)
-             3 '(1 2 3)
-             5 '(1 2 3 4 5)
-             9 '(1 2 3 4 5)
-             0 ()
-             -1 ()
-             -2 ()))
+    1 '(1)
+    3 '(1 2 3)
+    5 '(1 2 3 4 5)
+    9 '(1 2 3 4 5)
+    0 ()
+    -1 ()
+    -2 ()))
 
 (deftest test-drop
   (are [n y] (= (transduce (drop n) conj [1 2 3 4 5]) y)
-             1 '(2 3 4 5)
-             3 '(4 5)
-             5 ()
-             9 ()
-             0 '(1 2 3 4 5)
-             -1 '(1 2 3 4 5)
-             -2 '(1 2 3 4 5)))
+    1 '(2 3 4 5)
+    3 '(4 5)
+    5 ()
+    9 ()
+    0 '(1 2 3 4 5)
+    -1 '(1 2 3 4 5)
+    -2 '(1 2 3 4 5)))
 
 (deftest test-take-nth
   (are [n y] (= (transduce (take-nth n) conj [1 2 3 4 5]) y)
-             1 '(1 2 3 4 5)
-             2 '(1 3 5)
-             3 '(1 4)
-             4 '(1 5)
-             5 '(1)
-             9 '(1)))
+    1 '(1 2 3 4 5)
+    2 '(1 3 5)
+    3 '(1 4)
+    4 '(1 5)
+    5 '(1)
+    9 '(1)))
 
 (deftest test-take-while
   (are [coll y] (= (transduce (take-while pos?) conj coll) y)
-                [] ()
-                [1 2 3 4] '(1 2 3 4)
-                [1 2 3 -1] '(1 2 3)
-                [1 -1 2 3] '(1)
-                [-1 1 2 3] ()
-                [-1 -2 -3] ()))
+    [] ()
+    [1 2 3 4] '(1 2 3 4)
+    [1 2 3 -1] '(1 2 3)
+    [1 -1 2 3] '(1)
+    [-1 1 2 3] ()
+    [-1 -2 -3] ()))
 
 (deftest test-drop-while
   (are [coll y] (= (transduce (drop-while pos?) conj coll) y)
-                [] ()
-                [1 2 3 4] ()
-                [1 2 3 -1] '(-1)
-                [1 -1 2 3] '(-1 2 3)
-                [-1 1 2 3] '(-1 1 2 3)
-                [-1 -2 -3] '(-1 -2 -3)))
+    [] ()
+    [1 2 3 4] ()
+    [1 2 3 -1] '(-1)
+    [1 -1 2 3] '(-1 2 3)
+    [-1 1 2 3] '(-1 1 2 3)
+    [-1 -2 -3] '(-1 -2 -3)))
 
 (deftest test-re-reduced
   (is (= [:a] (transduce (take 1) conj [:a])))
@@ -333,24 +332,24 @@
            (eduction (map inc) (filter even?) (map str) (range 5)))))
   (testing "materialize at the end"
     (is (= [1 1 1 1 2 2 2 3 3 4]
-          (->> (range 5)
-            (eduction (mapcat range) (map inc))
-            sort)))
+           (->> (range 5)
+                (eduction (mapcat range) (map inc))
+                sort)))
     (is (= [1 1 2 1 2 3 1 2 3 4]
-          (vec (->> (range 5)
-                 (eduction (mapcat range) (map inc))
-                 to-array))))
+           (vec (->> (range 5)
+                     (eduction (mapcat range) (map inc))
+                     to-array))))
     (is (= {1 4, 2 3, 3 2, 4 1}
-          (->> (range 5)
-            (eduction (mapcat range) (map inc))
-            frequencies)))
+           (->> (range 5)
+                (eduction (mapcat range) (map inc))
+                frequencies)))
     (is (= ["drib" "god" "hsif" "kravdraa" "tac"]
-          (->> ["cat" "dog" "fish" "bird" "aardvark"]
-            (eduction (map clojure.string/reverse))
-            (sort-by first)))))
+           (->> ["cat" "dog" "fish" "bird" "aardvark"]
+                (eduction (map clojure.string/reverse))
+                (sort-by first)))))
   (testing "expanding transducer with nils"
-           (is (= '(1 2 3 nil 4 5 6 nil)
-                  (eduction cat [[1 2 3 nil] [4 5 6 nil]])))))
+    (is (= '(1 2 3 nil 4 5 6 nil)
+           (eduction cat [[1 2 3 nil] [4 5 6 nil]])))))
 
 (deftest test-eduction-completion
   (testing "eduction completes inner xformed reducing fn"
@@ -374,24 +373,24 @@
 
 (deftest test-distinct
   (are [out in] (= out (sequence (distinct in)) (sequence (distinct) in))
-       [] []
-       (range 10) (range 10)
-       [0] (repeat 10 0)
-       [0 1 2] [0 0 1 1 2 2 1 1 0 0]
-       [1] [1 1N]))
+    [] []
+    (range 10) (range 10)
+    [0] (repeat 10 0)
+    [0 1 2] [0 0 1 1 2 2 1 1 0 0]
+    [1] [1 1N]))
 
 (deftest test-interpose
   (are [out in] (= out (sequence (interpose :s) in))
-       [] (range 0)
-       [0] (range 1)
-       [0 :s 1] (range 2)
-       [0 :s 1 :s 2] (range 3))
+    [] (range 0)
+    [0] (range 1)
+    [0 :s 1] (range 2)
+    [0 :s 1 :s 2] (range 3))
   (testing "Can end reduction on separator or input"
     (let [expected (interpose :s (range))]
       (dotimes [i 10]
         (is (= (take i expected)
-          (sequence (comp (interpose :s) (take i))
-                    (range))))))))
+               (sequence (comp (interpose :s) (take i))
+                         (range))))))))
 
 (deftest test-map-indexed
   (is (= []

--- a/test/clojure/test_clojure/transients.clj
+++ b/test/clojure/test_clojure/transients.clj
@@ -3,17 +3,17 @@
 
 (deftest popping-off
   (testing "across a node boundary"
-    (are [n] 
-      (let [v (-> (range n) vec)]
-        (= (subvec v 0 (- n 2)) (-> v transient pop! pop! persistent!)))
+    (are [n]
+         (let [v (-> (range n) vec)]
+           (= (subvec v 0 (- n 2)) (-> v transient pop! pop! persistent!)))
       33 (+ 32 (inc (* 32 32))) (+ 32 (inc (* 32 32 32)))))
   (testing "off the end"
     (is (thrown-with-msg? IllegalStateException #"Can't pop empty vector"
-          (-> [] transient pop!))))
+                          (-> [] transient pop!))))
   (testing "copying array from a non-editable when put in tail position")
-    (is (= 31 (let [pv (vec (range 34))]
-                (-> pv transient pop! pop! pop! (conj! 42))
-                (nth pv 31)))))
+  (is (= 31 (let [pv (vec (range 34))]
+              (-> pv transient pop! pop! pop! (conj! 42))
+              (nth pv 31)))))
 
 (defn- hash-obj [hash]
   (reify Object (hashCode [this] hash)))
@@ -37,7 +37,7 @@
     (let [a (reify Object (hashCode [_] 42))
           b (reify Object (hashCode [_] 42))]
       (is (= (-> #{a b} transient (disj! a) persistent! (conj a))
-            (-> #{a b} transient (disj! a) persistent! (conj a)))))))
+             (-> #{a b} transient (disj! a) persistent! (conj a)))))))
 
 (deftest transient-mod-after-persistent
   (let [v [1 2 3]

--- a/test/clojure/test_clojure/try_catch.clj
+++ b/test/clojure/test_clojure/try_catch.clj
@@ -1,30 +1,29 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Paul M Bauer 
+;; Author: Paul M Bauer
 
 (ns clojure.test-clojure.try-catch
   (:use clojure.test)
-  (:import [clojure.test ReflectorTryCatchFixture 
-                         ReflectorTryCatchFixture$Cookies]))
+  (:import [clojure.test ReflectorTryCatchFixture
+            ReflectorTryCatchFixture$Cookies]))
 
 (defn- get-exception [expression]
   (try (eval expression)
-    nil
-    (catch java.lang.Throwable t
-      t)))
+       nil
+       (catch java.lang.Throwable t
+         t)))
 
 (deftest catch-receives-checked-exception-from-eval
   (are [expression expected-exception] (= expected-exception
                                           (type (get-exception expression)))
     "Eh, I'm pretty safe" nil
     '(java.io.FileReader. "CAFEBABEx0/idonotexist") java.io.FileNotFoundException))
-
 
 (defn fail [x]
   (ReflectorTryCatchFixture/fail x))
@@ -36,4 +35,4 @@
   (is (thrown-with-msg? ReflectorTryCatchFixture$Cookies #"Long" (fail 1)))
   (is (thrown-with-msg? ReflectorTryCatchFixture$Cookies #"Double" (fail 1.0)))
   (is (thrown-with-msg? ReflectorTryCatchFixture$Cookies #"Wrapped"
-        (.failWithCause (make-instance) 1.0))))
+                        (.failWithCause (make-instance) 1.0))))

--- a/test/clojure/test_clojure/vars.clj
+++ b/test/clojure/test_clojure/vars.clj
@@ -1,29 +1,28 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Frantisek Sodomka, Stephen C. Gilardi
+;; Author: Frantisek Sodomka, Stephen C. Gilardi
 
 
 (ns clojure.test-clojure.vars
   (:use clojure.test))
 
-; http://clojure.org/vars
+;; http://clojure.org/vars
 
-; def
-; defn defn- defonce
+;; def
+;; defn defn- defonce
 
-; declare intern binding find-var var
+;; declare intern binding find-var var
 
 (def ^:dynamic a)
 (deftest test-binding
   (are [x y] (= x y)
-      (eval `(binding [a 4] a)) 4     ; regression in Clojure SVN r1370
-  ))
+    (eval `(binding [a 4] a)) 4)) ; regression in Clojure SVN r1370
 
 (deftest defonce-test
   (let [_ (clojure.lang.Namespace/findOrCreate 'defonce-test)
@@ -45,9 +44,9 @@
                           (:once (meta (var a)))
                           (not (:foo (meta (var a)))))))))))
 
-; var-get var-set alter-var-root [var? (predicates.clj)]
-; with-in-str with-out-str
-; with-open
+;; var-get var-set alter-var-root [var? (predicates.clj)]
+;; with-in-str with-out-str
+;; with-open
 
 (deftest test-with-local-vars
   (let [factorial (fn [x]
@@ -60,16 +59,16 @@
 
 (deftest test-with-precision
   (are [x y] (= x y)
-       (with-precision 4 (+ 3.5555555M 1)) 4.556M
-       (with-precision 6 (+ 3.5555555M 1)) 4.55556M
-       (with-precision 6 :rounding CEILING     (+ 3.5555555M 1)) 4.55556M
-       (with-precision 6 :rounding FLOOR       (+ 3.5555555M 1)) 4.55555M
-       (with-precision 6 :rounding HALF_UP     (+ 3.5555555M 1)) 4.55556M
-       (with-precision 6 :rounding HALF_DOWN   (+ 3.5555555M 1)) 4.55556M
-       (with-precision 6 :rounding HALF_EVEN   (+ 3.5555555M 1)) 4.55556M
-       (with-precision 6 :rounding UP          (+ 3.5555555M 1)) 4.55556M
-       (with-precision 6 :rounding DOWN        (+ 3.5555555M 1)) 4.55555M
-       (with-precision 6 :rounding UNNECESSARY (+ 3.5555M 1))    4.5555M))
+    (with-precision 4 (+ 3.5555555M 1)) 4.556M
+    (with-precision 6 (+ 3.5555555M 1)) 4.55556M
+    (with-precision 6 :rounding CEILING     (+ 3.5555555M 1)) 4.55556M
+    (with-precision 6 :rounding FLOOR       (+ 3.5555555M 1)) 4.55555M
+    (with-precision 6 :rounding HALF_UP     (+ 3.5555555M 1)) 4.55556M
+    (with-precision 6 :rounding HALF_DOWN   (+ 3.5555555M 1)) 4.55556M
+    (with-precision 6 :rounding HALF_EVEN   (+ 3.5555555M 1)) 4.55556M
+    (with-precision 6 :rounding UP          (+ 3.5555555M 1)) 4.55556M
+    (with-precision 6 :rounding DOWN        (+ 3.5555555M 1)) 4.55555M
+    (with-precision 6 :rounding UNNECESSARY (+ 3.5555M 1))    4.5555M))
 
 (deftest test-settable-math-context
   (is (=
@@ -78,9 +77,9 @@
          (+ 3.55555555555555M 1))
        4.5555556M)))
 
-; set-validator get-validator
+;; set-validator get-validator
 
-; doc find-doc test
+;; doc find-doc test
 
 (def stub-me :original)
 
@@ -104,9 +103,9 @@
 (deftest test-with-redefs-throw
   (let [p (promise)]
     (is (thrown? Exception
-      (with-redefs [stub-me :temp]
-        (deliver p stub-me)
-        (throw (Exception. "simulated failure in with-redefs")))))
+                 (with-redefs [stub-me :temp]
+                   (deliver p stub-me)
+                   (throw (Exception. "simulated failure in with-redefs")))))
     (is (= :temp @p))
     (is (= :original stub-me))))
 

--- a/test/clojure/test_clojure/vectors.clj
+++ b/test/clojure/test_clojure/vectors.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
-; Author: Stuart Halloway, Daniel Solano Gómez
+;; Author: Stuart Halloway, Daniel Solano Gómez
 
 (ns clojure.test-clojure.vectors
   (:use clojure.test))
@@ -37,47 +37,47 @@
         vs-32 (.chunkedNext (seq vs))]
     (testing "="
       (are [a b] (= a b)
-           vs vs
-           vs-1 vs-1
-           vs-32 vs-32)
+        vs vs
+        vs-1 vs-1
+        vs-32 vs-32)
       (are [a b] (not= a b)
-           vs vs-1
-           vs-1 vs
-           vs vs-32
-           vs-32 vs))
+        vs vs-1
+        vs-1 vs
+        vs vs-32
+        vs-32 vs))
     (testing "IPersistentCollection.empty"
       (are [a] (identical? clojure.lang.PersistentList/EMPTY (.empty (seq a)))
-           vs vs-1 vs-32))
+        vs vs-1 vs-32))
     (testing "IPersistentCollection.cons"
       (are [result input] (= result (.cons input :foo))
-           [:foo 1] (seq (into (vector-of :int) [1]))))
+        [:foo 1] (seq (into (vector-of :int) [1]))))
     (testing "IPersistentCollection.count"
       (are [ct s] (= ct (.count (seq s)))
-           100 vs
-           99 vs-1
-           68 vs-32)
+        100 vs
+        99 vs-1
+        68 vs-32)
       ;; can't manufacture this scenario: ASeq defers to Counted, but
       ;; LazySeq doesn't, so Counted never gets checked on reified seq below
       #_(testing "hops to counted when available"
-        (is (= 200
-               (.count (concat
-                        (seq vs)
-                        (reify clojure.lang.ISeq
-                               (seq [this] this)
-                               clojure.lang.Counted
-                               (count [_] 100))))))))
+          (is (= 200
+                 (.count (concat
+                          (seq vs)
+                          (reify clojure.lang.ISeq
+                            (seq [this] this)
+                            clojure.lang.Counted
+                            (count [_] 100))))))))
     (testing "IPersistentCollection.equiv"
       (are [a b] (true? (.equiv a b))
-           vs vs
-           vs-1 vs-1
-           vs-32 vs-32
-           vs r)
+        vs vs
+        vs-1 vs-1
+        vs-32 vs-32
+        vs r)
       (are [a b] (false? (.equiv a b))
-           vs vs-1
-           vs-1 vs
-           vs vs-32
-           vs-32 vs
-           vs nil))
+        vs vs-1
+        vs-1 vs
+        vs vs-32
+        vs-32 vs
+        vs nil))
     (testing "internal-reduce"
       (is (= [99] (into [] (drop 99 vs)))))))
 
@@ -89,7 +89,7 @@
 (deftest test-vec-compare
   (let [nums      (range 1 100)
         ; randomly replaces a single item with the given value
-        rand-replace  (fn[val]
+        rand-replace  (fn [val]
                         (let [r (rand-int 99)]
                           (concat (take r nums) [val] (drop (inc r) nums))))
         ; all num sequences in map
@@ -111,7 +111,7 @@
                        :rand-lesser-2  (rand-replace 0)
                        :rand-lesser-3  (rand-replace 0)}
         ; a way to create compare values based on num-seqs
-        create-vals   (fn[base-val]
+        create-vals   (fn [base-val]
                         (zipmap (keys num-seqs)
                                 (map #(into base-val %1) (vals num-seqs))))
         ; Vecs made of int primitives
@@ -128,219 +128,219 @@
       (testing "equivalent"
         (are [x y] (= 0 (compare x y))
              ; standard
-             int-vec (:standard long-vecs)
-             (:standard long-vecs) int-vec
-             int-vec (:standard regular-vecs)
-             (:standard regular-vecs) int-vec
+          int-vec (:standard long-vecs)
+          (:standard long-vecs) int-vec
+          int-vec (:standard regular-vecs)
+          (:standard regular-vecs) int-vec
              ; empty
-             (:empty int-vecs) (:empty long-vecs)
-             (:empty long-vecs) (:empty int-vecs)))
+          (:empty int-vecs) (:empty long-vecs)
+          (:empty long-vecs) (:empty int-vecs)))
       (testing "lesser"
         (are [x] (= -1 (compare int-vec x))
-             (:longer int-vecs)
-             (:longer long-vecs)
-             (:longer regular-vecs)
-             (:first-greater int-vecs)
-             (:first-greater long-vecs)
-             (:first-greater regular-vecs)
-             (:last-greater int-vecs)
-             (:last-greater long-vecs)
-             (:last-greater regular-vecs)
-             (:rand-greater-1 int-vecs)
-             (:rand-greater-1 long-vecs)
-             (:rand-greater-1 regular-vecs)
-             (:rand-greater-2 int-vecs)
-             (:rand-greater-2 long-vecs)
-             (:rand-greater-2 regular-vecs)
-             (:rand-greater-3 int-vecs)
-             (:rand-greater-3 long-vecs)
-             (:rand-greater-3 regular-vecs))
+          (:longer int-vecs)
+          (:longer long-vecs)
+          (:longer regular-vecs)
+          (:first-greater int-vecs)
+          (:first-greater long-vecs)
+          (:first-greater regular-vecs)
+          (:last-greater int-vecs)
+          (:last-greater long-vecs)
+          (:last-greater regular-vecs)
+          (:rand-greater-1 int-vecs)
+          (:rand-greater-1 long-vecs)
+          (:rand-greater-1 regular-vecs)
+          (:rand-greater-2 int-vecs)
+          (:rand-greater-2 long-vecs)
+          (:rand-greater-2 regular-vecs)
+          (:rand-greater-3 int-vecs)
+          (:rand-greater-3 long-vecs)
+          (:rand-greater-3 regular-vecs))
         (are [x] (= -1 (compare x int-vec))
-             nil
-             (:empty int-vecs)
-             (:empty long-vecs)
-             (:empty regular-vecs)
-             (:shorter int-vecs)
-             (:shorter long-vecs)
-             (:shorter regular-vecs)
-             (:first-lesser int-vecs)
-             (:first-lesser long-vecs)
-             (:first-lesser regular-vecs)
-             (:last-lesser int-vecs)
-             (:last-lesser long-vecs)
-             (:last-lesser regular-vecs)
-             (:rand-lesser-1 int-vecs)
-             (:rand-lesser-1 long-vecs)
-             (:rand-lesser-1 regular-vecs)
-             (:rand-lesser-2 int-vecs)
-             (:rand-lesser-2 long-vecs)
-             (:rand-lesser-2 regular-vecs)
-             (:rand-lesser-3 int-vecs)
-             (:rand-lesser-3 long-vecs)
-             (:rand-lesser-3 regular-vecs)))
+          nil
+          (:empty int-vecs)
+          (:empty long-vecs)
+          (:empty regular-vecs)
+          (:shorter int-vecs)
+          (:shorter long-vecs)
+          (:shorter regular-vecs)
+          (:first-lesser int-vecs)
+          (:first-lesser long-vecs)
+          (:first-lesser regular-vecs)
+          (:last-lesser int-vecs)
+          (:last-lesser long-vecs)
+          (:last-lesser regular-vecs)
+          (:rand-lesser-1 int-vecs)
+          (:rand-lesser-1 long-vecs)
+          (:rand-lesser-1 regular-vecs)
+          (:rand-lesser-2 int-vecs)
+          (:rand-lesser-2 long-vecs)
+          (:rand-lesser-2 regular-vecs)
+          (:rand-lesser-3 int-vecs)
+          (:rand-lesser-3 long-vecs)
+          (:rand-lesser-3 regular-vecs)))
       (testing "greater"
         (are [x] (= 1 (compare int-vec x))
-             nil
-             (:empty int-vecs)
-             (:empty long-vecs)
-             (:empty regular-vecs)
-             (:shorter int-vecs)
-             (:shorter long-vecs)
-             (:shorter regular-vecs)
-             (:first-lesser int-vecs)
-             (:first-lesser long-vecs)
-             (:first-lesser regular-vecs)
-             (:last-lesser int-vecs)
-             (:last-lesser long-vecs)
-             (:last-lesser regular-vecs)
-             (:rand-lesser-1 int-vecs)
-             (:rand-lesser-1 long-vecs)
-             (:rand-lesser-1 regular-vecs)
-             (:rand-lesser-2 int-vecs)
-             (:rand-lesser-2 long-vecs)
-             (:rand-lesser-2 regular-vecs)
-             (:rand-lesser-3 int-vecs)
-             (:rand-lesser-3 long-vecs)
-             (:rand-lesser-3 regular-vecs))
+          nil
+          (:empty int-vecs)
+          (:empty long-vecs)
+          (:empty regular-vecs)
+          (:shorter int-vecs)
+          (:shorter long-vecs)
+          (:shorter regular-vecs)
+          (:first-lesser int-vecs)
+          (:first-lesser long-vecs)
+          (:first-lesser regular-vecs)
+          (:last-lesser int-vecs)
+          (:last-lesser long-vecs)
+          (:last-lesser regular-vecs)
+          (:rand-lesser-1 int-vecs)
+          (:rand-lesser-1 long-vecs)
+          (:rand-lesser-1 regular-vecs)
+          (:rand-lesser-2 int-vecs)
+          (:rand-lesser-2 long-vecs)
+          (:rand-lesser-2 regular-vecs)
+          (:rand-lesser-3 int-vecs)
+          (:rand-lesser-3 long-vecs)
+          (:rand-lesser-3 regular-vecs))
         (are [x] (= 1 (compare x int-vec))
-             (:longer int-vecs)
-             (:longer long-vecs)
-             (:longer regular-vecs)
-             (:first-greater int-vecs)
-             (:first-greater long-vecs)
-             (:first-greater regular-vecs)
-             (:last-greater int-vecs)
-             (:last-greater long-vecs)
-             (:last-greater regular-vecs)
-             (:rand-greater-1 int-vecs)
-             (:rand-greater-1 long-vecs)
-             (:rand-greater-1 regular-vecs)
-             (:rand-greater-2 int-vecs)
-             (:rand-greater-2 long-vecs)
-             (:rand-greater-2 regular-vecs)
-             (:rand-greater-3 int-vecs)
-             (:rand-greater-3 long-vecs)
-             (:rand-greater-3 regular-vecs))))
+          (:longer int-vecs)
+          (:longer long-vecs)
+          (:longer regular-vecs)
+          (:first-greater int-vecs)
+          (:first-greater long-vecs)
+          (:first-greater regular-vecs)
+          (:last-greater int-vecs)
+          (:last-greater long-vecs)
+          (:last-greater regular-vecs)
+          (:rand-greater-1 int-vecs)
+          (:rand-greater-1 long-vecs)
+          (:rand-greater-1 regular-vecs)
+          (:rand-greater-2 int-vecs)
+          (:rand-greater-2 long-vecs)
+          (:rand-greater-2 regular-vecs)
+          (:rand-greater-3 int-vecs)
+          (:rand-greater-3 long-vecs)
+          (:rand-greater-3 regular-vecs))))
     (testing "Comparable.compareTo"
       (testing "incompatible"
         (is (thrown? NullPointerException (.compareTo int-vec nil)))
         (are [x] (thrown? ClassCastException (.compareTo int-vec x))
-             '()
-             {}
-             #{}
-             (sorted-set)
-             (sorted-map)
-             nums
-             1))
+          '()
+          {}
+          #{}
+          (sorted-set)
+          (sorted-map)
+          nums
+          1))
       (testing "identical"
         (is (= 0 (.compareTo int-vec int-vec))))
       (testing "equivalent"
         (are [x] (= 0 (.compareTo int-vec x))
-             (:standard long-vecs)
-             (:standard regular-vecs)))
+          (:standard long-vecs)
+          (:standard regular-vecs)))
       (testing "lesser"
         (are [x] (= -1 (.compareTo int-vec x))
-             (:longer int-vecs)
-             (:longer long-vecs)
-             (:longer regular-vecs)
-             (:first-greater int-vecs)
-             (:first-greater long-vecs)
-             (:first-greater regular-vecs)
-             (:last-greater int-vecs)
-             (:last-greater long-vecs)
-             (:last-greater regular-vecs)
-             (:rand-greater-1 int-vecs)
-             (:rand-greater-1 long-vecs)
-             (:rand-greater-1 regular-vecs)
-             (:rand-greater-2 int-vecs)
-             (:rand-greater-2 long-vecs)
-             (:rand-greater-2 regular-vecs)
-             (:rand-greater-3 int-vecs)
-             (:rand-greater-3 long-vecs)
-             (:rand-greater-3 regular-vecs)))
+          (:longer int-vecs)
+          (:longer long-vecs)
+          (:longer regular-vecs)
+          (:first-greater int-vecs)
+          (:first-greater long-vecs)
+          (:first-greater regular-vecs)
+          (:last-greater int-vecs)
+          (:last-greater long-vecs)
+          (:last-greater regular-vecs)
+          (:rand-greater-1 int-vecs)
+          (:rand-greater-1 long-vecs)
+          (:rand-greater-1 regular-vecs)
+          (:rand-greater-2 int-vecs)
+          (:rand-greater-2 long-vecs)
+          (:rand-greater-2 regular-vecs)
+          (:rand-greater-3 int-vecs)
+          (:rand-greater-3 long-vecs)
+          (:rand-greater-3 regular-vecs)))
       (testing "greater"
         (are [x] (= 1 (.compareTo int-vec x))
-             (:empty int-vecs)
-             (:empty long-vecs)
-             (:empty regular-vecs)
-             (:shorter int-vecs)
-             (:shorter long-vecs)
-             (:shorter regular-vecs)
-             (:first-lesser int-vecs)
-             (:first-lesser long-vecs)
-             (:first-lesser regular-vecs)
-             (:last-lesser int-vecs)
-             (:last-lesser long-vecs)
-             (:last-lesser regular-vecs)
-             (:rand-lesser-1 int-vecs)
-             (:rand-lesser-1 long-vecs)
-             (:rand-lesser-1 regular-vecs)
-             (:rand-lesser-2 int-vecs)
-             (:rand-lesser-2 long-vecs)
-             (:rand-lesser-2 regular-vecs)
-             (:rand-lesser-3 int-vecs)
-             (:rand-lesser-3 long-vecs)
-             (:rand-lesser-3 regular-vecs))))))
+          (:empty int-vecs)
+          (:empty long-vecs)
+          (:empty regular-vecs)
+          (:shorter int-vecs)
+          (:shorter long-vecs)
+          (:shorter regular-vecs)
+          (:first-lesser int-vecs)
+          (:first-lesser long-vecs)
+          (:first-lesser regular-vecs)
+          (:last-lesser int-vecs)
+          (:last-lesser long-vecs)
+          (:last-lesser regular-vecs)
+          (:rand-lesser-1 int-vecs)
+          (:rand-lesser-1 long-vecs)
+          (:rand-lesser-1 regular-vecs)
+          (:rand-lesser-2 int-vecs)
+          (:rand-lesser-2 long-vecs)
+          (:rand-lesser-2 regular-vecs)
+          (:rand-lesser-3 int-vecs)
+          (:rand-lesser-3 long-vecs)
+          (:rand-lesser-3 regular-vecs))))))
 
 (deftest test-vec-associative
   (let [empty-v (vector-of :long)
         v       (into empty-v (range 1 6))]
     (testing "Associative.containsKey"
       (are [x] (.containsKey v x)
-           0 1 2 3 4)
+        0 1 2 3 4)
       (are [x] (not (.containsKey v x))
-           -1 -100 nil [] "" #"" #{} 5 100)
+        -1 -100 nil [] "" #"" #{} 5 100)
       (are [x] (not (.containsKey empty-v x))
-           0 1))
+        0 1))
     (testing "contains?"
       (are [x] (contains? v x)
-           0 2 4)
+        0 2 4)
       (are [x] (not (contains? v x))
-           -1 -100 nil "" 5 100)
+        -1 -100 nil "" 5 100)
       (are [x] (not (contains? empty-v x))
-           0 1))
+        0 1))
     (testing "Associative.entryAt"
       (are [idx val] (= (clojure.lang.MapEntry. idx val)
                         (.entryAt v idx))
-           0 1
-           2 3
-           4 5)
+        0 1
+        2 3
+        4 5)
       (are [idx] (nil? (.entryAt v idx))
-           -5 -1 5 10 nil "")
+        -5 -1 5 10 nil "")
       (are [idx] (nil? (.entryAt empty-v idx))
-           0 1))))
+        0 1))))
 
 (deftest test-vec-creation
   (testing "Plain (vector-of :type)"
     (are [x] (and (empty? x) (instance? clojure.core.Vec x))
-         (vector-of :boolean)
-         (vector-of :byte)
-         (vector-of :short)
-         (vector-of :int)
-         (vector-of :long)
-         (vector-of :float)
-         (vector-of :double)
-         (vector-of :char))
+      (vector-of :boolean)
+      (vector-of :byte)
+      (vector-of :short)
+      (vector-of :int)
+      (vector-of :long)
+      (vector-of :float)
+      (vector-of :double)
+      (vector-of :char))
     (testing "with invalid type argument"
       (are [x] (thrown? NullPointerException x)
-           (vector-of nil)
-           (vector-of Float/TYPE)
-           (vector-of 'int)
-           (vector-of ""))))
+        (vector-of nil)
+        (vector-of Float/TYPE)
+        (vector-of 'int)
+        (vector-of ""))))
   (testing "vector-like (vector-of :type x1 x2 x3 … xn)"
     (are [vec gvec] (and (instance? clojure.core.Vec gvec)
                          (= (into (vector-of :int) vec) gvec)
                          (= vec gvec)
                          (= (hash vec) (hash gvec)))
-         [1] (vector-of :int 1)
-         [1 2] (vector-of :int 1 2)
-         [1 2 3] (vector-of :int 1 2 3)
-         [1 2 3 4] (vector-of :int 1 2 3 4)
-         [1 2 3 4 5] (vector-of :int 1 2 3 4 5)
-         [1 2 3 4 5 6] (vector-of :int 1 2 3 4 5 6)
-         (apply vector (range 1000)) (apply vector-of :int (range 1000))
-         [1 2 3] (vector-of :int 1M 2.0 3.1)
-         [97 98 99] (vector-of :int \a \b \c))
+      [1] (vector-of :int 1)
+      [1 2] (vector-of :int 1 2)
+      [1 2 3] (vector-of :int 1 2 3)
+      [1 2 3 4] (vector-of :int 1 2 3 4)
+      [1 2 3 4 5] (vector-of :int 1 2 3 4 5)
+      [1 2 3 4 5 6] (vector-of :int 1 2 3 4 5 6)
+      (apply vector (range 1000)) (apply vector-of :int (range 1000))
+      [1 2 3] (vector-of :int 1M 2.0 3.1)
+      [97 98 99] (vector-of :int \a \b \c))
     (testing "with null values"
       (are [x] (thrown? NullPointerException x)
         (vector-of :int nil)
@@ -352,15 +352,15 @@
         (vector-of :int 1 2 3 4 5 6 nil)))
     (testing "with unsupported values"
       (are [x] (thrown? ClassCastException x)
-           (vector-of :int true)
-           (vector-of :int 1 2 3 4 5 false)
-           (vector-of :int {:a 1 :b 2})
-           (vector-of :int [1 2 3 4] [5 6])
-           (vector-of :int '(1 2 3 4))
-           (vector-of :int #{1 2 3 4})
-           (vector-of :int (sorted-set 1 2 3 4))
-           (vector-of :int 1 2 "3")
-           (vector-of :int "1" "2" "3")))))
+        (vector-of :int true)
+        (vector-of :int 1 2 3 4 5 false)
+        (vector-of :int {:a 1 :b 2})
+        (vector-of :int [1 2 3 4] [5 6])
+        (vector-of :int '(1 2 3 4))
+        (vector-of :int #{1 2 3 4})
+        (vector-of :int (sorted-set 1 2 3 4))
+        (vector-of :int 1 2 "3")
+        (vector-of :int "1" "2" "3")))))
 
 (deftest empty-vector-equality
   (let [colls [[] (vector-of :long) '()]]
@@ -373,18 +373,18 @@
 
 (deftest test-mapv
   (are [r c1] (=vec r (mapv + c1))
-       [1 2 3] [1 2 3])
+    [1 2 3] [1 2 3])
   (are [r c1 c2] (=vec r (mapv + c1 c2))
-       [2 3 4] [1 2 3] (repeat 1))
+    [2 3 4] [1 2 3] (repeat 1))
   (are [r c1 c2 c3] (=vec r (mapv + c1 c2 c3))
-       [3 4 5] [1 2 3] (repeat 1) (repeat 1))
+    [3 4 5] [1 2 3] (repeat 1) (repeat 1))
   (are [r c1 c2 c3 c4] (=vec r (mapv + c1 c2 c3 c4))
-       [4 5 6] [1 2 3] [1 1 1] [1 1 1] [1 1 1]))
+    [4 5 6] [1 2 3] [1 1 1] [1 1 1] [1 1 1]))
 
 (deftest test-filterv
   (are [r c1] (=vec r (filterv even? c1))
-       [] [1 3 5]
-       [2 4] [1 2 3 4 5]))
+    [] [1 3 5]
+    [2 4] [1 2 3 4 5]))
 
 (deftest test-subvec
   (let [v1 (vec (range 100))

--- a/test/clojure/test_clojure/volatiles.clj
+++ b/test/clojure/test_clojure/volatiles.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 
 ;;Author: Alex Miller
 

--- a/test/clojure/test_helper.clj
+++ b/test/clojure/test_helper.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Rich Hickey. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
 ;
 
 ;;  clojure.test-helper
@@ -18,7 +18,7 @@
 (ns clojure.test-helper
   (:use clojure.test))
 
-(let [nl (System/getProperty "line.separator")] 
+(let [nl (System/getProperty "line.separator")]
   (defn platform-newlines [s] (.replace s "\n" nl)))
 
 (defn temp-ns
@@ -47,29 +47,28 @@
 (defmethod assert-expr 'fails-with-cause?
   [msg [_ exception-class msg-re & body :as form]]
   `(try
-   ~@body
-   (report {:type :fail, :message ~msg, :expected '~form, :actual nil})
-   (catch Throwable t#
-     (if (some (fn [cause#]
-                 (and
-                  (= ~exception-class (class cause#))
-                  (re-find ~msg-re (.getMessage cause#))))
-               (causes t#))
-       (report {:type :pass, :message ~msg,
-                :expected '~form, :actual t#})
-       (report {:type :fail, :message ~msg,
-                :expected '~form, :actual t#})))))
-
+     ~@body
+     (report {:type :fail, :message ~msg, :expected '~form, :actual nil})
+     (catch Throwable t#
+       (if (some (fn [cause#]
+                   (and
+                    (= ~exception-class (class cause#))
+                    (re-find ~msg-re (.getMessage cause#))))
+                 (causes t#))
+         (report {:type :pass, :message ~msg,
+                  :expected '~form, :actual t#})
+         (report {:type :fail, :message ~msg,
+                  :expected '~form, :actual t#})))))
 
 (defn get-field
   "Access to private or protected field.  field-name is a symbol or
   keyword."
   ([klass field-name]
-     (get-field klass field-name nil))
+   (get-field klass field-name nil))
   ([klass field-name inst]
-     (-> klass (.getDeclaredField (name field-name))
-         (doto (.setAccessible true))
-         (.get inst))))
+   (-> klass (.getDeclaredField (name field-name))
+       (doto (.setAccessible true))
+       (.get inst))))
 
 (defn set-var-roots
   [maplike]
@@ -82,9 +81,9 @@
   (let [originals (doall (map (fn [[var _]] [var @var]) root-map))]
     (set-var-roots root-map)
     (try
-     (apply f args)
-     (finally
-      (set-var-roots originals)))))
+      (apply f args)
+      (finally
+        (set-var-roots originals)))))
 
 (defmacro with-var-roots
   [root-map & body]
@@ -120,8 +119,8 @@
    correctly for all semi-reasonable bindings of *err*."
   [msg-re form]
   `(binding [*warn-on-reflection* true]
-    (is (re-matches ~msg-re (with-err-string-writer (eval-in-temp-ns ~form))))
-    (is (re-matches ~msg-re (with-err-print-writer (eval-in-temp-ns ~form))))))
+     (is (re-matches ~msg-re (with-err-string-writer (eval-in-temp-ns ~form))))
+     (is (re-matches ~msg-re (with-err-print-writer (eval-in-temp-ns ~form))))))
 
 (defmacro should-not-reflect
   "Turn on all warning flags, and test that reflection does not occur


### PR DESCRIPTION
This changeset adds cljfmt as a linter, checking both the Clojure sources and the Clojure tests. It's not perfect, but it's better than nothing.

Also reformats both sources sets so that the linter runs cleanly.

Fixes #31 
