### PR TITLE
Fixup some compile warnings

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5309,7 +5309,7 @@
 
 (defn- descriptor [^Class c] (clojure.asm.Type/getDescriptor c))
 
-(declare process-annotation)
+(declare ^:private process-annotation)
 (defn- add-annotation [^clojure.asm.AnnotationVisitor av name v]
   (cond
    (vector? v) (let [avec (.visitArray av name)]

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -1655,7 +1655,7 @@
           (map #(str ", " %) (rest valid-keys)))))))
 
 ;;multimethods
-(def global-hierarchy)
+(def ^:private global-hierarchy)
 
 (defmacro defmulti
   "Creates a new multimethod with the associated dispatch function.


### PR DESCRIPTION
These two vars are forward declared without metadata which is added
later. This leads to a (correct) reloading warning that `^:private` is
being discarded and then re-added. This patch fixes those forward
declarations so that no warning is emitted.
