### PR TITLE
Add ^:once support to Vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## Change Log
 
 ### upcoming
+- [#89](https://github.com/jaunt-lang/jaunt/pull/89) Add ^:once support to Vars (@arrdem).
+  - This changeset enables analysis tooling to distinguish between `Var`s which are bound 'once' and
+    those which are simply bound.
+  - Add `clojure.lang.Var.isOnce()`, `clojure.lang.Var.setOnce()`, `clojure.lang.Var.setOnce(bool)`.
+  - Refactor `clojure.core/defonce` to use `isOnce` and set `^:once` rather than simply checking if
+    the `Var` is bound.
+  - `clojure.core/defonce` now returns the defined `Var` same as `def`.
+  - Add tests of `clojure.core/defonce` with regards to all of the above behavior.
 - [#87](https://github.com/jaunt-lang/jaunt/pull/87) Send build notifications to gitter (@arrdem).
 - [#86](https://github.com/jaunt-lang/jaunt/pull/86) Fix false changelog linter failures on develop, master, release/* (@arrdem).
 - [#84](https://github.com/jaunt-lang/jaunt/pull/84) Whole bag of project changes (@arrdem).

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5680,9 +5680,12 @@
   else expr is unevaluated"
   {:added "1.0"}
   [name expr]
-  `(let [v# (def ~name)]
-     (when-not (.hasRoot v#)
-       (def ~name ~expr))))
+  `(let [v# (clojure.lang.Var/intern
+             ^clojure.lang.Namespace *ns*
+             ^clojure.lang.Symbol '~name)]
+     (when-not (or (.isOnce v#)
+                   (.hasRoot v#))
+       (def ~(with-meta name (assoc (meta name) :once true)) ~expr))))
 
 ;;;;;;;;;;; require/use/load, contributed by Stephen C. Gilardi ;;;;;;;;;;;;;;;;;;
 

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5680,6 +5680,9 @@
   else expr is unevaluated"
   {:added "1.0"}
   [name expr]
+  (assert-args
+   (symbol? name) "Name must be a symbol."
+   (not (namespace name)) "Cannot define namespace qualified symbols.")
   `(let [v# (clojure.lang.Var/intern
              ^clojure.lang.Namespace *ns*
              ^clojure.lang.Symbol '~name)]

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5688,7 +5688,8 @@
              ^clojure.lang.Symbol '~name)]
      (when-not (or (.isOnce v#)
                    (.hasRoot v#))
-       (def ~(with-meta name (assoc (meta name) :once true)) ~expr))))
+       (def ~(with-meta name (assoc (meta name) :once true)) ~expr))
+     v#))
 
 ;;;;;;;;;;; require/use/load, contributed by Stephen C. Gilardi ;;;;;;;;;;;;;;;;;;
 

--- a/src/jvm/clojure/lang/Var.java
+++ b/src/jvm/clojure/lang/Var.java
@@ -322,6 +322,19 @@ public final class Var
     return !_private;
   }
 
+  public Var setOnce() {
+    return setOnce(true);
+  }
+
+  public Var setOnce(boolean state) {
+    resetMeta(meta().assoc(onceKey, state));
+    return this;
+  }
+
+  public boolean isOnce() {
+    return _once;
+  }
+
   final public Object getRawRoot() {
     return root;
   }

--- a/test/clojure/test_clojure/vars.clj
+++ b/test/clojure/test_clojure/vars.clj
@@ -25,6 +25,26 @@
       (eval `(binding [a 4] a)) 4     ; regression in Clojure SVN r1370
   ))
 
+(deftest defonce-test
+  (let [_ (clojure.lang.Namespace/findOrCreate 'defonce-test)
+        v (clojure.lang.Var/find 'defonce-test/a)]
+    (binding [*ns* *ns*]
+      (is (= 3
+             (eval '(do (ns defonce-test)
+                        (defonce b 3)
+                        (defonce b 1)
+                        b))))
+      (is (eval '(do (ns defonce-test)
+                     (let [v (def a 3)]
+                       (and (= (defonce a 4) v)
+                            (= a 3))))))
+      (is (eval '(do (ns defonce-test)
+                     (def ^:once a 3)
+                     (defonce ^:foo a nil)
+                     (and (.isOnce (var a))
+                          (:once (meta (var a)))
+                          (not (:foo (meta (var a)))))))))))
+
 ; var-get var-set alter-var-root [var? (predicates.clj)]
 ; with-in-str with-out-str
 ; with-open


### PR DESCRIPTION
This patch refactors Vars to add `.isOnce()` and `.setOnce()`, taking advantage of `^:once` metadata and makes `defonce` take advantage of `.isOnce()` rather than simply checking if the Var is bound. This enables analysis tools to distinguish between Vars which are simply bound, and those which are bound exactly once as via `defonce`.
