### PR TITLE
Use errPrintWriter which flushes correctly at REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Change Log
 
 ### upcoming
+- [#92](https://github.com/jaunt-lang/jaunt/pull/92) Fix refer/alias warnings not displaying at the REPL (@arrdem).
 - [#89](https://github.com/jaunt-lang/jaunt/pull/89) Add ^:once support to Vars (@arrdem).
   - This changeset enables analysis tooling to distinguish between `Var`s which are bound 'once' and
     those which are simply bound.


### PR DESCRIPTION
Deals with a UX issue where warnings about referring deprecated vars and
aliasing deprecated namespaces would not appear correctly at the REPL
due to some combination of writer flushing behaviors.
