### PR TITLE
Bind *compiler-options* for REPL set!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Change Log
 
 ### upcoming
+- [#94](https://github.com/jaunt-lang/jaunt/pull/94) Provide a thread binding of *compiler-options* so it may be set! (@arrdem).
 - [#93](https://github.com/jaunt-lang/jaunt/pull/93) Display the correct project name in the REPL banner (@arrdem).
 - [#92](https://github.com/jaunt-lang/jaunt/pull/92) Fix refer/alias warnings not displaying at the REPL (@arrdem).
 - [#89](https://github.com/jaunt-lang/jaunt/pull/89) Add ^:once support to Vars (@arrdem).

--- a/src/clj/clojure/main.clj
+++ b/src/clj/clojure/main.clj
@@ -66,24 +66,25 @@
   "Executes body in the context of thread-local bindings for several vars
   that often need to be set!: *ns* *warn-on-reflection* *math-context*
   *print-meta* *print-length* *print-level* *compile-path*
-  *command-line-args* *1 *2 *3 *e"
+  *command-line-args* *1 *2 *3 *e *compiler-options*"
   [& body]
-  `(binding [*ns* *ns*
-             *warn-on-reflection* *warn-on-reflection*
-             *math-context* *math-context*
-             *print-meta* *print-meta*
-             *print-length* *print-length*
-             *print-level* *print-level*
-             *data-readers* *data-readers*
+  `(binding [*ns*                     *ns*
+             *warn-on-reflection*     *warn-on-reflection*
+             *math-context*           *math-context*
+             *print-meta*             *print-meta*
+             *print-length*           *print-length*
+             *print-level*            *print-level*
+             *data-readers*           *data-readers*
              *default-data-reader-fn* *default-data-reader-fn*
-             *compile-path* (System/getProperty "clojure.compile.path" "classes")
-             *command-line-args* *command-line-args*
-             *unchecked-math* *unchecked-math*
-             *assert* *assert*
-             *1 nil
-             *2 nil
-             *3 nil
-             *e nil]
+             *compile-path*           (System/getProperty "clojure.compile.path" "classes")
+             *command-line-args*      *command-line-args*
+             *unchecked-math*         *unchecked-math*
+             *assert*                 *assert*
+             *1                       nil
+             *2                       nil
+             *3                       nil
+             *e                       nil
+             *compiler-options*       *compiler-options*] 
      ~@body))
 
 (defn repl-prompt


### PR DESCRIPTION
This allows users to bind `*compiler-options*` as they would any other compiler options such as `*warn-on-reflection*`.
