### PR TITLE
Introduce *jaunt-version*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Change Log
 
 ### upcoming
+- [#95](https://github.com/jaunt-lang/jaunt/pull/95) Introduce `*jaunt-version*`, deprecating `*clojure-version*` (@arrdem).
 - [#101](https://github.com/jaunt-lang/jaunt/pull/99) Add small (64px, 128px) logos (@arrdem).
 - [#99](https://github.com/jaunt-lang/jaunt/pull/99) Bugfix: make `private?` check `^:private` (@arrdem).
   - Fix `private?` to check the correct metadata

--- a/build.xml
+++ b/build.xml
@@ -29,7 +29,7 @@
   <!-- Get the version string out of the POM -->
   <xmlproperty file="pom.xml" prefix="pom"/>
   <property name="clojure.version.label" value="${pom.project.version}"/>
-  <property name="version.properties" value="${build}/clojure/version.properties"/>
+  <property name="version.properties" value="${build}/jaunt/version.properties"/>
 
   <property name="clojure_jar" location="${dist}/jaunt-${clojure.version.label}.jar"/>
   <property name="clojure_noversion_jar" location="${dist}/jaunt.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <configuration>
           <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>src/resources/clojure/git.properties</generateGitPropertiesFilename>
+          <generateGitPropertiesFilename>src/resources/jaunt/git.properties</generateGitPropertiesFilename>
         </configuration>
       </plugin>
       <plugin>

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6914,8 +6914,7 @@
     {::build {:dirty (Boolean/valueOf (prop "git.dirty"))
               :date  (-> (new java.text.SimpleDateFormat "dd.MM.yyyy '@' HH:mm:ss z")
                          (.parse (prop "git.build.time")))
-              :git   {:closest-tag (prop "git.closest.tag.name")
-                      :commit      (prop "git.commit.id.abbrev")
+              :git   {:commit      (prop "git.commit.id.abbrev")
                       :branch      (prop "git.branch")}}}))
 
 (defn- ensure-interim [m]

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6899,7 +6899,7 @@
      :incremental  (Integer/valueOf ^String incremental)
      :interim      (.endsWith ^String qualifier "-SNAPSHOT")
      :qualifiers   (->> (.split ^String qualifier "-")
-                        (filter (complement empty?))
+                        (filter not-empty)
                         set)
      ::raw-version v}))
 

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -6861,46 +6861,88 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; clojure version number ;;;;;;;;;;;;;;;;;;;;;;
 
-(let [properties (with-open [version-stream (.getResourceAsStream
-                                             (clojure.lang.RT/baseLoader)
-                                             "clojure/version.properties")]
-                   (doto (new java.util.Properties)
-                     (.load version-stream)))
-      version-string (.getProperty properties "version")
-      [_ major minor incremental qualifier snapshot]
-      (re-matches
-       #"(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9_]+))?(?:-(SNAPSHOT))?"
-       version-string)
-      clojure-version {:major       (Integer/valueOf ^String major)
-                       :minor       (Integer/valueOf ^String minor)
-                       :incremental (Integer/valueOf ^String incremental)
-                       :qualifier   (if (= qualifier "SNAPSHOT") nil qualifier)}]
-  (def ^:dynamic *clojure-version*
-    (if (.contains version-string "SNAPSHOT")
-      (clojure.lang.RT/assoc clojure-version :interim true)
-      clojure-version)))
+(def
+  ^{:dynamic    true
+    :deprecated "FIXME"
+    :added      "1.0"}
+  *clojure-version*
+  "DEPRECATED: replaced by *jaunt-version*
 
-(add-doc-and-meta *clojure-version*
-  "The version info for Clojure core, as a map containing :major :minor 
-  :incremental and :qualifier keys. Feature releases may increment 
-  :minor and/or :major, bugfix releases will increment :incremental. 
-  Possible values of :qualifier include \"GA\", \"SNAPSHOT\", \"RC-x\" \"BETA-x\""
-  {:added "1.0"})
+  The version of Clojure from which this Jaunt build is derived. Version information is encoded as a
+  map containing :major :minor :incremental and :qualifier keys."
+  {:major       1
+   :minor       8
+   :incremental 0
+   :qualifier   nil})
 
-(defn
-  clojure-version 
-  "Returns clojure version as a printable string."
-  {:added "1.0"}
+(defn clojure-version
+  "DEPRECATED: replaced by jaunt-version
+
+  Returns clojure version as a printable string."
+  {:added      "1.0"
+   :deprecated "FIXME"}
   []
-  (str (:major *clojure-version*)
-       "."
-       (:minor *clojure-version*)
-       (when-let [i (:incremental *clojure-version*)]
-         (str "." i))
-       (when-let [q (:qualifier *clojure-version*)]
-         (when (pos? (count q)) (str "-" q)))
-       (when (:interim *clojure-version*)
-         "-SNAPSHOT")))
+  "1.8.0")
+
+(defn- parse-version [v]
+  {:pre [(string? v)]}
+  (let [[_ major minor incremental qualifier]
+        ,,(re-matches #"^(\d+)\.(\d+)\.(\d+)(-.*)?$" v)]
+    {:major        (Integer/valueOf ^String major)
+     :minor        (Integer/valueOf ^String minor)
+     :incremental  (Integer/valueOf ^String incremental)
+     :interim      (.endsWith ^String qualifier "-SNAPSHOT")
+     :qualifiers   (->> (.split ^String qualifier "-")
+                        (filter (complement empty?))
+                        set)
+     ::raw-version v}))
+
+(defn- read-version-properties [p]
+  (-> (with-open [version-stream
+                  (.getResourceAsStream (clojure.lang.RT/baseLoader) p)]
+        (doto (new java.util.Properties)
+          (.load version-stream)))
+      (.getProperty "version")
+      (parse-version)))
+
+(defn- read-git-properties [p]
+  (let [m    (with-open [version-stream
+                         (.getResourceAsStream (clojure.lang.RT/baseLoader) p)]
+               (doto (new java.util.Properties)
+                 (.load version-stream)))
+        prop (partial get m)]
+    {::build {:dirty (Boolean/valueOf (prop "git.dirty"))
+              :date  (-> (new java.text.SimpleDateFormat "dd.MM.yyyy '@' HH:mm:ss z")
+                         (.parse (prop "git.build.time")))
+              :git   {:closest-tag (prop "git.closest.tag.name")
+                      :commit      (prop "git.commit.id.abbrev")
+                      :branch      (prop "git.branch")}}}))
+
+(defn- ensure-interim [m]
+  (update m :interim #(or %1 (-> m ::build (get :dirty false)))))
+
+(def
+  ^{:dynamic true
+    :added   "FIXME"}
+  *jaunt-version*
+  "The version number of the Jaunt build.
+
+  :major - integer value of the SemVer major version
+  :minor - integer value of the SemVer minor version
+  :incremental - integer value of the SemVer patch version
+  :interim - boolean indicating whether the build is dirty or a snapshot
+  :qualifiers - a set of strings, being the version qualifiers."
+  (-> (read-version-properties "jaunt/version.properties")
+      (merge (read-git-properties "jaunt/git.properties"))
+      ensure-interim))
+
+(defn jaunt-version
+  "Returns the Jaunt version as a printable string."
+  {:added "FIXME"}
+  []
+  (or (::raw-version *jaunt-version*)
+      (let [{:keys [major minor incremental qualifier]} *jaunt-version*]
+        (format "%d.%d.%d%s" major minor incremental qualifier))))
 
 (defn promise
   "Returns a promise object that can be read with deref/@, and set,

--- a/src/clj/clojure/main.clj
+++ b/src/clj/clojure/main.clj
@@ -321,7 +321,7 @@ by default when a new command-line REPL is started."} repl-requires
   present"
   [[_ & args] inits]
   (when-not (some #(= eval-opt (init-dispatch (first %))) inits)
-    (println "Jaunt" (clojure-version)))
+    (println "Jaunt" (jaunt-version)))
   (repl :init (fn []
                 (initialize args inits)
                 (apply require repl-requires)))

--- a/src/clj/clojure/main.clj
+++ b/src/clj/clojure/main.clj
@@ -321,7 +321,7 @@ by default when a new command-line REPL is started."} repl-requires
   present"
   [[_ & args] inits]
   (when-not (some #(= eval-opt (init-dispatch (first %))) inits)
-    (println "Jaunt" (jaunt-version)))
+    (printf "Jaunt %s (Clojure %s derived)\n" (jaunt-version) (clojure-version)))
   (repl :init (fn []
                 (initialize args inits)
                 (apply require repl-requires)))


### PR DESCRIPTION
Suggested by @andrewhr [here](https://github.com/jaunt-lang/jaunt/issues/39#issuecomment-194079413).

This changeset introduces `*jaunt-version*` and `jaunt-version` replacing, deprecating and hardcoding `*clojure-version*` and `clojure-version`.
