### PR TITLE
Clarify (lack of) boot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ All you need is a `jaunt.clj` like this
 
 ### With Boot
 
-Unfortunately boot is not yet supported. Pull requests detailing usage with boot would be most
-welcome.
+Due to a minor breaking change in Jaunt's implementation details and the fact that Boot is fully AOT
+compiled against Clojure for startup performance, Jaunt is not usable with boot at this time.
 
 ## Goals
 


### PR DESCRIPTION
So in Jaunt it's `Var.setMacro():Var`, in Clojure it's `Var.setMacro():void`. This causes a binary incompatibility with Boot due to having been AOT'd against Clojure. Hence no support is possible.
