### PR TITLE
Add tests against CIDER master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ user.clj
 *.html
 .lein-env
 *.iml
+cider-nrepl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Change Log
 
 ### upcoming
+- [#108](https://github.com/jaunt-lang/jaunt/pull/107) Add tests against CIDER (@arrdem).
 - [#107](https://github.com/jaunt-lang/jaunt/pull/107) Set version to 0.1.0 (@arrdem).
   - Fix a minor bug in `*jaunt-version*` loading due to the Maven qualifier being empty/`nil`
   - Refactor `ns` forms to prefer explicit full ns macro docstrings, attrs over `^{}`

--- a/etc/bin/run-tests.sh
+++ b/etc/bin/run-tests.sh
@@ -8,6 +8,9 @@ function do_tests () {
     1)
       ant test-generative 2>&1 | tee test-generative.log
       ;;
+    2)
+      bash etc/bin/test-cider.sh 2>&1 | tee test-cider.log
+      ;;
   esac
 }
 
@@ -21,19 +24,29 @@ else
   ( export CIRCLE_NODE_INDEX=0;
     do_tests > /dev/null ) &
   tex=$1
+
   ( export CIRCLE_NODE_INDEX=1;
     do_tests > /dev/null ) &
   teg=$1
+
+  ( export CIRCLE_NODE_INDEX=2;
+    do_tests > /dev/null ) &
+  tec=$1
+  
   wait $tex
   texr=$?
   wait $teg
   tegr=$?
-  if [ $texr ] && [ $tegr ]
+  wait $tec
+  tecr=$?
+
+  if [ $texr ] && [ $tegr ] && [ $tecr ]
   then
     echo "Tests OK!"
   else
     [ ! $texr ] && echo "Example tests failed, see test-example.log"
     [ ! $tegr ] && echo "Generative tests failed, see test-generative.log"
+    [ ! $tecr ] && echo "CIDER tests failed, see test-cider.log"
     echo "Tests failed :("
     exit 1
   fi

--- a/etc/bin/test-cider.sh
+++ b/etc/bin/test-cider.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+VERSION="$(cat VERSION)-test-SNAPSHOT"
+mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$VERSION
+mvn install -Dmaven.test.skip=true
+
+if [ ! -d "cider-nrepl" ]
+then
+  git clone git@github.com:clojure-emacs/cider-nrepl.git
+else
+  (cd cider-nrepl; git reset --hard origin/master; git pull)
+fi
+
+cd cider-nrepl &&
+lein do clean, source-deps :project-prefix cider.inlined-deps &&
+lein with-profile +plugin.mranderson/config,+test-clj,+test-cljs update-in :dependencies conj "[org.jaunt-lang/jaunt \"$VERSION\"]" -- test


### PR DESCRIPTION
This changeset adds a script for running cider-nrepl's test suite with a fresh Jaunt build as an integration check.
