### PR TITLE
Add a warning for expanding deprecated macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## upcomming
+- [#111](https://github.com/jaunt-lang/jaunt/pull/111) Add a warning when expanding deprecated macros (@arrdem).
 
 ## Jaunt 0.1.0
 - [#108](https://github.com/jaunt-lang/jaunt/pull/108) Add tests against CIDER (@arrdem).

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -6525,6 +6525,12 @@ public class Compiler implements Opcodes {
       //macro expansion
       Var v = isMacro(op);
       if (v != null) {
+        if (isDeprecated(v) &&
+            warnOnDeprecated()) {
+          RT.errPrintWriter().println(
+            String.format("Warning: expanding deprecated macro: %s (%s:%d:%d)",
+                          v.toString(), SOURCE_PATH.get(), lineDeref(), columnDeref()));
+        }
         try {
           return v.applyTo(RT.cons(form,RT.cons(LOCAL_ENV.get(),form.next())));
         } catch (ArityException e) {


### PR DESCRIPTION
Does just what it says on the box. There are no examples of such macros in core, but when expanding a `^:deprecated` macro this change causes the compiler to print a warning.
