### PR TITLE
Deprecate clojure.core/use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
 ## upcomming
+- [#112](https://github.com/jaunt-lang/jaunt/pull/112) Self-refactoring use (@arrdem).
+  - Add `clojure.core/sift`.
+  - Refactor `clojure.core/use` to emit a warning describing how to rewrite use into require/refer.
+  - Refactor out uses of `use`.
 - [#111](https://github.com/jaunt-lang/jaunt/pull/111) Add a warning when expanding deprecated macros (@arrdem).
 
 ## Jaunt 0.1.0

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -155,12 +155,40 @@
     (. clojure.lang.RT (seq coll))))
 
 (def
+  ^{:arglists '(^clojure.lang.ISeq [coll])
+    :doc      "Returns true if coll has no items - same as(not (seq coll)). Please use the idiom (seq x) rather than (not (empty? x))"
+    :tag      Boolean
+    :added    "0.1.0"
+    :static   true}
+  empty?
+  (fn ^:static  [coll]
+    (if (seq coll) false true)))
+
+(def
   ^{:arglists '([^Class c x])
     :doc      "Evaluates x and tests if it is an instance of the class c. Returns true or false"
     :added    "0.1.0"}
   instance?
   (fn instance? [^Class c x]
     (. c (isInstance x))))
+
+(def
+  ^{:arglists '([x])
+    :doc      "Returns true if x implements IPersistentCollection"
+    :added    "0.1.0"
+    :static   true}
+  coll?
+  (fn ^:static coll? [x]
+    (instance? clojure.lang.IPersistentCollection x)))
+
+(def
+  ^{:arglists '([x])
+    :doc      "Returns true if x implements IPersistentList"
+    :added    "0.1.0"
+    :static   true}
+  list?
+  (fn ^:static list? [x]
+    (instance? clojure.lang.IPersistentList x)))
 
 (def
   ^{:arglists '([x])
@@ -215,6 +243,15 @@
   var?
   (fn ^:static var? [x]
     (instance? clojure.lang.Var x)))
+
+(def
+  ^{:arglists '([coll])
+    :doc      "Returns true if coll implements Associative"
+    :added    "0.1.0"
+    :static   true}
+  associative?
+  (fn ^:static associative? [coll]
+    (instance? clojure.lang.Associative coll)))
 
 (def
   ^{:arglists '([map key val] [map key val & kvs])
@@ -6088,25 +6125,6 @@
   ([m k f x y z & more]
    (assoc m k (apply f (get m k) x y z more))))
 
-(defn empty?
-  "Returns true if coll has no items - same as (not (seq coll)).
-  Please use the idiom (seq x) rather than (not (empty? x))"
-  {:added "0.1.0"
-   :static true}
-  [coll] (not (seq coll)))
-
-(defn coll?
-  "Returns true if x implements IPersistentCollection"
-  {:added "0.1.0"
-   :static true}
-  [x] (instance? clojure.lang.IPersistentCollection x))
-
-(defn list?
-  "Returns true if x implements IPersistentList"
-  {:added "0.1.0"
-   :static true}
-  [x] (instance? clojure.lang.IPersistentList x))
-
 (defn ifn?
   "Returns true if x implements IFn. Note that many data structures
   (e.g. sets and maps) implement IFn"
@@ -6119,12 +6137,6 @@
   {:added "0.1.0"
    :static true}
   [x] (instance? clojure.lang.Fn x))
-
-(defn associative?
-  "Returns true if coll implements Associative"
-  {:added "0.1.0"
-   :static true}
-  [coll] (instance? clojure.lang.Associative coll))
 
 (defn sequential?
   "Returns true if coll implements Sequential"

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5975,14 +5975,18 @@
   (apply load-libs :require args))
 
 (defn use
-  "Like 'require, but also refers to each lib's namespace using
-  clojure.core/refer. Use :use in the ns macro in preference to calling
-  this directly.
+  "DEPRECATED: Unrestricted referrals are difficult to reason about and should be avoided in favor
+  of qualified imports. Restricted and unrestricted referrals can both be achieved via require, so
+  use has no special value.
 
-  'use accepts additional options in libspecs: :exclude, :only, :rename.
-  The arguments and semantics for :exclude, :only, and :rename are the same
-  as those documented for clojure.core/refer."
-  {:added "0.1.0"}
+  Like 'require, but also refers to each lib's namespace using clojure.core/refer. Use :use in the
+  ns macro in preference to calling this directly.
+
+  'use accepts additional options in libspecs: :exclude, :only, :rename.  The arguments and
+  semantics for :exclude, :only, and :rename are the same as those documented for
+  clojure.core/refer."
+  {:added      "0.1.0"
+   :deprecated "0.2.0"}
   [& args] (apply load-libs :require :use args))
 
 (defn loaded-libs

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4594,6 +4594,21 @@
                   (let ~(vec (interleave bs gs))
                     ~@body)))))))
 
+(defn sift
+  "Takes a predicate and a seq, returns two seqs being respectively the elements for which pred
+  returned truthy and falsey."
+  {:added  "0.2.0"
+   :static true}
+  [pred coll]
+  (loop [t                    []
+         f                    []
+         [e & coll' :as coll] coll]
+    (if (empty? coll)
+      [t f]
+      (if (pred e)
+        (recur (conj t e) f coll')
+        (recur t (conj f e) coll')))))
+
 (defmacro when-first
   "bindings => x xs
 

--- a/test/clojure/test_clojure/agents.clj
+++ b/test/clojure/test_clojure/agents.clj
@@ -9,7 +9,7 @@
 ;; Author: Shawn Hoover
 
 (ns clojure.test-clojure.agents
-  (:use clojure.test)
+  (:require [clojure.test :refer :all])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 ;; tests are fragile. If wait fails, could indicate that

--- a/test/clojure/test_clojure/annotations.clj
+++ b/test/clojure/test_clojure/annotations.clj
@@ -9,7 +9,7 @@
 ;; Authors: Stuart Halloway, Rich Hickey
 
 (ns clojure.test-clojure.annotations
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (case (System/getProperty "java.specification.version")
   "1.6" (load "annotations/java_6")

--- a/test/clojure/test_clojure/atoms.clj
+++ b/test/clojure/test_clojure/atoms.clj
@@ -9,7 +9,7 @@
 ;;Author: Frantisek Sodomka
 
 (ns clojure.test-clojure.atoms
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; http://clojure.org/atoms
 

--- a/test/clojure/test_clojure/clojure_set.clj
+++ b/test/clojure/test_clojure/clojure_set.clj
@@ -10,8 +10,8 @@
 
 
 (ns clojure.test-clojure.clojure-set
-  (:use clojure.test)
-  (:require [clojure.set :as set]))
+  (:require [clojure.test :refer :all]
+            [clojure.set :as set]))
 
 (deftest test-union
   (are [x y] (= x y)

--- a/test/clojure/test_clojure/clojure_walk.clj
+++ b/test/clojure/test_clojure/clojure_walk.clj
@@ -1,6 +1,6 @@
 (ns clojure.test-clojure.clojure-walk
-  (:require [clojure.walk :as w])
-  (:use clojure.test))
+  (:require [clojure.walk :as w]
+            [clojure.test :refer :all]))
 
 (deftest t-prewalk-replace
   (is (= (w/prewalk-replace {:a :b} [:a {:a :a} (list 3 :c :a)])

--- a/test/clojure/test_clojure/clojure_xml.clj
+++ b/test/clojure/test_clojure/clojure_xml.clj
@@ -8,10 +8,9 @@
 
 ;;Author: Frantisek Sodomka
 
-
 (ns clojure.test-clojure.clojure-xml
-  (:use clojure.test)
-  (:require [clojure.xml :as xml]))
+  (:require [clojure.test :refer :all]
+            [clojure.xml :as xml]))
 
 ;; parse
 

--- a/test/clojure/test_clojure/clojure_zip.clj
+++ b/test/clojure/test_clojure/clojure_zip.clj
@@ -10,8 +10,8 @@
 
 
 (ns clojure.test-clojure.clojure-zip
-  (:use clojure.test)
-  (:require [clojure.zip :as zip]))
+  (:require [clojure.test :refer :all]
+            [clojure.zip :as zip]))
 
 ;; zipper
 ;

--- a/test/clojure/test_clojure/compilation.clj
+++ b/test/clojure/test_clojure/compilation.clj
@@ -13,9 +13,9 @@
   (:import (clojure.lang Compiler Compiler$CompilerException))
   (:require [clojure.test.generative :refer (defspec)]
             [clojure.data.generators :as gen]
-            [clojure.test-clojure.compilation.line-number-examples :as line])
-  (:use clojure.test
-        [clojure.test-helper :only (should-not-reflect should-print-err-message)]))
+            [clojure.test-clojure.compilation.line-number-examples :as line]
+            [clojure.test-helper :refer [should-not-reflect should-print-err-message]]
+            [clojure.test :refer :all]))
 
 ;; http://clojure.org/compilation
 
@@ -26,23 +26,23 @@
 (deftest test-compiler-metadata
   (let [m (meta #'when)]
     (are [x y]  (= x y)
-      (list? (:arglists m)) true
+      (list? (:arglists m))       true
       (> (count (:arglists m)) 0) true
 
-      (string? (:doc m)) true
-      (> (.length (:doc m)) 0) true
+      (string? (:doc m))          true
+      (> (.length (:doc m)) 0)    true
 
-      (string? (:file m)) true
-      (> (.length (:file m)) 0) true
+      (string? (:file m))         true
+      (> (.length (:file m)) 0)   true
 
-      (integer? (:line m)) true
-      (> (:line m) 0) true
+      (integer? (:line m))        true
+      (> (:line m) 0)             true
 
-      (integer? (:column m)) true
-      (> (:column m) 0) true
+      (integer? (:column m))      true
+      (> (:column m) 0)           true
 
-      (:macro m) true
-      (:name m) 'when)))
+      (:macro m)                  true
+      (:name m)                   'when)))
 
 (deftest test-embedded-constants
   (testing "Embedded constants"

--- a/test/clojure/test_clojure/control.clj
+++ b/test/clojure/test_clojure/control.clj
@@ -13,8 +13,8 @@
 ;;
 
 (ns clojure.test-clojure.control
-  (:use clojure.test
-        clojure.test-helper))
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer :all]))
 
 ;; *** Helper functions ***
 

--- a/test/clojure/test_clojure/data.clj
+++ b/test/clojure/test_clojure/data.clj
@@ -7,26 +7,27 @@
 ;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.data
-  (:use clojure.data clojure.test)
+  (:require [clojure.data :refer [diff]]
+            [clojure.test :refer [deftest are]])
   (import java.util.HashSet))
 
 (deftest diff-test
   (are [d x y] (= d (diff x y))
-    [nil nil nil] nil nil
-    [1 2 nil] 1 2
-    [nil nil [1 2 3]] [1 2 3] '(1 2 3)
-    [1 [:a :b] nil] 1 [:a :b]
-    [{:a 1} :b nil] {:a 1} :b
-    [:team #{:p1 :p2} nil] :team #{:p1 :p2}
-    [{0 :a} [:a] nil] {0 :a} [:a]
-    [nil [nil 2] [1]] [1] [1 2]
-    [nil nil [1 2]] [1 2] (into-array [1 2])
-    [#{:a} #{:b} #{:c :d}] #{:a :c :d} #{:b :c :d}
-    [nil nil {:a 1}] {:a 1} {:a 1}
-    [{:a #{2}} {:a #{4}} {:a #{3}}] {:a #{2 3}} {:a #{3 4}}
-    [#{1} #{3} #{2}] (HashSet. [1 2]) (HashSet. [2 3])
-    [nil nil [1 2]] [1 2] (into-array [1 2])
-    [nil nil [1 2]] (into-array [1 2]) [1 2]
-    [{:a {:c [1]}} {:a {:c [0]}} {:a {:c [nil 2] :b 1}}] {:a {:b 1 :c [1 2]}} {:a {:b 1 :c [0 2]}}
-    [{:a nil} {:a false} {:b nil :c false}] {:a nil :b nil :c false} {:a false :b nil :c false}))
+    [nil nil nil]                                        nil                      nil
+    [1 2 nil]                                            1                        2
+    [nil nil [1 2 3]]                                    [1 2 3]                  '(1 2 3)
+    [1 [:a :b] nil]                                      1                        [:a :b]
+    [{:a 1} :b nil]                                      {:a 1}                   :b
+    [:team #{:p1 :p2} nil]                               :team                    #{:p1 :p2}
+    [{0 :a} [:a] nil]                                    {0 :a}                   [:a]
+    [nil [nil 2] [1]]                                    [1]                      [1 2]
+    [nil nil [1 2]]                                      [1 2]                    (into-array [1 2])
+    [#{:a} #{:b} #{:c :d}]                               #{:a :c :d}              #{:b :c :d}
+    [nil nil {:a 1}]                                     {:a 1}                   {:a 1}
+    [{:a #{2}} {:a #{4}} {:a #{3}}]                      {:a #{2 3}}              {:a #{3 4}}
+    [#{1} #{3} #{2}]                                     (HashSet. [1 2])         (HashSet. [2 3])
+    [nil nil [1 2]]                                      [1 2]                    (into-array [1 2])
+    [nil nil [1 2]]                                      (into-array [1 2])       [1 2]
+    [{:a {:c [1]}} {:a {:c [0]}} {:a {:c [nil 2] :b 1}}] {:a {:b 1 :c [1 2]}}     {:a {:b 1 :c [0 2]}}
+    [{:a nil} {:a false} {:b nil :c false}]              {:a nil :b nil :c false} {:a false :b nil :c false}))
 

--- a/test/clojure/test_clojure/data_structures.clj
+++ b/test/clojure/test_clojure/data_structures.clj
@@ -10,11 +10,12 @@
 
 
 (ns clojure.test-clojure.data-structures
-  (:use clojure.test
-        [clojure.test.generative :exclude (is)])
   (:require [clojure.test-clojure.generators :as cgen]
             [clojure.data.generators :as gen]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [clojure.test :refer :all]
+            clojure.test.generative)
+  (:refer clojure.test.generative :exclude (is)))
 
 ;; *** Helper functions ***
 

--- a/test/clojure/test_clojure/data_structures_interop.clj
+++ b/test/clojure/test_clojure/data_structures_interop.clj
@@ -10,7 +10,7 @@
   (:require [clojure.test :refer :all]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :refer (defspec)]))
+            [clojure.test.check.clojure-test :refer [defspec]]))
 
 (defn gen-range [min max]
   (gen/bind (gen/choose min max) (fn [n] (gen/tuple (gen/return n)

--- a/test/clojure/test_clojure/def.clj
+++ b/test/clojure/test_clojure/def.clj
@@ -7,8 +7,9 @@
 ;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.def
-  (:use clojure.test clojure.test-helper
-        clojure.test-clojure.protocols))
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer :all]
+            [clojure.test-clojure.protocols :refer :all]))
 
 (deftest defn-error-messages
   (testing "multiarity syntax invalid parameter declaration"

--- a/test/clojure/test_clojure/delays.clj
+++ b/test/clojure/test_clojure/delays.clj
@@ -1,5 +1,5 @@
 (ns clojure.test-clojure.delays
-  (:use clojure.test))
+  (:require [clojure.test :refer [deftest is]]))
 
 (deftest calls-once
   (let [a (atom 0)

--- a/test/clojure/test_clojure/edn.clj
+++ b/test/clojure/test_clojure/edn.clj
@@ -8,7 +8,6 @@
 
 ;; Author: Stuart Halloway
 
-
 (ns clojure.test-clojure.edn
   (:require [clojure.test.generative :refer (defspec)]
             [clojure.test-clojure.generators :as cgen]

--- a/test/clojure/test_clojure/errors.clj
+++ b/test/clojure/test_clojure/errors.clj
@@ -9,7 +9,7 @@
 ;; Tests for error handling and messages
 
 (ns clojure.test-clojure.errors
-  (:use clojure.test)
+  (:require [clojure.test :refer :all])
   (:import clojure.lang.ArityException))
 
 (defn f0 [] 0)

--- a/test/clojure/test_clojure/evaluation.clj
+++ b/test/clojure/test_clojure/evaluation.clj
@@ -15,7 +15,7 @@
 ;;  Created 22 October 2008
 
 (ns clojure.test-clojure.evaluation
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (import '(java.lang Boolean)
         '(clojure.lang Compiler Compiler$CompilerException))

--- a/test/clojure/test_clojure/fn.clj
+++ b/test/clojure/test_clojure/fn.clj
@@ -9,7 +9,7 @@
 ;; Author: Ambrose Bonnaire-Sergeant
 
 (ns clojure.test-clojure.fn
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (deftest fn-error-checking
   (testing "bad arglist"

--- a/test/clojure/test_clojure/for.clj
+++ b/test/clojure/test_clojure/for.clj
@@ -12,7 +12,7 @@
 ;;  Created Dec 2008
 
 (ns clojure.test-clojure.for
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (deftest Docstring-Example
   (is (= (take 100 (for [x (range 100000000)

--- a/test/clojure/test_clojure/genclass.clj
+++ b/test/clojure/test_clojure/genclass.clj
@@ -6,18 +6,19 @@
 ;;    the terms of this license.
 ;;    You must not remove this notice, or any other, from this software.
 
-(ns ^{:doc "Tests for clojure.core/gen-class"
-      :author "Stuart Halloway, Daniel Solano Gómez"}
- clojure.test-clojure.genclass
-  (:use clojure.test clojure.test-helper)
-  (:require clojure.test_clojure.genclass.examples)
+(ns clojure.test-clojure.genclass
+  {:doc     "Tests for clojure.core/gen-class"
+   :authors ["Stuart Halloway"
+             "Daniel Solano Gómez"]}
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer :all]
+            clojure.test_clojure.genclass.examples)
   (:import [clojure.test_clojure.genclass.examples
             ExampleClass
             ExampleAnnotationClass
             ProtectedFinalTester
             ArrayDefInterface
             ArrayGenInterface]
-
            [java.lang.annotation ElementType
             Retention
             RetentionPolicy

--- a/test/clojure/test_clojure/java/io.clj
+++ b/test/clojure/test_clojure/java/io.clj
@@ -7,13 +7,13 @@
 ;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.java.io
-  (:use clojure.test clojure.java.io
-        [clojure.test-helper :only [platform-newlines]])
-  (:import (java.io File BufferedInputStream
-                    FileInputStream InputStreamReader InputStream
-                    FileOutputStream OutputStreamWriter OutputStream
-                    ByteArrayInputStream ByteArrayOutputStream)
-           (java.net URL URI Socket ServerSocket)))
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :refer :all]
+            [clojure.test-helper :refer [platform-newlines]])
+  (:import [java.io File BufferedInputStream FileInputStream InputStreamReader InputStream
+            FileOutputStream OutputStreamWriter OutputStream ByteArrayInputStream
+            ByteArrayOutputStream]
+           [java.net URL URI Socket ServerSocket]))
 
 (defn temp-file
   [prefix suffix]
@@ -112,6 +112,7 @@
        (bytes-should-equal (.getBytes s "UTF-8")
                            (.toByteArray o)
                            (str "combination " test opts))))))
+
 ;; does not work on IBM JDK
 #_(deftest test-copy-encodings
     (doseq [enc ["UTF-8" "UTF-16" "UTF-16BE" "UTF-16LE"]]
@@ -127,38 +128,38 @@
 
 (deftest test-as-file
   (are [result input] (= result (as-file input))
-    (File. "foo") "foo"
-    (File. "bar") (File. "bar")
-    (File. "baz") (URL. "file:baz")
-    (File. "bar+baz") (URL. "file:bar+baz")
-    (File. "bar baz qux") (URL. "file:bar%20baz%20qux")
-    (File. "quux") (URI. "file:quux")
+    (File. "foo")           "foo"
+    (File. "bar")           (File. "bar")
+    (File. "baz")           (URL. "file:baz")
+    (File. "bar+baz")       (URL. "file:bar+baz")
+    (File. "bar baz qux")   (URL. "file:bar%20baz%20qux")
+    (File. "quux")          (URI. "file:quux")
     (File. "abcíd/foo.txt") (URL. "file:abc%c3%add/foo.txt")
-    nil nil))
+    nil                     nil))
 
 (deftest test-resources-with-spaces
   (let [file-with-spaces (temp-file "test resource 2" "txt")
-        url (as-url (.getParentFile file-with-spaces))
-        loader (java.net.URLClassLoader. (into-array [url]))
-        r (resource (.getName file-with-spaces) loader)]
+        url              (as-url (.getParentFile file-with-spaces))
+        loader           (java.net.URLClassLoader. (into-array [url]))
+        r                (resource (.getName file-with-spaces) loader)]
     (is (= r (as-url file-with-spaces)))
     (spit r "foobar")
     (is (= "foobar" (slurp r)))))
 
 (deftest test-file
   (are [result args] (= (File. result) (apply file args))
-    "foo" ["foo"]
-    "foo/bar" ["foo" "bar"]
+    "foo"         ["foo"]
+    "foo/bar"     ["foo" "bar"]
     "foo/bar/baz" ["foo" "bar" "baz"]))
 (deftest test-as-url
   (are [file-part input] (= (URL. (str "file:" file-part)) (as-url input))
-    "foo" "file:foo"
-    "baz" (URL. "file:baz")
+    "foo"  "file:foo"
+    "baz"  (URL. "file:baz")
     "quux" (URI. "file:quux"))
   (is (nil? (as-url nil))))
 
 (deftest test-delete-file
-  (let [file (temp-file "test" "deletion")
+  (let [file     (temp-file "test" "deletion")
         not-file (File. (str (java.util.UUID/randomUUID)))]
     (delete-file (.getAbsolutePath file))
     (is (not (.exists file)))
@@ -182,9 +183,9 @@
     (is (= (seq expected-bytes) (seq actual-bytes)) (str msg " : byte arrays should match"))))
 
 (deftest test-input-stream
-  (let [file (temp-file "test-input-stream" "txt")
+  (let [file    (temp-file "test-input-stream" "txt")
         content (apply str (concat "a" (repeat 500 "\u226a\ud83d\ude03")))
-        bytes (.getBytes content "UTF-8")]
+        bytes   (.getBytes content "UTF-8")]
     (spit file content)
     (doseq [[expr msg]
             [[file File]
@@ -207,8 +208,8 @@
 (deftest test-resource
   (is (nil? (resource "non/existent/resource")))
   (is (instance? URL (resource "clojure/core.clj")))
-  (let [file (temp-file "test-resource" "txt")
-        url (as-url (.getParentFile file))
+  (let [file   (temp-file "test-resource" "txt")
+        url    (as-url (.getParentFile file))
         loader (java.net.URLClassLoader. (into-array [url]))]
     (is (nil? (resource "non/existent/resource" loader)))
     (is (instance? URL (resource (.getName file) loader)))))

--- a/test/clojure/test_clojure/java/javadoc.clj
+++ b/test/clojure/test_clojure/java/javadoc.clj
@@ -7,16 +7,16 @@
 ;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.java.javadoc
-  (:use clojure.test
-        [clojure.java.javadoc :as j])
+  (:require [clojure.test :refer :all]
+            [clojure.java.javadoc :as j])
   (:import (java.io File)))
 
 (deftest javadoc-url-test
   (testing "for a core api"
-    (binding [*feeling-lucky* false]
+    (binding [j/*feeling-lucky* false]
       (are [x y] (= x (#'j/javadoc-url y))
-        nil "foo.Bar"
-        (str *core-java-api* "java/lang/String.html") "java.lang.String")))
+        nil                                             "foo.Bar"
+        (str j/*core-java-api* "java/lang/String.html") "java.lang.String")))
   (testing "for a remote javadoc"
-    (binding [*remote-javadocs* (ref (sorted-map "java." "http://example.com/"))]
+    (binding [j/*remote-javadocs* (ref (sorted-map "java." "http://example.com/"))]
       (is (= "http://example.com/java/lang/Number.html" (#'j/javadoc-url "java.lang.Number"))))))

--- a/test/clojure/test_clojure/java/shell.clj
+++ b/test/clojure/test_clojure/java/shell.clj
@@ -7,35 +7,45 @@
 ;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.java.shell
-  (:use clojure.test
-        [clojure.java.shell :as sh])
-  (:import (java.io File)))
+  (:require [clojure.test :refer :all]
+            [clojure.java.shell :as sh])
+  (:import [java.io File]))
 
-(def platform-enc (.name (java.nio.charset.Charset/defaultCharset)))
-(def default-enc "UTF-8")
+(def platform-enc
+  (.name (java.nio.charset.Charset/defaultCharset)))
+
+(def default-enc
+  "UTF-8")
 
 (deftest test-parse-args
-  (are [x y] (= x y)
-    [[] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args [])
-    [["ls"] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args ["ls"])
-    [["ls" "-l"] {:in-enc default-enc :out-enc default-enc :dir nil :env nil}] (#'sh/parse-args ["ls" "-l"])
-    [["ls"] {:in-enc default-enc :out-enc "ISO-8859-1" :dir nil :env nil}] (#'sh/parse-args ["ls" :out-enc "ISO-8859-1"])
-    [[] {:in-enc platform-enc :out-enc platform-enc :dir nil :env nil}] (#'sh/parse-args [:in-enc platform-enc :out-enc platform-enc])))
+  (let [o1 {:in-enc  default-enc
+            :out-enc default-enc
+            :dir     nil
+            :env     nil}
+        o2 {:in-enc  default-enc
+            :out-enc "ISO-8859-1"
+            :dir     nil
+            :env     nil}]
+    (are [x y] (= x y)
+      [[]          o1] (#'sh/parse-args [])
+      [["ls"]      o1] (#'sh/parse-args ["ls"])
+      [["ls" "-l"] o1] (#'sh/parse-args ["ls" "-l"])
+      [["ls"]      o2] (#'sh/parse-args ["ls" :out-enc "ISO-8859-1"])
+      [[]          o1] (#'sh/parse-args [:in-enc platform-enc :out-enc platform-enc]))))
 
 (deftest test-with-sh-dir
   (are [x y] (= x y)
-    nil *sh-dir*
-    "foo" (with-sh-dir "foo" *sh-dir*)))
+    nil   sh/*sh-dir*
+    "foo" (sh/with-sh-dir "foo" sh/*sh-dir*)))
 
 (deftest test-with-sh-env
   (are [x y] (= x y)
-    nil *sh-env*
-    {:KEY "VAL"} (with-sh-env {:KEY "VAL"} *sh-env*)))
+    nil          sh/*sh-env*
+    {:KEY "VAL"} (sh/with-sh-env {:KEY "VAL"} sh/*sh-env*)))
 
 (deftest test-as-env-strings
   (are [x y] (= x y)
-    nil (#'sh/as-env-strings nil)
-    ["FOO=BAR"] (seq (#'sh/as-env-strings {"FOO" "BAR"}))
-    ["FOO_SYMBOL=BAR"] (seq (#'sh/as-env-strings {'FOO_SYMBOL "BAR"}))
+    nil                 (#'sh/as-env-strings nil)
+    ["FOO=BAR"]         (seq (#'sh/as-env-strings {"FOO" "BAR"}))
+    ["FOO_SYMBOL=BAR"]  (seq (#'sh/as-env-strings {'FOO_SYMBOL "BAR"}))
     ["FOO_KEYWORD=BAR"] (seq (#'sh/as-env-strings {:FOO_KEYWORD "BAR"}))))
-

--- a/test/clojure/test_clojure/java_interop.clj
+++ b/test/clojure/test_clojure/java_interop.clj
@@ -8,13 +8,11 @@
 
 ;; Author: Frantisek Sodomka
 
-
 (ns clojure.test-clojure.java-interop
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; http://clojure.org/java_interop
 ;; http://clojure.org/compilation
-
 
 (deftest test-dot
   ; (.instanceMember instance args*)

--- a/test/clojure/test_clojure/keywords.clj
+++ b/test/clojure/test_clojure/keywords.clj
@@ -7,7 +7,7 @@
 ;;    You must not remove this notice, or any other, from this software.
 
 (ns clojure.test-clojure.keywords
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (let [this-ns (str (.name *ns*))]
   (deftest test-find-keyword

--- a/test/clojure/test_clojure/logic.clj
+++ b/test/clojure/test_clojure/logic.clj
@@ -12,8 +12,8 @@
 ;;  Created 1/29/2009
 
 (ns clojure.test-clojure.logic
-  (:use clojure.test
-        [clojure.test-helper :only (exception)]))
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer [exception]]))
 
 ;; *** Tests ***
 

--- a/test/clojure/test_clojure/macros.clj
+++ b/test/clojure/test_clojure/macros.clj
@@ -9,7 +9,7 @@
 ;; Author: Frantisek Sodomka
 
 (ns clojure.test-clojure.macros
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; http://clojure.org/macros
 

--- a/test/clojure/test_clojure/main.clj
+++ b/test/clojure/test_clojure/main.clj
@@ -10,9 +10,9 @@
 
 
 (ns clojure.test-clojure.main
-  (:use clojure.test
-        [clojure.test-helper :only [platform-newlines]])
-  (:require [clojure.main :as main]))
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer [platform-newlines]]
+            [clojure.main :as main]))
 
 (deftest eval-opt
   (testing "evals and prints forms"

--- a/test/clojure/test_clojure/metadata.clj
+++ b/test/clojure/test_clojure/metadata.clj
@@ -9,9 +9,9 @@
 ;; Authors: Stuart Halloway, Frantisek Sodomka
 
 (ns clojure.test-clojure.metadata
-  (:use clojure.test
-        [clojure.test-helper :only (eval-in-temp-ns)])
-  (:require [clojure.set :as set]))
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer (eval-in-temp-ns)]
+            [clojure.set :as set]))
 
 (def public-namespaces
   '[clojure.core

--- a/test/clojure/test_clojure/multimethods.clj
+++ b/test/clojure/test_clojure/multimethods.clj
@@ -9,8 +9,9 @@
 ;; Author: Frantisek Sodomka, Robert Lachlan
 
 (ns clojure.test-clojure.multimethods
-  (:use clojure.test [clojure.test-helper :only (with-var-roots)])
-  (:require [clojure.set :as set]))
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer [with-var-roots]]
+            [clojure.set :as set]))
 
 ;; http://clojure.org/multimethods
 

--- a/test/clojure/test_clojure/ns_libs.clj
+++ b/test/clojure/test_clojure/ns_libs.clj
@@ -9,7 +9,8 @@
 ;; Authors: Frantisek Sodomka, Stuart Halloway
 
 (ns clojure.test-clojure.ns-libs
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]
+            [clojure.test-helper :refer [silenced]]))
 
 ;; http://clojure.org/namespaces
 
@@ -60,8 +61,9 @@
   (is (thrown? Exception (require))))
 
 (deftest test-use
-  (is (thrown? Exception (use :foo)))
-  (is (thrown? Exception (use))))
+  (silenced
+   (is (thrown? Exception (use :foo)))
+   (is (thrown? Exception (use)))))
 
 (deftest reimporting-deftypes
   (let [inst1 (binding [*ns* *ns*]
@@ -79,7 +81,7 @@
     (testing "you can reimport a changed class and see the changes"
       (is (= [:a] (keys inst1)))
       (is (= [:a :b] (keys inst2))))
-    ;fragile tests, please fix
+    ;; fragile tests, please fix
     #_(testing "you cannot import same local name from a different namespace"
         (is (thrown? clojure.lang.Compiler$CompilerException
                      #"ReimportMe already refers to: class exporter.ReimportMe in namespace: importer"

--- a/test/clojure/test_clojure/numbers.clj
+++ b/test/clojure/test_clojure/numbers.clj
@@ -12,11 +12,12 @@
 ;;
 
 (ns clojure.test-clojure.numbers
-  (:use clojure.test
-        [clojure.test.generative :exclude (is)]
-        clojure.template)
-  (:require [clojure.data.generators :as gen]
-            [clojure.test-helper :as helper]))
+  (:require [clojure.test :refer :all]
+            clojure.test.generative
+            [clojure.data.generators :as gen]
+            [clojure.template :refer :all]
+            [clojure.test-helper :as helper])
+  (:refer clojure.test.generative :exclude [is]))
 
 ;; TODO:
 ;; ==
@@ -24,7 +25,6 @@
 
 
 ;; *** Types ***
-
 
 (deftest Coerced-BigDecimal
   (doseq [v [(bigdec 3) (bigdec (inc (bigint Long/MAX_VALUE)))]]

--- a/test/clojure/test_clojure/other_functions.clj
+++ b/test/clojure/test_clojure/other_functions.clj
@@ -8,9 +8,8 @@
 
 ;; Author: Frantisek Sodomka
 
-
 (ns clojure.test-clojure.other-functions
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; http://clojure.org/other_functions
 

--- a/test/clojure/test_clojure/parallel.clj
+++ b/test/clojure/test_clojure/parallel.clj
@@ -10,7 +10,7 @@
 
 
 (ns clojure.test-clojure.parallel
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; !! Tests for the parallel library will be in a separate file clojure_parallel.clj !!
 
@@ -20,9 +20,8 @@
 ;; pcalls
 ;; pvalues
 
-
 ;; pmap
-;;
+
 (deftest pmap-does-its-thing
   ;; regression fixed in r1218; was OutOfMemoryError
   (is (= '(1) (pmap inc [0]))))

--- a/test/clojure/test_clojure/pprint.clj
+++ b/test/clojure/test_clojure/pprint.clj
@@ -10,11 +10,11 @@
 
 (ns clojure.test-clojure.pprint
   (:refer-clojure :exclude [format])
-  (:require [clojure.string :as str])
-  (:use [clojure.test :only (deftest is are run-tests)]
-        [clojure.test-helper :only [platform-newlines]]
-        clojure.test-clojure.pprint.test-helper
-        clojure.pprint))
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is are run-tests]]
+            [clojure.test-helper :refer [platform-newlines]]
+            [clojure.test-clojure.pprint.test-helper :refer :all]
+            [clojure.pprint :refer :all]))
 
 (load "pprint/test_cl_format")
 (load "pprint/test_pretty")

--- a/test/clojure/test_clojure/pprint/test_helper.clj
+++ b/test/clojure/test_clojure/pprint/test_helper.clj
@@ -15,10 +15,11 @@
 ;; This is just a macro to make my tests a little cleaner
 
 (ns clojure.test-clojure.pprint.test-helper
-  (:use [clojure.test :only (deftest is)]
-        [clojure.test-helper :only [platform-newlines]]))
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.test-helper :refer [platform-newlines]]))
 
-(defn- back-match [x y] (re-matches y x))
+(defn- back-match [x y]
+  (re-matches y x))
 
 (defmacro simple-tests [name & test-pairs]
   `(deftest ~name

--- a/test/clojure/test_clojure/predicates.clj
+++ b/test/clojure/test_clojure/predicates.clj
@@ -12,7 +12,7 @@
 ;;  Created 1/28/2009
 
 (ns clojure.test-clojure.predicates
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; *** Type predicates ***
 

--- a/test/clojure/test_clojure/printer.clj
+++ b/test/clojure/test_clojure/printer.clj
@@ -14,7 +14,7 @@
 ;;  Created 29 October 2008
 
 (ns clojure.test-clojure.printer
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (deftest print-length-empty-seq
   (let [coll () val "()"]

--- a/test/clojure/test_clojure/protocols.clj
+++ b/test/clojure/test_clojure/protocols.clj
@@ -9,8 +9,9 @@
 ;; Author: Stuart Halloway
 
 (ns clojure.test-clojure.protocols
-  (:use clojure.test clojure.test-clojure.protocols.examples)
-  (:require [clojure.test-clojure.protocols.more-examples :as other]
+  (:require [clojure.test :refer :all]
+            [clojure.test-clojure.protocols.examples :refer :all]
+            [clojure.test-clojure.protocols.more-examples :as other]
             [clojure.set :as set]
             clojure.test-helper)
   (:import [clojure.test_clojure.protocols.examples ExampleInterface]))

--- a/test/clojure/test_clojure/protocols/hash_collisions.clj
+++ b/test/clojure/test_clojure/protocols/hash_collisions.clj
@@ -1,5 +1,5 @@
 (ns clojure.test-clojure.protocols.hash-collisions
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (defprotocol TestProtocolA
   (method-a [this] "Test method A"))

--- a/test/clojure/test_clojure/reader.cljc
+++ b/test/clojure/test_clojure/reader.cljc
@@ -17,11 +17,11 @@
 ;;  Created 22 October 2008
 
 (ns clojure.test-clojure.reader
-  (:use clojure.test)
-  (:use [clojure.instant :only [read-instant-date
-                                read-instant-calendar
-                                read-instant-timestamp]])
-  (:require clojure.walk
+  (:require [clojure.test :refer :all]
+            [clojure.instant :refer [read-instant-date
+                                     read-instant-calendar
+                                     read-instant-timestamp]]
+            clojure.walk
             [clojure.test.generative :refer (defspec)]
             [clojure.test-clojure.generators :as cgen])
   (:import [clojure.lang BigInt Ratio]
@@ -469,8 +469,8 @@
   (is (= clojure.core// /))
   (binding [*ns* *ns*]
     (eval '(do (ns foo
-                 (:require [clojure.core :as bar])
-                 (:use [clojure.test]))
+                 (:require [clojure.core :as bar]
+                           [clojure.test :refer :all]))
                (is (= clojure.core// bar//))))))
 
 (deftest Instants

--- a/test/clojure/test_clojure/reducers.clj
+++ b/test/clojure/test_clojure/reducers.clj
@@ -11,8 +11,8 @@
 (ns clojure.test-clojure.reducers
   (:require [clojure.core.reducers :as r]
             [clojure.test.generative :refer (defspec)]
-            [clojure.data.generators :as gen])
-  (:use clojure.test))
+            [clojure.data.generators :as gen]
+            [clojure.test :refer :all]))
 
 (defmacro defequivtest
   ;; f is the core fn, r is the reducers equivalent, rt is the reducible ->

--- a/test/clojure/test_clojure/reflect.clj
+++ b/test/clojure/test_clojure/reflect.clj
@@ -1,5 +1,8 @@
 (ns clojure.test-clojure.reflect
-  (:use clojure.data [clojure.reflect :as reflect] clojure.test clojure.pprint)
+  (:require [clojure.data :refer :all]
+            [clojure.reflect :as reflect]
+            [clojure.test :refer :all]
+            [clojure.pprint :refer :all])
   (:import [clojure.reflect AsmReflector JavaReflector]
            [reflector IBar$Factory]))
 

--- a/test/clojure/test_clojure/refs.clj
+++ b/test/clojure/test_clojure/refs.clj
@@ -8,9 +8,8 @@
 
 ;; Author: Frantisek Sodomka
 
-
 (ns clojure.test-clojure.refs
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; http://clojure.org/refs
 

--- a/test/clojure/test_clojure/repl.clj
+++ b/test/clojure/test_clojure/repl.clj
@@ -1,9 +1,9 @@
 (ns clojure.test-clojure.repl
-  (:use clojure.test
-        clojure.repl
-        [clojure.test-helper :only [platform-newlines]]
-        clojure.test-clojure.repl.example)
-  (:require [clojure.string :as str]))
+  (:require [clojure.test :refer :all]
+            [clojure.repl :refer :all]
+            [clojure.test-helper :refer [platform-newlines]]
+            [clojure.test-clojure.repl.example :refer :all]
+            [clojure.string :as str]))
 
 (deftest test-doc
   (testing "with namespaces"

--- a/test/clojure/test_clojure/rt.clj
+++ b/test/clojure/test_clojure/rt.clj
@@ -9,8 +9,9 @@
 ;; Author: Stuart Halloway
 
 (ns clojure.test-clojure.rt
-  (:require clojure.set)
-  (:use clojure.test clojure.test-helper))
+  (:require [clojure.set :as set]
+            [clojure.test :refer :all]
+            [clojure.test-helper :refer :all]))
 
 (defn bare-rt-print
   "Return string RT would print prior to print-initialize"
@@ -77,36 +78,32 @@
 
 (deftest last-var-wins-for-core
   (testing "you can replace a core name, with warning"
-    (let [ns (temp-ns)
+    (let [ns          (temp-ns)
           replacement (gensym)]
       (with-err-string-writer (intern ns 'prefers replacement))
       (is (= replacement @('prefers (ns-publics ns))))))
   (testing "you can replace a name you defined before"
     (let [ns (temp-ns)
-          s (gensym)
+          s  (gensym)
           v1 (intern ns 'foo s)
           v2 (intern ns 'bar s)]
       (with-err-string-writer (.refer ns 'flatten v1))
       (.refer ns 'flatten v2)
       (is (= v2 (ns-resolve ns 'flatten)))))
   (testing "you cannot intern over an existing non-core name"
-    (let [ns (temp-ns 'clojure.set)
+    (let [ns          (temp-ns '[clojure.set :as set :refer :all])
           replacement (gensym)]
       (is (thrown? IllegalStateException
                    (intern ns 'subset? replacement)))
       (is (nil? ('subset? (ns-publics ns))))
-      (is (= #'clojure.set/subset? ('subset? (ns-refers ns))))))
+      (is (= #'set/subset? ('subset? (ns-refers ns))))))
   (testing "you cannot refer over an existing non-core name"
-    (let [ns (temp-ns 'clojure.set)
+    (let [ns          (temp-ns '[clojure.set :as set :refer :all])
           replacement (gensym)]
       (is (thrown? IllegalStateException
-                   (.refer ns 'subset? #'clojure.set/intersection)))
+                   (.refer ns 'subset? #'set/intersection)))
       (is (nil? ('subset? (ns-publics ns))))
-      (is (= #'clojure.set/subset? ('subset? (ns-refers ns)))))))
-
-(defmacro silenced [& forms]
-  `(binding [*err* (new java.io.StringWriter)]
-     ~@forms))
+      (is (= #'set/subset? ('subset? (ns-refers ns)))))))
 
 (deftest var-meta-tests
   (testing "Var.resetMeta should clear flags, getters"

--- a/test/clojure/test_clojure/serialization.clj
+++ b/test/clojure/test_clojure/serialization.clj
@@ -10,7 +10,7 @@
 ;;         cemerick@snowtide.com
 
 (ns clojure.test-clojure.serialization
-  (:use clojure.test)
+  (:require [clojure.test :refer :all])
   (:import (java.io ObjectOutputStream ObjectInputStream
                     ByteArrayOutputStream ByteArrayInputStream)))
 

--- a/test/clojure/test_clojure/special.clj
+++ b/test/clojure/test_clojure/special.clj
@@ -13,7 +13,7 @@
 ;;
 
 (ns clojure.test-clojure.special
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; http://clojure.org/special_forms
 

--- a/test/clojure/test_clojure/string.clj
+++ b/test/clojure/test_clojure/string.clj
@@ -1,6 +1,6 @@
 (ns clojure.test-clojure.string
-  (:require [clojure.string :as s])
-  (:use clojure.test))
+  (:require [clojure.string :as s]
+            [clojure.test :refer :all]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/clojure/test_clojure/test.clj
+++ b/test/clojure/test_clojure/test.clj
@@ -14,10 +14,9 @@
 ;; Thanks to Chas Emerick, Allen Rohner, and Stuart Halloway for
 ;; contributions and suggestions.
 
-
 (ns clojure.test-clojure.test
-  (:use clojure.test)
-  (:require [clojure.stacktrace :as stack]))
+  (:require [clojure.test :refer :all]
+            [clojure.stacktrace :as stack]))
 
 (deftest can-test-symbol
   (let [x true]

--- a/test/clojure/test_clojure/test_fixtures.clj
+++ b/test/clojure/test_clojure/test_fixtures.clj
@@ -12,7 +12,7 @@
 ;; March 28, 2009
 
 (ns clojure.test-clojure.test-fixtures
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (declare ^:dynamic *a* ^:dynamic *b* ^:dynamic *c* ^:dynamic *d*)
 

--- a/test/clojure/test_clojure/transients.clj
+++ b/test/clojure/test_clojure/transients.clj
@@ -1,5 +1,13 @@
+;;    Copyright (c) Rich Hickey. All rights reserved.
+;;    The use and distribution terms for this software are covered by the
+;;    Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;    which can be found in the file epl-v10.html at the root of this distribution.
+;;    By using this software in any fashion, you are agreeing to be bound by
+;;    the terms of this license.
+;;    You must not remove this notice, or any other, from this software.
+
 (ns clojure.test-clojure.transients
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (deftest popping-off
   (testing "across a node boundary"

--- a/test/clojure/test_clojure/try_catch.clj
+++ b/test/clojure/test_clojure/try_catch.clj
@@ -9,7 +9,7 @@
 ;; Author: Paul M Bauer
 
 (ns clojure.test-clojure.try-catch
-  (:use clojure.test)
+  (:require [clojure.test :refer :all])
   (:import [clojure.test ReflectorTryCatchFixture
             ReflectorTryCatchFixture$Cookies]))
 

--- a/test/clojure/test_clojure/vars.clj
+++ b/test/clojure/test_clojure/vars.clj
@@ -8,9 +8,8 @@
 
 ;; Author: Frantisek Sodomka, Stephen C. Gilardi
 
-
 (ns clojure.test-clojure.vars
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 ;; http://clojure.org/vars
 

--- a/test/clojure/test_clojure/vectors.clj
+++ b/test/clojure/test_clojure/vectors.clj
@@ -9,7 +9,7 @@
 ;; Author: Stuart Halloway, Daniel Solano Gómez
 
 (ns clojure.test-clojure.vectors
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (deftest test-reversed-vec
   (let [r (range 6)

--- a/test/clojure/test_clojure/volatiles.clj
+++ b/test/clojure/test_clojure/volatiles.clj
@@ -9,7 +9,7 @@
 ;;Author: Alex Miller
 
 (ns clojure.test-clojure.volatiles
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (deftest volatile-basics
   (let [vol (volatile! "abc")]

--- a/test/clojure/test_helper.clj
+++ b/test/clojure/test_helper.clj
@@ -16,30 +16,33 @@
 ;;  Created 04 November 2010
 
 (ns clojure.test-helper
-  (:use clojure.test))
+  (:require [clojure.test :refer :all]))
 
 (let [nl (System/getProperty "line.separator")]
   (defn platform-newlines [s] (.replace s "\n" nl)))
 
 (defn temp-ns
-  "Create and return a temporary ns, using clojure.core + uses"
-  [& uses]
+  "Create and return a temporary ns, using clojure.core + requires"
+  [& requires]
   (binding [*ns* *ns*]
-    (in-ns (gensym))
-    (apply clojure.core/use 'clojure.core uses)
+    (eval `(ns ~(gensym)
+             ~@(when requires [(cons :require requires)])))
     *ns*))
 
 (defmacro eval-in-temp-ns [& forms]
   `(binding [*ns* *ns*]
-     (in-ns (gensym))
-     (clojure.core/use 'clojure.core)
+     (ns ~(gensym))
      (eval
       '(do ~@forms))))
+
+(defmacro silenced [& forms]
+  `(binding [*err* (new java.io.StringWriter)]
+     ~@forms))
 
 (defn causes
   [^Throwable throwable]
   (loop [causes []
-         t throwable]
+         t      throwable]
     (if t (recur (conj causes t) (.getCause t)) causes)))
 
 ;; this is how I wish clojure.test/thrown? worked...


### PR DESCRIPTION
This patch deprecates use, doing a bunch of legwork to provide automatic refactor suggestions for replacing use with require and refer.
