### PR TITLE
Create :jnt reader conditional support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
 ## Upcoming
+- [#123](https://github.com/jaunt-lang/jaunt/pull/123) Add support for `:jnt` in reader conditionals (@arrdem).
+  - Update to Java 1.8
+  - Implement `java.lang.Iterable` over `clojure.lang.Seqable` using a Java 8 interface default method
+  - Add `clojure.lang.RT.union(set, seq):set`
 - [#122](https://github.com/jaunt-lang/jaunt/pull/122) Catch and print exceptions encountered loading `user.clj` (@arrdem).
 - [#116](https://github.com/jaunt-lang/jaunt/pull/116) Deprecate `clojure.core/refer` (@arrdem).
   - Deprecate `clojure.core/refer`

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,9 @@ dependencies:
   cache_directories:
     - ~/bin
   pre:
+    - sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java
+    - sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+    - echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> ~/.circlerc
     - bash etc/bin/make-astyle.sh
     - bash etc/bin/circle-deps.sh
   post:

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -38,57 +38,62 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class LispReader {
-
   static final Symbol QUOTE = Symbol.intern("quote");
   static final Symbol THE_VAR = Symbol.intern("var");
-//static Symbol SYNTAX_QUOTE = Symbol.intern(null, "syntax-quote");
-  static Symbol UNQUOTE = Symbol.intern("clojure.core", "unquote");
-  static Symbol UNQUOTE_SPLICING = Symbol.intern("clojure.core", "unquote-splicing");
-  static Symbol CONCAT = Symbol.intern("clojure.core", "concat");
-  static Symbol SEQ = Symbol.intern("clojure.core", "seq");
-  static Symbol LIST = Symbol.intern("clojure.core", "list");
-  static Symbol APPLY = Symbol.intern("clojure.core", "apply");
-  static Symbol HASHMAP = Symbol.intern("clojure.core", "hash-map");
-  static Symbol HASHSET = Symbol.intern("clojure.core", "hash-set");
-  static Symbol VECTOR = Symbol.intern("clojure.core", "vector");
-  static Symbol WITH_META = Symbol.intern("clojure.core", "with-meta");
-  static Symbol META = Symbol.intern("clojure.core", "meta");
-  static Symbol DEREF = Symbol.intern("clojure.core", "deref");
-  static Symbol READ_COND = Symbol.intern("clojure.core", "read-cond");
-  static Symbol READ_COND_SPLICING = Symbol.intern("clojure.core", "read-cond-splicing");
-  static Keyword UNKNOWN = Keyword.intern(null, "unknown");
-//static Symbol DEREF_BANG = Symbol.intern("clojure.core", "deref!");
+  static final Symbol UNQUOTE = Symbol.intern("clojure.core", "unquote");
+  static final Symbol UNQUOTE_SPLICING = Symbol.intern("clojure.core", "unquote-splicing");
+  static final Symbol CONCAT = Symbol.intern("clojure.core", "concat");
+  static final Symbol SEQ = Symbol.intern("clojure.core", "seq");
+  static final Symbol LIST = Symbol.intern("clojure.core", "list");
+  static final Symbol APPLY = Symbol.intern("clojure.core", "apply");
+  static final Symbol HASHMAP = Symbol.intern("clojure.core", "hash-map");
+  static final Symbol HASHSET = Symbol.intern("clojure.core", "hash-set");
+  static final Symbol VECTOR = Symbol.intern("clojure.core", "vector");
+  static final Symbol WITH_META = Symbol.intern("clojure.core", "with-meta");
+  static final Symbol META = Symbol.intern("clojure.core", "meta");
+  static final Symbol DEREF = Symbol.intern("clojure.core", "deref");
+
+  static final Keyword UNKNOWN = Keyword.intern(null, "unknown");
+  static final Keyword DEFAULT_FEATURE = Keyword.intern(null, "default");
+  static final Keyword OPT_EOF = Keyword.intern(null,"eof");
+  static final Keyword OPT_FEATURES = Keyword.intern(null, "features");
+  static final Keyword OPT_READ_COND = Keyword.intern(null, "read-cond");
+  static final Keyword EOFTHROW = Keyword.intern(null, "eofthrow");
+  static final Keyword COND_ALLOW = Keyword.intern(null, "allow");
+  static final Keyword COND_PRESERVE = Keyword.intern(null, "preserve");
+
+  // Platform features - always installed
+  static final IPersistentSet PLATFORM_FEATURES =
+    RT.set(Keyword.intern("clj"),
+           Keyword.intern("jnt"));
+
+  final static public IPersistentSet RESERVED_FEATURES =
+    RT.set(Keyword.intern(null, "else"),
+           Keyword.intern(null, "none"));
 
   static IFn[] macros = new IFn[256];
   static IFn[] dispatchMacros = new IFn[256];
-//static Pattern symbolPat = Pattern.compile("[:]?([\\D&&[^:/]][^:/]*/)?[\\D&&[^:/]][^:/]*");
   static Pattern symbolPat = Pattern.compile("[:]?([\\D&&[^/]].*/)?(/|[\\D&&[^/]][^/]*)");
-//static Pattern varPat = Pattern.compile("([\\D&&[^:\\.]][^:\\.]*):([\\D&&[^:\\.]][^:\\.]*)");
-//static Pattern intPat = Pattern.compile("[-+]?[0-9]+\\.?");
   static Pattern intPat =
-    Pattern.compile(
-      "([-+]?)(?:(0)|([1-9][0-9]*)|0[xX]([0-9A-Fa-f]+)|0([0-7]+)|([1-9][0-9]?)[rR]([0-9A-Za-z]+)|0[0-9]+)(N)?");
+    Pattern.compile( "([-+]?)(?:(0)|([1-9][0-9]*)|0[xX]([0-9A-Fa-f]+)|0([0-7]+)|([1-9][0-9]?)[rR]([0-9A-Za-z]+)|0[0-9]+)(N)?");
   static Pattern ratioPat = Pattern.compile("([-+]?[0-9]+)/([0-9]+)");
   static Pattern floatPat = Pattern.compile("([-+]?[0-9]+(\\.[0-9]*)?([eE][-+]?[0-9]+)?)(M)?");
-//static Pattern accessorPat = Pattern.compile("\\.[a-zA-Z_]\\w*");
-//static Pattern instanceMemberPat = Pattern.compile("\\.([a-zA-Z_][\\w\\.]*)\\.([a-zA-Z_]\\w*)");
-//static Pattern staticMemberPat = Pattern.compile("([a-zA-Z_][\\w\\.]*)\\.([a-zA-Z_]\\w*)");
-//static Pattern classNamePat = Pattern.compile("([a-zA-Z_][\\w\\.]*)\\.");
 
-//symbol->gensymbol
+  //symbol->gensymbol
   static Var GENSYM_ENV = Var.create(null).setDynamic();
-//sorted-map num->gensymbol
+
+  //sorted-map num->gensymbol
   static Var ARG_ENV = Var.create(null).setDynamic();
   static IFn ctorReader = new CtorReader();
 
-// Dynamic var set to true in a read-cond context
+  // Dynamic var set to true in a read-cond context
   static Var READ_COND_ENV = Var.create(null).setDynamic();
 
   static {
     macros['"'] = new StringReader();
     macros[';'] = new CommentReader();
     macros['\''] = new WrappingReader(QUOTE);
-    macros['@'] = new WrappingReader(DEREF);//new DerefReader();
+    macros['@'] = new WrappingReader(DEREF);
     macros['^'] = new MetaReader();
     macros['`'] = new SyntaxQuoteReader();
     macros['~'] = new UnquoteReader();
@@ -98,11 +103,9 @@ public class LispReader {
     macros[']'] = new UnmatchedDelimiterReader();
     macros['{'] = new MapReader();
     macros['}'] = new UnmatchedDelimiterReader();
-//  macros['|'] = new ArgVectorReader();
     macros['\\'] = new CharacterReader();
     macros['%'] = new ArgReader();
     macros['#'] = new DispatchReader();
-
 
     dispatchMacros['^'] = new MetaReader();
     dispatchMacros['\''] = new VarReader();
@@ -148,22 +151,6 @@ public class LispReader {
     }
   }
 
-// Reader opts
-  static public final Keyword OPT_EOF = Keyword.intern(null,"eof");
-  static public final Keyword OPT_FEATURES = Keyword.intern(null,"features");
-  static public final Keyword OPT_READ_COND = Keyword.intern(null, "read-cond");
-
-// EOF special value to throw on eof
-  static public final Keyword EOFTHROW = Keyword.intern(null,"eofthrow");
-
-// Platform features - always installed
-  static private final Keyword PLATFORM_KEY = Keyword.intern(null, "clj");
-  static private final Object PLATFORM_FEATURES = PersistentHashSet.create(PLATFORM_KEY);
-
-// Reader conditional options - use with :read-cond
-  static public final Keyword COND_ALLOW = Keyword.intern(null, "allow");
-  static public final Keyword COND_PRESERVE = Keyword.intern(null, "preserve");
-
   static public Object read(PushbackReader r, Object opts) {
     boolean eofIsError = true;
     Object eofValue = null;
@@ -207,7 +194,7 @@ public class LispReader {
       if (features == null) {
         return mopts.assoc(LispReader.OPT_FEATURES, PLATFORM_FEATURES);
       } else {
-        return mopts.assoc(LispReader.OPT_FEATURES, RT.conj((IPersistentSet) features, PLATFORM_KEY));
+        return mopts.assoc(LispReader.OPT_FEATURES, RT.union((IPersistentSet) features, PLATFORM_FEATURES));
       }
     }
   }
@@ -277,7 +264,6 @@ public class LispReader {
         throw Util.sneakyThrow(e);
       }
       LineNumberingPushbackReader rdr = (LineNumberingPushbackReader) r;
-      //throw Util.runtimeException(String.format("ReaderError:(%d,1) %s", rdr.getLineNumber(), e.getMessage()), e);
       throw new ReaderException(rdr.getLineNumber(), rdr.getColumnNumber(), e);
     }
   }
@@ -374,7 +360,6 @@ public class LispReader {
     throw Util.runtimeException("Invalid token: " + s);
   }
 
-
   private static Object matchSymbol(String s) {
     Matcher m = symbolPat.matcher(s);
     if (m.matches()) {
@@ -410,7 +395,6 @@ public class LispReader {
     }
     return null;
   }
-
 
   private static Object matchNumber(String s) {
     Matcher m = intPat.matcher(s);
@@ -483,8 +467,6 @@ public class LispReader {
   }
 
   public static class RegexReader extends AFn {
-    static StringReader stringrdr = new StringReader();
-
     public Object invoke(Object reader, Object doublequote, Object opts, Object pendingForms) {
       StringBuilder sb = new StringBuilder();
       Reader r = (Reader) reader;
@@ -574,7 +556,6 @@ public class LispReader {
       } while (ch != -1 && ch != '\n' && ch != '\r');
       return r;
     }
-
   }
 
   public static class DiscardReader extends AFn {
@@ -597,7 +578,6 @@ public class LispReader {
       Object o = read(r, true, null, true, opts, ensurePending(pendingForms));
       return RT.list(sym, o);
     }
-
   }
 
   public static class DeprecatedWrappingReader extends AFn {
@@ -617,46 +597,15 @@ public class LispReader {
       Object o = read(r, true, null, true, opts, ensurePending(pendingForms));
       return RT.list(sym, o);
     }
-
   }
 
   public static class VarReader extends AFn {
     public Object invoke(Object reader, Object quote, Object opts, Object pendingForms) {
       PushbackReader r = (PushbackReader) reader;
       Object o = read(r, true, null, true, opts, ensurePending(pendingForms));
-//    if(o instanceof Symbol)
-//      {
-//      Object v = Compiler.maybeResolveIn(Compiler.currentNS(), (Symbol) o);
-//      if(v instanceof Var)
-//        return v;
-//      }
       return RT.list(THE_VAR, o);
     }
   }
-
-  /*
-  static class DerefReader extends AFn{
-
-    public Object invoke(Object reader, Object quote) {
-      PushbackReader r = (PushbackReader) reader;
-      int ch = read1(r);
-      if(ch == -1)
-        throw Util.runtimeException("EOF while reading character");
-      if(ch == '!')
-        {
-        Object o = read(r, true, null, true);
-        return RT.list(DEREF_BANG, o);
-        }
-      else
-        {
-        r.unread(ch);
-        Object o = read(r, true, null, true);
-        return RT.list(DEREF, o);
-        }
-    }
-
-  }
-  */
 
   public static class DispatchReader extends AFn {
     public Object invoke(Object reader, Object hash, Object opts, Object pendingForms) {
@@ -799,7 +748,6 @@ public class LispReader {
         throw new IllegalArgumentException("Metadata can only be applied to IMetas");
       }
     }
-
   }
 
   public static class SyntaxQuoteReader extends AFn {
@@ -846,8 +794,7 @@ public class LispReader {
                            Symbol.intern(null, sym.ns));
           if (maybeClass instanceof Class) {
             // Classname/foo -> package.qualified.Classname/foo
-            sym = Symbol.intern(
-                    ((Class)maybeClass).getName(), sym.name);
+            sym = Symbol.intern(((Class)maybeClass).getName(), sym.name);
           } else {
             sym = Compiler.resolveSymbol(sym);
           }
@@ -915,12 +862,11 @@ public class LispReader {
       IPersistentVector keyvals = PersistentVector.EMPTY;
       for (ISeq s = RT.seq(form); s != null; s = s.next()) {
         IMapEntry e = (IMapEntry) s.first();
-        keyvals = (IPersistentVector) keyvals.cons(e.key());
-        keyvals = (IPersistentVector) keyvals.cons(e.val());
+        keyvals = keyvals.cons(e.key());
+        keyvals = keyvals.cons(e.val());
       }
       return keyvals;
     }
-
   }
 
   static boolean isUnquoteSplicing(Object form) {
@@ -948,7 +894,6 @@ public class LispReader {
         return RT.list(UNQUOTE, o);
       }
     }
-
   }
 
   public static class CharacterReader extends AFn {
@@ -992,7 +937,6 @@ public class LispReader {
       }
       throw Util.runtimeException("Unsupported character: \\" + token);
     }
-
   }
 
   public static class ListReader extends AFn {
@@ -1009,47 +953,13 @@ public class LispReader {
         return PersistentList.EMPTY;
       }
       IObj s = (IObj) PersistentList.create(list);
-//    IObj s = (IObj) RT.seq(list);
       if (line != -1) {
         return s.withMeta(RT.map(RT.LINE_KEY, line, RT.COLUMN_KEY, column));
       } else {
         return s;
       }
     }
-
   }
-
-  /*
-  static class CtorReader extends AFn{
-    static final Symbol cls = Symbol.intern("class");
-
-    public Object invoke(Object reader, Object leftangle) {
-      PushbackReader r = (PushbackReader) reader;
-      // #<class classname>
-      // #<classname args*>
-      // #<classname/staticMethod args*>
-      List list = readDelimitedList('>', r, true);
-      if(list.isEmpty())
-        throw Util.runtimeException("Must supply 'class', classname or classname/staticMethod");
-      Symbol s = (Symbol) list.get(0);
-      Object[] args = list.subList(1, list.size()).toArray();
-      if(s.equals(cls))
-        {
-        return RT.classForName(args[0].toString());
-        }
-      else if(s.ns != null) //static method
-        {
-        String classname = s.ns;
-        String method = s.name;
-        return Reflector.invokeStaticMethod(classname, method, args);
-        }
-      else
-        {
-        return Reflector.invokeConstructor(RT.classForName(s.name), args);
-        }
-    }
-  }
-  */
 
   public static class EvalReader extends AFn {
     public Object invoke(Object reader, Object eq, Object opts, Object pendingForms) {
@@ -1065,7 +975,7 @@ public class LispReader {
         Symbol fs = (Symbol) RT.first(o);
         if (fs.equals(THE_VAR)) {
           Symbol vs = (Symbol) RT.second(o);
-          return RT.var(vs.ns, vs.name);  //Compiler.resolve((Symbol) RT.second(o),true);
+          return RT.var(vs.ns, vs.name);
         }
         if (fs.name.endsWith(".")) {
           Object[] args = RT.toArray(RT.next(o));
@@ -1086,20 +996,11 @@ public class LispReader {
     }
   }
 
-//static class ArgVectorReader extends AFn{
-//  public Object invoke(Object reader, Object leftparen) {
-//    PushbackReader r = (PushbackReader) reader;
-//    return ArgVector.create(readDelimitedList('|', r, true));
-//  }
-//
-//}
-
   public static class VectorReader extends AFn {
     public Object invoke(Object reader, Object leftparen, Object opts, Object pendingForms) {
       PushbackReader r = (PushbackReader) reader;
       return LazilyPersistentVector.create(readDelimitedList(']', r, true, opts, ensurePending(pendingForms)));
     }
-
   }
 
   public static class MapReader extends AFn {
@@ -1111,7 +1012,6 @@ public class LispReader {
       }
       return RT.map(a);
     }
-
   }
 
   public static class SetReader extends AFn {
@@ -1119,7 +1019,6 @@ public class LispReader {
       PushbackReader r = (PushbackReader) reader;
       return PersistentHashSet.createWithCheck(readDelimitedList('}', r, true, opts, ensurePending(pendingForms)));
     }
-
   }
 
   public static class UnmatchedDelimiterReader extends AFn {
@@ -1135,7 +1034,7 @@ public class LispReader {
     }
   }
 
-// Sentinel values for reading lists
+  // Sentinel values for reading lists
   private static final Object READ_EOF = new Object();
   private static final Object READ_FINISHED = new Object();
 
@@ -1177,16 +1076,17 @@ public class LispReader {
 
       if (isPreserveReadCond(opts) || RT.suppressRead()) {
         return TaggedLiteral.create(sym, form);
+      } else if (sym.getName().contains(".")) {
+        return readRecord(form, sym, opts, pendingForms);
       } else {
-        return sym.getName().contains(".") ? readRecord(form, sym, opts, pendingForms) : readTagged(form, sym, opts, pendingForms);
+        return readTagged(form, sym, opts, pendingForms);
       }
-
     }
 
     private Object readTagged(Object o, Symbol tag, Object opts, Object pendingForms) {
+      ILookup data_readers = (ILookup) RT.DATA_READERS.deref();
+      IFn data_reader = (IFn) RT.get(data_readers, tag);
 
-      ILookup data_readers = (ILookup)RT.DATA_READERS.deref();
-      IFn data_reader = (IFn)RT.get(data_readers, tag);
       if (data_reader == null) {
         data_readers = (ILookup)RT.DEFAULT_DATA_READERS.deref();
         data_reader = (IFn)RT.get(data_readers, tag);
@@ -1211,8 +1111,6 @@ public class LispReader {
       }
 
       Class recordClass = RT.classForNameNonLoading(recordName.toString());
-
-
       boolean shortForm = true;
 
       if (form instanceof IPersistentMap) {
@@ -1224,7 +1122,7 @@ public class LispReader {
       }
 
       Object ret = null;
-      Constructor[] allctors = ((Class)recordClass).getConstructors();
+      Constructor[] allctors = recordClass.getConstructors();
 
       if (shortForm) {
         IPersistentVector recordEntries = (IPersistentVector)form;
@@ -1264,11 +1162,7 @@ public class LispReader {
   }
 
   public static class ConditionalReader extends AFn {
-
     final static private Object READ_STARTED = new Object();
-    final static public Keyword DEFAULT_FEATURE = Keyword.intern(null, "default");
-    final static public IPersistentSet RESERVED_FEATURES =
-      RT.set(Keyword.intern(null, "else"), Keyword.intern(null, "none"));
 
     public static boolean hasFeature(Object feature, Object opts) {
       if (! (feature instanceof Keyword)) {
@@ -1313,8 +1207,8 @@ public class LispReader {
           }
 
           if (hasFeature(form, opts)) {
-
-            //Read the form corresponding to the feature, and assign it to result if everything is kosher
+            // Read the form corresponding to the feature, and assign it to result if everything is
+            // kosher
 
             form = read(r, false, READ_EOF, ')', READ_FINISHED, true, opts, pendingForms);
 
@@ -1336,7 +1230,8 @@ public class LispReader {
           }
         }
 
-        // When we already have a result, or when the feature didn't match, discard the next form in the reader
+        // When we already have a result, or when the feature didn't match, discard the next form in
+        // the reader
         try {
           Var.pushThreadBindings(RT.map(RT.SUPPRESS_READ, RT.T));
           form = read(r, false, READ_EOF, ')', READ_FINISHED, true, opts, pendingForms);
@@ -1375,12 +1270,13 @@ public class LispReader {
       } else {
         return result;
       }
-    };
+    }
 
     private static void checkConditionalAllowed(Object opts) {
       IPersistentMap mopts = (IPersistentMap)opts;
-      if (! (opts != null && (COND_ALLOW.equals(mopts.valAt(OPT_READ_COND)) ||
-                              COND_PRESERVE.equals(mopts.valAt(OPT_READ_COND))))) {
+      if (! (opts != null
+             && (COND_ALLOW.equals(mopts.valAt(OPT_READ_COND)) ||
+                 COND_PRESERVE.equals(mopts.valAt(OPT_READ_COND))))) {
         throw Util.runtimeException("Conditional read not allowed");
       }
     }
@@ -1429,37 +1325,4 @@ public class LispReader {
       }
     }
   }
-
-  /*
-  public static void main(String[] args) throws Exception{
-    //RT.init();
-    PushbackReader rdr = new PushbackReader( new java.io.StringReader( "(+ 21 21)" ) );
-    Object input = LispReader.read(rdr, false, new Object(), false );
-    System.out.println(Compiler.eval(input));
-  }
-
-  public static void main(String[] args){
-    LineNumberingPushbackReader r = new LineNumberingPushbackReader(new InputStreamReader(System.in));
-    OutputStreamWriter w = new OutputStreamWriter(System.out);
-    Object ret = null;
-    try
-      {
-      for(; ;)
-        {
-        ret = LispReader.read(r, true, null, false);
-        RT.print(ret, w);
-        w.write('\n');
-        if(ret != null)
-          w.write(ret.getClass().toString());
-        w.write('\n');
-        w.flush();
-        }
-      }
-    catch(Exception e)
-      {
-      e.printStackTrace();
-      }
-  }
-   */
-
 }

--- a/src/jvm/clojure/lang/PersistentHashSet.java
+++ b/src/jvm/clojure/lang/PersistentHashSet.java
@@ -123,5 +123,4 @@ public class PersistentHashSet extends APersistentSet implements IObj, IEditable
       return new PersistentHashSet(null, impl.persistent());
     }
   }
-
 }

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -696,6 +696,13 @@ public class RT {
     return coll.cons(x);
   }
 
+  static public IPersistentSet union(IPersistentSet a, Seqable b) {
+    for (Object o : b) {
+      a = (IPersistentSet) a.cons(o);
+    }
+    return a;
+  }
+
   static public ISeq cons(Object x, Object coll) {
     if (coll == null) {
       return new PersistentList(x);

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -35,22 +35,21 @@ public class RT {
   static final public Boolean F = Boolean.FALSE;
   static final public String LOADER_SUFFIX = "__init";
 
-//simple-symbol->class
+  final static Keyword TAG_KEY = Keyword.intern(null, "tag");
+  final static Keyword CONST_KEY = Keyword.intern(null, "const");
+  final static Keyword LINE_KEY = Keyword.intern(null, "line");
+  final static Keyword COLUMN_KEY = Keyword.intern(null, "column");
+  final static Keyword FILE_KEY = Keyword.intern(null, "file");
+  final static Keyword DECLARED_KEY = Keyword.intern(null, "declared");
+  final static Keyword DOC_KEY = Keyword.intern(null, "doc");
+
+  final static Symbol LOAD_FILE = Symbol.intern("load-file");
+  final static Symbol IN_NAMESPACE = Symbol.intern("in-ns");
+  final static Symbol NAMESPACE = Symbol.intern("ns");
+  final static Symbol IDENTICAL = Symbol.intern("identical?");
+
+  //simple-symbol->class
   final static IPersistentMap DEFAULT_IMPORTS = map(
-//                          Symbol.intern("RT"), "clojure.lang.RT",
-//                                                  Symbol.intern("Num"), "clojure.lang.Num",
-//                                                  Symbol.intern("Symbol"), "clojure.lang.Symbol",
-//                                                  Symbol.intern("Keyword"), "clojure.lang.Keyword",
-//                                                  Symbol.intern("Var"), "clojure.lang.Var",
-//                                                  Symbol.intern("Ref"), "clojure.lang.Ref",
-//                                                  Symbol.intern("IFn"), "clojure.lang.IFn",
-//                                                  Symbol.intern("IObj"), "clojure.lang.IObj",
-//                                                  Symbol.intern("ISeq"), "clojure.lang.ISeq",
-//                                                  Symbol.intern("IPersistentCollection"),
-//                                                  "clojure.lang.IPersistentCollection",
-//                                                  Symbol.intern("IPersistentMap"), "clojure.lang.IPersistentMap",
-//                                                  Symbol.intern("IPersistentList"), "clojure.lang.IPersistentList",
-//                                                  Symbol.intern("IPersistentVector"), "clojure.lang.IPersistentVector",
         Symbol.intern("Boolean"), Boolean.class,
         Symbol.intern("Byte"), Byte.class,
         Symbol.intern("Character"), Character.class,
@@ -147,26 +146,9 @@ public class RT {
         Symbol.intern("Deprecated"), Deprecated.class,
         Symbol.intern("Override"), Override.class,
         Symbol.intern("SuppressWarnings"), SuppressWarnings.class
-
-//                                                  Symbol.intern("Collection"), "java.util.Collection",
-//                                                  Symbol.intern("Comparator"), "java.util.Comparator",
-//                                                  Symbol.intern("Enumeration"), "java.util.Enumeration",
-//                                                  Symbol.intern("EventListener"), "java.util.EventListener",
-//                                                  Symbol.intern("Formattable"), "java.util.Formattable",
-//                                                  Symbol.intern("Iterator"), "java.util.Iterator",
-//                                                  Symbol.intern("List"), "java.util.List",
-//                                                  Symbol.intern("ListIterator"), "java.util.ListIterator",
-//                                                  Symbol.intern("Map"), "java.util.Map",
-//                                                  Symbol.intern("Map$Entry"), "java.util.Map$Entry",
-//                                                  Symbol.intern("Observer"), "java.util.Observer",
-//                                                  Symbol.intern("Queue"), "java.util.Queue",
-//                                                  Symbol.intern("RandomAccess"), "java.util.RandomAccess",
-//                                                  Symbol.intern("Set"), "java.util.Set",
-//                                                  Symbol.intern("SortedMap"), "java.util.SortedMap",
-//                                                  Symbol.intern("SortedSet"), "java.util.SortedSet"
       );
 
-// single instance of UTF-8 Charset, so as to avoid catching UnsupportedCharsetExceptions everywhere
+  // single instance of UTF-8 Charset, so as to avoid catching UnsupportedCharsetExceptions everywhere
   static public Charset UTF8 = Charset.forName("UTF-8");
 
   static Object readTrueFalseUnknown(String s) {
@@ -178,66 +160,104 @@ public class RT {
     return Keyword.intern(null, "unknown");
   }
 
-  static public final Namespace CLOJURE_NS = Namespace.findOrCreate(Symbol.intern("clojure.core"));
-//static final Namespace USER_NS = Namespace.findOrCreate(Symbol.intern("user"));
+  static public final Namespace CLOJURE_NS =
+    Namespace.findOrCreate(Symbol.intern("clojure.core"));
+
   final static public Var OUT =
     Var.intern(CLOJURE_NS, Symbol.intern("*out*"), new OutputStreamWriter(System.out)).setDynamic();
+
   final static public Var IN =
     Var.intern(CLOJURE_NS, Symbol.intern("*in*"),
                new LineNumberingPushbackReader(new InputStreamReader(System.in))).setDynamic();
+
   final static public Var ERR =
     Var.intern(CLOJURE_NS, Symbol.intern("*err*"),
                new PrintWriter(new OutputStreamWriter(System.err), true)).setDynamic();
-  final static Keyword TAG_KEY = Keyword.intern(null, "tag");
-  final static Keyword CONST_KEY = Keyword.intern(null, "const");
-  final static public Var AGENT = Var.intern(CLOJURE_NS, Symbol.intern("*agent*"), null).setDynamic();
-  static Object readeval = readTrueFalseUnknown(System.getProperty("clojure.read.eval","true"));
-  final static public Var READEVAL = Var.intern(CLOJURE_NS, Symbol.intern("*read-eval*"),  readeval).setDynamic();
-  final static public Var DATA_READERS = Var.intern(CLOJURE_NS, Symbol.intern("*data-readers*"), RT.map()).setDynamic();
-  final static public Var DEFAULT_DATA_READER_FN = Var.intern(CLOJURE_NS, Symbol.intern("*default-data-reader-fn*"), RT.map()).setDynamic();
-  final static public Var DEFAULT_DATA_READERS = Var.intern(CLOJURE_NS, Symbol.intern("default-data-readers"), RT.map());
-  final static public Var SUPPRESS_READ = Var.intern(CLOJURE_NS, Symbol.intern("*suppress-read*"), null).setDynamic();
-  final static public Var ASSERT = Var.intern(CLOJURE_NS, Symbol.intern("*assert*"), T).setDynamic();
-  final static public Var MATH_CONTEXT = Var.intern(CLOJURE_NS, Symbol.intern("*math-context*"), null).setDynamic();
-  static Keyword LINE_KEY = Keyword.intern(null, "line");
-  static Keyword COLUMN_KEY = Keyword.intern(null, "column");
-  static Keyword FILE_KEY = Keyword.intern(null, "file");
-  static Keyword DECLARED_KEY = Keyword.intern(null, "declared");
-  static Keyword DOC_KEY = Keyword.intern(null, "doc");
+
+  final static public Var AGENT =
+    Var.intern(CLOJURE_NS, Symbol.intern("*agent*"),
+               null).setDynamic();
+
+  final static public Var READEVAL =
+    Var.intern(CLOJURE_NS, Symbol.intern("*read-eval*"),
+               readTrueFalseUnknown(System.getProperty("clojure.read.eval","true"))).setDynamic();
+
+  final static public Var DATA_READERS =
+    Var.intern(CLOJURE_NS, Symbol.intern("*data-readers*"),
+               map()).setDynamic();
+
+  final static public Var DEFAULT_DATA_READER_FN =
+    Var.intern(CLOJURE_NS, Symbol.intern("*default-data-reader-fn*"),
+               map()).setDynamic();
+
+  final static public Var DEFAULT_DATA_READERS =
+    Var.intern(CLOJURE_NS, Symbol.intern("default-data-readers"),
+               map());
+
+  final static public Var SUPPRESS_READ =
+    Var.intern(CLOJURE_NS, Symbol.intern("*suppress-read*"),
+               null).setDynamic();
+
+  final static public Var ASSERT =
+    Var.intern(CLOJURE_NS, Symbol.intern("*assert*"),
+               T).setDynamic();
+
+  final static public Var MATH_CONTEXT =
+    Var.intern(CLOJURE_NS, Symbol.intern("*math-context*"),
+               null).setDynamic();
+
   final static public Var USE_CONTEXT_CLASSLOADER =
-    Var.intern(CLOJURE_NS, Symbol.intern("*use-context-classloader*"), T).setDynamic();
-//boolean
-  static final public Var UNCHECKED_MATH = Var.intern(Namespace.findOrCreate(Symbol.intern("clojure.core")),
-      Symbol.intern("*unchecked-math*"), Boolean.FALSE).setDynamic();
+    Var.intern(CLOJURE_NS, Symbol.intern("*use-context-classloader*"),
+               T).setDynamic();
 
-//final static public Var CURRENT_MODULE = Var.intern(Symbol.intern("clojure.core", "current-module"),
-//                                                    Module.findOrCreateModule("clojure/user"));
+  static final public Var UNCHECKED_MATH =
+    Var.intern(CLOJURE_NS, Symbol.intern("*unchecked-math*"),
+               F).setDynamic();
 
-  final static Symbol LOAD_FILE = Symbol.intern("load-file");
-  final static Symbol IN_NAMESPACE = Symbol.intern("in-ns");
-  final static Symbol NAMESPACE = Symbol.intern("ns");
-  static final Symbol IDENTICAL = Symbol.intern("identical?");
-  final static Var CMD_LINE_ARGS = Var.intern(CLOJURE_NS, Symbol.intern("*command-line-args*"), null).setDynamic();
-//symbol
-  final public static Var CURRENT_NS = Var.intern(CLOJURE_NS, Symbol.intern("*ns*"),
-                                       CLOJURE_NS).setDynamic();
+  final static Var CMD_LINE_ARGS =
+    Var.intern(CLOJURE_NS, Symbol.intern("*command-line-args*"),
+               null).setDynamic();
 
-  final static Var FLUSH_ON_NEWLINE = Var.intern(CLOJURE_NS, Symbol.intern("*flush-on-newline*"), T).setDynamic();
-  final static Var PRINT_META = Var.intern(CLOJURE_NS, Symbol.intern("*print-meta*"), F).setDynamic();
-  final static Var PRINT_READABLY = Var.intern(CLOJURE_NS, Symbol.intern("*print-readably*"), T).setDynamic();
-  final static Var PRINT_DUP = Var.intern(CLOJURE_NS, Symbol.intern("*print-dup*"), F).setDynamic();
-  final static Var WARN_ON_REFLECTION = Var.intern(CLOJURE_NS, Symbol.intern("*warn-on-reflection*"), F).setDynamic();
-  final static Var ALLOW_UNRESOLVED_VARS = Var.intern(CLOJURE_NS, Symbol.intern("*allow-unresolved-vars*"), F).setDynamic();
+  final public static Var CURRENT_NS =
+    Var.intern(CLOJURE_NS, Symbol.intern("*ns*"),
+               CLOJURE_NS).setDynamic();
 
-  final static Var IN_NS_VAR = Var.intern(CLOJURE_NS, Symbol.intern("in-ns"), F);
-  final static Var NS_VAR = Var.intern(CLOJURE_NS, Symbol.intern("ns"), F);
-  final static Var FN_LOADER_VAR = Var.intern(CLOJURE_NS, Symbol.intern("*fn-loader*"), null).setDynamic();
+  final static Var FLUSH_ON_NEWLINE =
+    Var.intern(CLOJURE_NS, Symbol.intern("*flush-on-newline*"),
+               T).setDynamic();
+
+  final static Var PRINT_META =
+    Var.intern(CLOJURE_NS, Symbol.intern("*print-meta*"),
+               F).setDynamic();
+
+  final static Var PRINT_READABLY =
+    Var.intern(CLOJURE_NS, Symbol.intern("*print-readably*"),
+               T).setDynamic();
+
+  final static Var PRINT_DUP =
+    Var.intern(CLOJURE_NS, Symbol.intern("*print-dup*"),
+               F).setDynamic();
+
+  final static Var WARN_ON_REFLECTION =
+    Var.intern(CLOJURE_NS, Symbol.intern("*warn-on-reflection*"),
+               F).setDynamic();
+
+  final static Var ALLOW_UNRESOLVED_VARS =
+    Var.intern(CLOJURE_NS, Symbol.intern("*allow-unresolved-vars*"),
+               F).setDynamic();
+
+  final static Var FN_LOADER_VAR =
+    Var.intern(CLOJURE_NS, Symbol.intern("*fn-loader*"),
+               null).setDynamic();
+
   static final Var PRINT_INITIALIZED =
     Var.intern(CLOJURE_NS,
                Symbol.intern("print-initialized"),
                F).setPublic(false).setDynamic();
-  static final Var PR_ON = Var.intern(CLOJURE_NS, Symbol.intern("pr-on"));
-//final static Var IMPORTS = Var.intern(CLOJURE_NS, Symbol.intern("*imports*"), DEFAULT_IMPORTS);
+
+  static final Var PR_ON =
+    Var.intern(CLOJURE_NS, Symbol.intern("pr-on"));
+
   final static IFn inNamespace = new AFn() {
     public Object invoke(Object arg1) {
       Symbol nsname = (Symbol) arg1;
@@ -246,6 +266,10 @@ public class RT {
       return ns;
     }
   };
+
+  final static Var IN_NS_VAR =
+    Var.intern(CLOJURE_NS, Symbol.intern("in-ns"),
+               inNamespace);
 
   final static IFn bootNamespace = new AFn() {
     public Object invoke(Object __form, Object __env, Object arg1) {
@@ -256,17 +280,21 @@ public class RT {
     }
   };
 
+  final static Var NS_VAR =
+    Var.intern(CLOJURE_NS, Symbol.intern("ns"),
+               bootNamespace).setMacro();
+
   public static List<String> processCommandLine(String[] args) {
     List<String> arglist = Arrays.asList(args);
     int split = arglist.indexOf("--");
     if (split >= 0) {
-      CMD_LINE_ARGS.bindRoot(RT.seq(arglist.subList(split + 1, args.length)));
+      CMD_LINE_ARGS.bindRoot(seq(arglist.subList(split + 1, args.length)));
       return arglist.subList(0, split);
     }
     return arglist;
   }
 
-// duck typing stderr plays nice with e.g. swank
+  // duck typing stderr plays nice with e.g. swank
   public static PrintWriter errPrintWriter() {
     Writer w = (Writer) ERR.deref();
     if (w instanceof PrintWriter) {
@@ -316,10 +344,8 @@ public class RT {
     OUT.setTag(Symbol.intern("java.io.Writer"));
     CURRENT_NS.setTag(Symbol.intern("clojure.lang.Namespace"));
     MATH_CONTEXT.setTag(Symbol.intern("java.math.MathContext"));
-    Var nv = Var.intern(CLOJURE_NS, NAMESPACE, bootNamespace);
-    nv.setMacro();
-    Var v;
-    v = Var.intern(CLOJURE_NS, IN_NAMESPACE, inNamespace);
+
+    Var v = Var.intern(CLOJURE_NS, IN_NAMESPACE, inNamespace);
     v.setMeta(map(DOC_KEY, "Sets *ns* to the namespace named by the symbol, creating it if needed.",
                   arglistskw, list(vector(namesym))));
     v = Var.intern(CLOJURE_NS, LOAD_FILE,
@@ -385,7 +411,7 @@ public class RT {
   }
 
   static public void init() {
-    RT.errPrintWriter().println("No need to call RT.init() anymore");
+    errPrintWriter().println("No need to call RT.init() anymore");
   }
 
   static public long lastModified(URL url, String libfile) throws IOException {
@@ -441,9 +467,9 @@ public class RT {
         || classURL == null) {
       try {
         Var.pushThreadBindings(
-          RT.mapUniqueKeys(CURRENT_NS, CURRENT_NS.deref(),
-                           WARN_ON_REFLECTION, WARN_ON_REFLECTION.deref()
-                           ,RT.UNCHECKED_MATH, RT.UNCHECKED_MATH.deref()));
+          mapUniqueKeys(CURRENT_NS,           CURRENT_NS.deref()
+                        , WARN_ON_REFLECTION, WARN_ON_REFLECTION.deref()
+                        , UNCHECKED_MATH,     UNCHECKED_MATH.deref()));
         loaded = (loadClassForName(scriptbase.replace('/', '.') + LOADER_SUFFIX) != null);
       } finally {
         Var.popThreadBindings();
@@ -671,7 +697,6 @@ public class RT {
   }
 
   static public ISeq cons(Object x, Object coll) {
-    //ISeq y = seq(coll);
     if (coll == null) {
       return new PersistentList(x);
     } else if (coll instanceof ISeq) {
@@ -909,7 +934,7 @@ public class RT {
     }
 
     else if (coll instanceof Sequential) {
-      ISeq seq = RT.seq(coll);
+      ISeq seq = seq(coll);
       coll = null;
       for (int i = 0; i <= n && seq != null; ++i, seq = seq.next()) {
         if (i == n) {
@@ -969,7 +994,7 @@ public class RT {
       }
       return notFound;
     } else if (coll instanceof Sequential) {
-      ISeq seq = RT.seq(coll);
+      ISeq seq = seq(coll);
       coll = null;
       for (int i = 0; i <= n && seq != null; ++i, seq = seq.next()) {
         if (i == n) {
@@ -998,7 +1023,7 @@ public class RT {
   }
 
   static boolean hasTag(Object o, Object tag) {
-    return Util.equals(tag, RT.get(RT.meta(o), TAG_KEY));
+    return Util.equals(tag, get(meta(o), TAG_KEY));
   }
 
   /**
@@ -1706,8 +1731,8 @@ public class RT {
     if (sizeOrSeq instanceof Number) {
       return new Object[((Number) sizeOrSeq).intValue()];
     } else {
-      ISeq s = RT.seq(sizeOrSeq);
-      int size = RT.count(s);
+      ISeq s = seq(sizeOrSeq);
+      int size = count(s);
       Object[] ret = new Object[size];
       for (int i = 0; i < size && s != null; i++, s = s.next()) {
         ret[i] = s.first();
@@ -1913,15 +1938,13 @@ public class RT {
 
   static public void print(Object x, Writer w) throws IOException {
     //call multimethod
-    if (PRINT_INITIALIZED.isBound() && RT.booleanCast(PRINT_INITIALIZED.deref())) {
+    if (PRINT_INITIALIZED.isBound() && booleanCast(PRINT_INITIALIZED.deref())) {
       PR_ON.invoke(x, w);
-    }
-//*
-    else {
+    } else {
       boolean readably = booleanCast(PRINT_READABLY.deref());
       if (x instanceof Obj) {
         Obj o = (Obj) x;
-        if (RT.count(o.meta()) > 0 &&
+        if (count(o.meta()) > 0 &&
             ((readably && booleanCast(PRINT_META.deref()))
              || booleanCast(PRINT_DUP.deref()))) {
           IPersistentMap meta = o.meta();
@@ -2146,15 +2169,15 @@ public class RT {
           if (args == null) {
             throw new IllegalArgumentException("Missing argument");
           }
-          RT.formatAesthetic(w, RT.first(args));
-          args = RT.next(args);
+          formatAesthetic(w, first(args));
+          args = next(args);
           break;
         case 's':
           if (args == null) {
             throw new IllegalArgumentException("Missing argument");
           }
-          RT.formatStandard(w, RT.first(args));
-          args = RT.next(args);
+          formatStandard(w, first(args));
+          args = next(args);
           break;
         case '{':
           int j = s.indexOf("~}", i);    //note - does not nest
@@ -2162,10 +2185,10 @@ public class RT {
             throw new IllegalArgumentException("Missing ~}");
           }
           String subs = s.substring(i, j);
-          for (ISeq sargs = RT.seq(RT.first(args)); sargs != null;) {
+          for (ISeq sargs = seq(first(args)); sargs != null;) {
             sargs = doFormat(w, subs, sargs);
           }
-          args = RT.next(args);
+          args = next(args);
           i = j + 2; //skip ~}
           break;
         case '^':
@@ -2201,8 +2224,7 @@ public class RT {
     return (ClassLoader) AccessController.doPrivileged(new PrivilegedAction() {
       public Object run() {
         try {
-          Var.pushThreadBindings(RT.map(USE_CONTEXT_CLASSLOADER, RT.T));
-//      getRootClassLoader();
+          Var.pushThreadBindings(map(USE_CONTEXT_CLASSLOADER, T));
           return new DynamicClassLoader(baseLoader());
         } finally {
           Var.popThreadBindings();

--- a/src/jvm/clojure/lang/Seqable.java
+++ b/src/jvm/clojure/lang/Seqable.java
@@ -12,6 +12,12 @@
 
 package clojure.lang;
 
-public interface Seqable {
+import java.util.Iterator;
+
+public interface Seqable extends Iterable {
   ISeq seq();
+
+default Iterator iterator() {
+    return new SeqIterator(seq());
+  }
 }

--- a/src/jvm/clojure/lang/TaggedLiteral.java
+++ b/src/jvm/clojure/lang/TaggedLiteral.java
@@ -68,5 +68,4 @@ public class TaggedLiteral implements ILookup {
     result = 31 * result + Util.hash(form);
     return result;
   }
-
 }

--- a/test/clojure/test_clojure/reader.cljc
+++ b/test/clojure/test_clojure/reader.cljc
@@ -38,8 +38,7 @@
   (is (= 'abc.def/ghi (symbol "abc.def" "ghi")))
   (is (= 'abc/def.ghi (symbol "abc" "def.ghi")))
   (is (= 'abc:def/ghi:jkl.mno (symbol "abc:def" "ghi:jkl.mno")))
-  (is (instance? clojure.lang.Symbol 'alphabet))
-  )
+  (is (instance? clojure.lang.Symbol 'alphabet)))
 
 ;; Literals
 
@@ -47,7 +46,7 @@
   ; 'nil 'false 'true are reserved by Clojure and are not symbols
   (is (= 'nil nil))
   (is (= 'false false))
-  (is (= 'true true)) )
+  (is (= 'true true)))
 
 ;; Strings
 
@@ -663,16 +662,22 @@
            (read-string {:read-cond :allow :features #{:foo :bar}} "[#?(:foo foo-form :bar bar-form)]")))
     (is (= '[]
            (read-string {:read-cond :allow :features #{:baz}} "[#?( :foo foo-form :bar bar-form)]"))))
+
   (testing "environmental features"
+    (is (= "jaunt" #?(:jnt "jaunt" :clj "clojure" :cljs "clojurescript" :default "default")))
+    (is (= "first-wins" #?(:clj "first-wins" :jnt "jaunt" :cljs "clojurescript" :default "default")))
     (is (= "clojure" #?(:clj "clojure" :cljs "clojurescript" :default "default"))))
+
   (testing "default features"
     (is (= "default" #?(:clj-clr "clr" :cljs "cljs" :default "default"))))
+
   (testing "splicing"
     (is (= [] [#?@(:clj [])]))
     (is (= [:a] [#?@(:clj [:a])]))
     (is (= [:a :b] [#?@(:clj [:a :b])]))
     (is (= [:a :b :c] [#?@(:clj [:a :b :c])]))
     (is (= [:a :b :c] [#?@(:clj [:a :b :c])])))
+
   (testing "nested splicing"
     (is (= [:a :b :c :d :e]
            [#?@(:clj [:a #?@(:clj [:b #?@(:clj [:c]) :d]):e])]))
@@ -682,9 +687,11 @@
            '(+ #?@(:clj [(+ #?@(:clj [2 3])) 1]))))
     (is (= [:a [:b [:c] :d] :e]
            [#?@(:clj [:a [#?@(:clj [:b #?@(:clj [[:c]]) :d])] :e])])))
+
   (testing "bypass unknown tagged literals"
     (is (= [1 2 3] #?(:cljs #js [1 2 3] :clj [1 2 3])))
     (is (= :clojure #?(:foo #some.nonexistent.Record {:x 1} :clj :clojure))))
+
   (testing "error cases"
     (is (thrown-with-msg? RuntimeException #"Feature should be a keyword" (read-string {:read-cond :allow} "#?((+ 1 2) :a)")))
     (is (thrown-with-msg? RuntimeException #"even number of forms" (read-string {:read-cond :allow} "#?(:cljs :a :clj)")))
@@ -696,6 +703,7 @@
     (is (thrown-with-msg? RuntimeException #"Reader conditional splicing not allowed at the top level" (read-string {:read-cond :allow} "#?@(:clj [1 2])")))
     (is (thrown-with-msg? RuntimeException #"Reader conditional splicing not allowed at the top level" (read-string {:read-cond :allow} "#?@(:clj [1])")))
     (is (thrown-with-msg? RuntimeException #"Reader conditional splicing not allowed at the top level" (read-string {:read-cond :allow} "#?@(:clj []) 1"))))
+
   (testing "clj-1698-regression"
     (let [opts {:features #{:clj} :read-cond :allow}]
       (is (= 1 (read-string opts "#?(:cljs {'a 1 'b 2} :clj 1)")))
@@ -703,6 +711,7 @@
       (is (= '(def m {}) (read-string opts "(def m #?(:cljs ^{:a :b} {} :clj  ^{:a :b} {}))")))
       (is (= '(def m {}) (read-string opts "(def m #?(:cljs ^{:a :b} {} :clj ^{:a :b} {}))")))
       (is (= 1 (read-string opts "#?(:cljs {:a #_:b :c} :clj 1)")))))
+
   (testing "nil expressions"
     (is (nil? #?(:default nil)))
     (is (nil? #?(:foo :bar :clj nil)))


### PR DESCRIPTION
This changeset has one primary change: supporting the `:jnt` conditional clause in addition to `:clj`.

``` clojure
#?(:cljs "nope" :jnt "w00t" :clj "nope")
;; => "w00t"

#?(:cljs "nope" :clj "still works")
;; => "still works"
```

Incidental changes to this end include:
- Upgrading to Java 1.8
- Providing an interface default implementation of `clojure.lang.Seqable/iterator` (Java 1.8 feature)
- Adding `clojure.lang.RT/union [set, coll] -> set` (used in the reader changes)

Fixes #68 
