### PR TITLE
Add RT.load support for .jnt files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Upcoming
+- [#131](https://github.com/jaunt-lang/jaunt/pull/131) Add support for `.jnt` files (@arrdem).
+  - `load-file` now chooses the first file of `.class`, `.jnt`, `.clj`, `.cljc`.
 - [#129](https://github.com/jaunt-lang/jaunt/pull/129) Emit `^:uses` metadata on `Fn` instances (@arrdem).
 - [#126](https://github.com/jaunt-lang/jaunt/pull/126) Add reader support for `Infinity`, `NaN` (@arrdem).
 - [#123](https://github.com/jaunt-lang/jaunt/pull/123) Add support for `:jnt` in reader conditionals (@arrdem).

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -442,14 +442,19 @@ public class RT {
 
   static public void load(String scriptbase, boolean failIfNotFound) throws IOException, ClassNotFoundException {
     String classfile = scriptbase + LOADER_SUFFIX + ".class";
-    String cljfile = scriptbase + ".clj";
-    String scriptfile = cljfile;
-    URL classURL = getResource(baseLoader(),classfile);
+    URL classURL = getResource(baseLoader(), classfile);
+
+    String scriptfile = scriptbase + ".jnt";
     URL cljURL = getResource(baseLoader(), scriptfile);
+    if (cljURL == null) {
+      scriptfile = scriptbase + ".clj";
+      cljURL = getResource(baseLoader(), scriptfile);
+    }
     if (cljURL == null) {
       scriptfile = scriptbase + ".cljc";
       cljURL = getResource(baseLoader(), scriptfile);
     }
+
     boolean loaded = false;
 
     if ((classURL != null &&
@@ -473,7 +478,7 @@ public class RT {
         loadResourceScript(RT.class, scriptfile);
       }
     } else if (!loaded && failIfNotFound)
-      throw new FileNotFoundException(String.format("Could not locate %s or %s on classpath.%s", classfile, cljfile,
+      throw new FileNotFoundException(String.format("Could not locate %s.{class,jnt,clj,cljc} on classpath.%s", scriptbase,
                                       scriptbase.contains("_") ? " Please check that namespaces with dashes use underscores in the Clojure file name." : ""));
   }
 

--- a/test/clojure/test_clojure/compilation.clj
+++ b/test/clojure/test_clojure/compilation.clj
@@ -8,7 +8,6 @@
 
 ;; Author: Frantisek Sodomka
 
-
 (ns clojure.test-clojure.compilation
   (:import (clojure.lang Compiler Compiler$CompilerException))
   (:require [clojure.test.generative :refer (defspec)]
@@ -21,7 +20,6 @@
 
 ;; compile
 ;; gen-class, gen-interface
-
 
 (deftest test-compiler-metadata
   (let [m (meta #'when)]

--- a/test/clojure/test_clojure/compilation.clj
+++ b/test/clojure/test_clojure/compilation.clj
@@ -389,3 +389,8 @@
       ;; eventually call `load` and reset called?.
       (require 'clojure.repl :reload))
     (is @called?)))
+
+(deftest load-preference
+  (is (= :jnt (do (load "clojure/test_clojure/compilation/jnt_first") *1)))
+  (is (= :clj (do (load "clojure/test_clojure/compilation/clj_over_cljc") *1)))
+  (is (= :cljc (do (load "clojure/test_clojure/compilation/just_cljc") *1))))

--- a/test/clojure/test_clojure/compilation/clj_over_cljc.clj
+++ b/test/clojure/test_clojure/compilation/clj_over_cljc.clj
@@ -1,0 +1,4 @@
+(ns clojure.test-clojure.compilation.clj-over-cljc)
+
+(set! *1 :clj)
+

--- a/test/clojure/test_clojure/compilation/clj_over_cljc.cljc
+++ b/test/clojure/test_clojure/compilation/clj_over_cljc.cljc
@@ -1,0 +1,4 @@
+(ns clojure.test-clojure.compilation.clj-over-cljc)
+
+(set! *1 :cljc)
+

--- a/test/clojure/test_clojure/compilation/jnt_first.clj
+++ b/test/clojure/test_clojure/compilation/jnt_first.clj
@@ -1,0 +1,3 @@
+(ns clojure.test-clojure.compilation.jnt-first)
+
+(set! *1 :clj)

--- a/test/clojure/test_clojure/compilation/jnt_first.jnt
+++ b/test/clojure/test_clojure/compilation/jnt_first.jnt
@@ -1,0 +1,3 @@
+(ns clojure.test-clojure.compilation.jnt-first)
+
+(set! *1 :jnt)

--- a/test/clojure/test_clojure/compilation/just_cljc.cljc
+++ b/test/clojure/test_clojure/compilation/just_cljc.cljc
@@ -1,0 +1,4 @@
+(ns clojure.test-clojure.compilation.just-cljc)
+
+(set! *1 :cljc)
+

--- a/test/clojure/test_clojure/evaluation.clj
+++ b/test/clojure/test_clojure/evaluation.clj
@@ -6,7 +6,6 @@
 ;;    the terms of this license.
 ;;    You must not remove this notice, or any other, from this software.
 
-
 ;;  Tests for the Clojure functions documented at the URL:
 ;;
 ;;    http://clojure.org/Evaluation
@@ -15,10 +14,9 @@
 ;;  Created 22 October 2008
 
 (ns clojure.test-clojure.evaluation
-  (:require [clojure.test :refer :all]))
-
-(import '(java.lang Boolean)
-        '(clojure.lang Compiler Compiler$CompilerException))
+  (:require [clojure.test :refer :all])
+  (:import java.lang.Boolean
+           [clojure.lang Compiler Compiler$CompilerException]))
 
 (defmacro test-that
   "Provides a useful way for specifying the purpose of tests. If the first-level
@@ -184,7 +182,6 @@
 (defstruct struct-with-symbols (with-meta 'k {:a "A"}))
 
 (deftest Metadata
-
   (test-that
    "find returns key symbols and their metadata"
    (let [s (struct struct-with-symbols 1)]


### PR DESCRIPTION
load now searches first for a classfile, then for a jnt file, then clj,
then cljc. This preserves the existing view that Jaunt is Clojure, while
adding support for a unique file extension.

Fixes #130 
