### PR TITLE
Fix refer-clojure at the top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+- [#133](https://github.com/jaunt-lang/jaunt/pull/133) Bugfix: demote refer-clojure from macro to fn so it works outside the ns form (@arrdem).
+
 ## Jaunt 0.2.0
 
 This release focuses on fleshing Jaunt out as a separate platform atop Clojure, adding support for

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5838,11 +5838,11 @@
                             nil)]
     res-form))
 
-(defmacro refer-clojure
+(defn refer-clojure
   "Same as (refer 'clojure.core <filters>)"
   {:added "0.1.0"}
   [& filters]
-  `(clojure.core/refer* *ns* '~'clojure.core ~@filters))
+  (apply clojure.core/refer* *ns* 'clojure.core filters))
 
 (defmacro defonce
   "defs name to have the root value of the expr iff the named var has no root value,


### PR DESCRIPTION
Since `refer` is now deprecated, and `refer*` is private, `refer-clojure` cannot (correctly) macroexpand to a `refer*` invocation outside of the `ns` form where it is sanboxed within a `fn` compiled in `clojure.core`. Rather than implement `refer-clojure` as a macro and conditionally employ the same `(with-ns clj (eval))` tactic used by `ns`, this patch simply makes `refer-clojure` a fn which invokes `refer*`.

Fixes #132 
