### PR TITLE
Strict get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Upcoming
+- [#135](https://github.com/jaunt-lang/jaunt/pull/134) Make `get` throw on non-associative arguments (@arrdem).
 
 ## Jaunt 0.2.1
 

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -532,7 +532,8 @@
 
 (defn- protocol?
   [maybe-p]
-  (boolean (:on-interface maybe-p)))
+  (try (boolean (:on-interface maybe-p))
+       (catch Exception _ false)))
 
 (defn- implements? [protocol atype]
   (and atype (.isAssignableFrom ^Class (:on-interface protocol) atype)))

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -809,7 +809,7 @@ public class RT {
       return null;
     }
 
-    return null;
+    throw new IllegalArgumentException("get not supported on type: " + coll.getClass().getName());
   }
 
   static public Object get(Object coll, Object key, Object notFound) {

--- a/test/clojure/test_clojure/data_structures.clj
+++ b/test/clojure/test_clojure/data_structures.clj
@@ -649,33 +649,34 @@
 (deftest test-get
   (let [m {:a 1, :b 2, :c {:d 3, :e 4}, :f nil, :g false, nil {:h 5}}]
     (is (thrown? IllegalArgumentException (get-in {:a 1} 5)))
+    (is (thrown? IllegalArgumentException (get 5 :a)))
     (are [x y] (= x y)
-      (get m :a) 1
-      (get m :e) nil
-      (get m :e 0) 0
-      (get m nil) {:h 5}
-      (get m :b 0) 2
-      (get m :f 0) nil
+      (get m :a)                1
+      (get m :e)                nil
+      (get m :e 0)              0
+      (get m nil)               {:h 5}
+      (get m :b 0)              2
+      (get m :f 0)              nil
 
-      (get-in m [:c :e]) 4
-      (get-in m '(:c :e)) 4
-      (get-in m [:c :x]) nil
-      (get-in m [:f]) nil
-      (get-in m [:g]) false
-      (get-in m [:h]) nil
-      (get-in m []) m
-      (get-in m nil) m
+      (get-in m [:c :e])        4
+      (get-in m '(:c :e))       4
+      (get-in m [:c :x])        nil
+      (get-in m [:f])           nil
+      (get-in m [:g])           false
+      (get-in m [:h])           nil
+      (get-in m [])             m
+      (get-in m nil)            m
 
-      (get-in m [:c :e] 0) 4
-      (get-in m '(:c :e) 0) 4
-      (get-in m [:c :x] 0) 0
-      (get-in m [:b] 0) 2
-      (get-in m [:f] 0) nil
-      (get-in m [:g] 0) false
-      (get-in m [:h] 0) 0
+      (get-in m [:c :e] 0)      4
+      (get-in m '(:c :e) 0)     4
+      (get-in m [:c :x] 0)      0
+      (get-in m [:b] 0)         2
+      (get-in m [:f] 0)         nil
+      (get-in m [:g] 0)         false
+      (get-in m [:h] 0)         0
       (get-in m [:x :y] {:y 1}) {:y 1}
-      (get-in m [] 0) m
-      (get-in m nil 0) m)))
+      (get-in m [] 0)           m
+      (get-in m nil 0)          m)))
 
 (deftest test-nested-map-destructuring
   (let [sample-map {:a 1 :b {:a 2}}


### PR DESCRIPTION
Because `(get t :- T ...)` for any non-associative `T` is probably a bug and is really really hard to debug because of the implicit nil behavior of `RT.get`/`clojure.core/get`.

Fixes #108 
