### PR TITLE
Revert deprecation of *clojure-version*, clojure-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming
 - [#136](https://github.com/jaunt-lang/jaunt/pull/136) Support `^:deprecated` annotations on single fn arities (@arrdem).
+- [#138](https://github.com/jaunt-lang/jaunt/pull/138) Roll back deprecation of `clojure-version`, `*clojure-version*` (@arrdem).
 - [#135](https://github.com/jaunt-lang/jaunt/pull/134) Make `get` throw on non-associative arguments (@arrdem).
 
 ## Jaunt 0.2.1

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -7128,14 +7128,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; clojure version number ;;;;;;;;;;;;;;;;;;;;;;
 
 (def
-  ^{:dynamic    true
-    :deprecated "0.1.0"
-    :added      "0.1.0"}
+  ^{:dynamic true
+    :added   "0.1.0"}
   *clojure-version*
-  "DEPRECATED: replaced by *jaunt-version*
-
-  The version of Clojure from which this Jaunt build is derived. Version information is encoded as a
-  map containing :major :minor :incremental and :qualifier keys."
+  "The version of Clojure from which this Jaunt build is derived. Version information is encoded as
+  a map containing :major :minor :incremental and :qualifier keys."
   {:major       1
    :minor       8
    :incremental 0

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -7142,8 +7142,7 @@
   "DEPRECATED: replaced by jaunt-version
 
   Returns clojure version as a printable string."
-  {:added      "0.1.0"
-   :deprecated "0.1.0"}
+  {:added "0.1.0"}
   []
   "1.8.0")
 


### PR DESCRIPTION
These symbols still have perfectly reasonable meanings in the context of Jaunt, and their deprecation means that a bunch of junk warnings may be generated.
