### PR TITLE
Improve errors from refer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Upcoming
+- [#142](https://github.com/jaunt-lang/jaunt/pull/142) Improve replacement messages from refer (@arrdem).
 - [#136](https://github.com/jaunt-lang/jaunt/pull/136) Support `^:deprecated` annotations on single fn arities (@arrdem).
 - [#138](https://github.com/jaunt-lang/jaunt/pull/138) Roll back deprecation of `clojure-version`, `*clojure-version*` (@arrdem).
 - [#135](https://github.com/jaunt-lang/jaunt/pull/134) Make `get` throw on non-associative arguments (@arrdem).


### PR DESCRIPTION
This patch promotes #'clojure.core/refer to a macro, so that generated errors are source location precise. This fixes a UX defect where code using refer would be loaded, and the warnings about refer's deprecation and the replacement text would be generated at separate times.

Previously, the deprecated symbol warning (generated when analyzing a usage of `require`) would occur and then later after any other analysis warnings the deprecated usage message would be generated when the fully macroexpanded form is evaluated. This means that other errors and messages with other causes could be generated first. This patch ensures that the replacement message will be generated immediately after the deprecated symbol warning.

The primary limitation of this patch is that it has to do some unquoting nonsense which is pretty fragile when users are using refer inline, as in the test suite. However since the whole line of reasoning with this work is that refer should be deprecated and eventually removed I don't have a huge issue with making it fragile for now.
