### PR TITLE
Fix quoting in refer rewrite messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Upcoming
+- [#143](https://github.com/jaunt-lang/jaunt/pull/142) Strip unquoting from refer replacement messages (@arrdem).
 - [#142](https://github.com/jaunt-lang/jaunt/pull/142) Improve replacement messages from refer (@arrdem).
 - [#136](https://github.com/jaunt-lang/jaunt/pull/136) Support `^:deprecated` annotations on single fn arities (@arrdem).
 - [#138](https://github.com/jaunt-lang/jaunt/pull/138) Roll back deprecation of `clojure-version`, `*clojure-version*` (@arrdem).

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,8 @@
   :source-paths      ["src/clj"]
   :java-source-paths ["src/jvm" "test/java"]
   :test-paths        ["test/clojure"]
-  :resource-paths    ["src/resources"]
+  :resource-paths    ["src/resources"
+                      "target/resources"]
   :exclusions        [org.clojure/clojure]
   :profiles {:dev {:plugins [[lein-cljfmt "0.5.0"]]
                    :cljfmt  {:indents {fn*                 [[:inner 0]]
@@ -10,4 +11,3 @@
                                        with-debug-bindings [[:inner 0]]
                                        merge-meta          [[:inner 0]]
                                        add-doc-and-meta    [[:inner 0]]}}}})
-

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4266,9 +4266,9 @@
         exclude (:exclude fs [])
         only    (:refer fs (:only fs :all))]
     `[[~ns-sym
-       ~@[:refer only]
+       ~@[:refer (vec only)]
        ~@(when-not (empty? exclude)
-           [:exclude exclude])
+           [:exclude (vec exclude)])
        ~@(when-not (empty? rename)
            [:rename rename])]]))
 

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4295,17 +4295,20 @@
   {:added      "0.1.0"
    :deprecated "0.2.0"}
   [ns-sym & filters]
-  (let [fs       (apply hash-map filters)
+  (let [unquote* (fn unquote* [o]
+                   (if (and (instance? clojure.lang.ISeq o)
+                            (= 'quote (first o)))
+                     (second o)
+                     (if (instance? clojure.lang.APersistentVector o)
+                       (vec (map unquote* o))
+                       o)))
+        filters  (doall (map unquote* filters))
+        fs       (apply hash-map filters)
         rename   (:rename fs {})
-        d-ctx    (deprecated? *ns*)
         *err*    (errwriter)
         pos      (str " (" *file* ":" *line* ":" *column* ")")
         refer*   (fn [ns filters]
-                   (apply refer* *ns* ns filters))
-        unquote* (fn [o]
-                   (if (and (instance? clojure.lang.ISeq o)
-                            (= 'quote (first o)))
-                     (second o) o))]
+                   (apply refer* *ns* ns filters))]
     (. *err* (println
               (format (str "Refer is deprecated, require should be preferred%s\n"
                            "Instead of:\n%s"
@@ -4315,8 +4318,8 @@
                       pos
                       (str "  (:refer " ns-sym (when-not (empty? filters)
                                                  (str " " (string-join " " filters))) ")\n")
-                      (str "  (:require " (string-join " " (rewrite-refer ns-sym fs)) ")\n"))))
-    `(~refer* ~ns-sym '~(map unquote* filters))))
+                      (str "  (:require " (string-join " " (rewrite-refer (unquote* ns-sym) fs)) ")\n"))))
+    `(~refer* ~ns-sym '~(vec filters))))
 
 (defn ns-refers
   "Returns a map of the refer mappings for the namespace."


### PR DESCRIPTION
This patch tweaks the way that clojure.core/refer generates rewrite messages so as to unquote symbols which don't need to be quoted in the rewritten `(:refer ...)` form.

Before:
![2016-06-24-212626_704x846_scrot](https://cloud.githubusercontent.com/assets/704767/16354708/5c1d8e60-3a52-11e6-9014-a8c3056b9908.png)

After:
![2016-06-24-214605_784x774_scrot](https://cloud.githubusercontent.com/assets/704767/16354756/11cf05c0-3a55-11e6-9c64-cfa828ce6a2b.png)
