### PR TITLE
Implement Named in RT so the compiler can use it

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -1663,19 +1663,19 @@
 
 (defn name
   "Returns the name String of a string, symbol or keyword."
-  {:tag String
-   :added "0.1.0"
+  {:tag    String
+   :added  "0.1.0"
    :static true}
   [x]
-  (if (string? x) x (. ^clojure.lang.Named x (getName))))
+  (clojure.lang.RT/name x))
 
 (defn namespace
   "Returns the namespace String of a symbol or keyword, or nil if not present."
-  {:tag String
-   :added "0.1.0"
+  {:tag    String
+   :added  "0.1.0"
    :static true}
-  [^clojure.lang.Named x]
-  (. x (getNamespace)))
+  [x]
+  (clojure.lang.RT/namespace x))
 
 (defmacro locking
   "Executes exprs in an implicit do, while holding the monitor of x.

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -825,7 +825,7 @@ public class Compiler implements Opcodes {
 
     static class Parser implements IParser {
       public Expr parse(C context, Object form) {
-        return new ImportExpr((String) RT.second(form));
+        return new ImportExpr(RT.name(RT.second(form)));
       }
     }
   }

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -2377,6 +2377,26 @@ public class RT {
     return classForName(name);
   }
 
+  static public String name(Object o) {
+    if (o instanceof String) {
+      return (String) o;
+    } else if (o instanceof Named) {
+      return ((Named) o).getName();
+    } else {
+      throw new IllegalArgumentException("Cannot take name of class: " + o.getClass().getSimpleName());
+    }
+  }
+
+  static public String namespace(Object o) {
+    if (o instanceof String) {
+      return null;
+    } else if (o instanceof Named) {
+      return ((Named) o).getNamespace();
+    } else {
+      throw new IllegalArgumentException("Cannot take namespace of class: " + o.getClass().getSimpleName());
+    }
+  }
+
   static public float aget(float[] xs, int i) {
     return xs[i];
   }


### PR DESCRIPTION
This patch enables the `(clojure.core/import* )` special form to accept a symbol so that we could conceivably do away with the gigantic `DEFAULT_IMPORTS` map in `RT.java` and instead be much more selective about what importing is done by using more ... well normal Clojure style importing inside of core and elsewhere.
