### PR TITLE
Refactoring defprotcol for syntax consistency with defn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - [#136](https://github.com/jaunt-lang/jaunt/pull/136) Support `^:deprecated` annotations on single fn arities (@arrdem).
 - [#138](https://github.com/jaunt-lang/jaunt/pull/138) Roll back deprecation of `clojure-version`, `*clojure-version*` (@arrdem).
 - [#135](https://github.com/jaunt-lang/jaunt/pull/134) Make `get` throw on non-associative arguments (@arrdem).
-- [#164](https://github.com/jaunt-lang/jaunt/pull/164) Add `defn` style docstring and attr-map support to `defonce`
+- [#164](https://github.com/jaunt-lang/jaunt/pull/164) Add `defn` style docstring and attr-map support to `defonce` (@arrdem).
+- [#155](https://github.com/jaunt-lang/jaunt/pull/155) Add `defn` style docstring and attr-map support to `defprotocol` (@arrdem).
 
 ## Jaunt 0.2.1
 


### PR DESCRIPTION
Same vein as #146, the more syntax a user has to remember the more awkward it is. I didn't realize for instance that protocol methods could be variadic, or that protocols could have docstrings attached. If they can have docstrings, why don't they have metadata same as other `def` forms?

Why is the parsing all done inline in one ungodly block?

Shavin' yaks....
